### PR TITLE
Ls adding contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+We welcome contributions to this plugin repository. If you're interested in building and sharing your own, please follow these steps:
+
+- [Open a ticket](https://github.com/mapbox/mapbox-plugins-android/issues/new) to kick off a conversation, feel free to tag the `@mapbox/android` team. It's a good idea to explain your plans before you push any code to make sure noone else is working on something similar and to discuss the best approaches to tackle your particular idea.
+
+- Create a new branch that will contain the code for your plugin.
+
+- Create a new Android library module inside the `plugins` project with Android Studio. Each plugin is a separate library that depends on the Mapbox Android SDK, and potentially on other third-party libraries. Besides the code for the plugin, make sure you include:
+
+  - Tests.
+  - Javadoc that documents the plugin usage and purpose in detail.
+
+- Create a new activity inside the demo app that showcases how to use your plugin. As important as having a working plugin is to show how to use it so that anyone can include it in their projects easily.
+
+- Finally, once you're ready to share your code, list your plugin in this file and then open a PR for the `@mapbox/android` team to review.
+
+
+# Code of conduct
+Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](http://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](http://contributor-covenant.org/version/1/2/0/).
+
+You can learn more about our open source philosophy on [mapbox.com](https://www.mapbox.com/about/open/).

--- a/README.md
+++ b/README.md
@@ -60,20 +60,3 @@ This might change in the future as we build more plugins and learn how you use t
 Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
 
 Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
-
-## Contributing
-
-We welcome contributions to this plugin repository. If you're interested in building and sharing your own, please follow these steps:
-
-- [Open a ticket](https://github.com/mapbox/mapbox-plugins-android/issues/new) to kick off a conversation, feel free to tag the `@mapbox/android` team. It's a good idea to explain your plans before you push any code to make sure noone else is working on something similar and to discuss the best approaches to tackle your particular idea.
-
-- Create a new branch that will contain the code for your plugin.
-
-- Create a new Android library module inside the `plugins` project with Android Studio. Each plugin is a separate library that depends on the Mapbox Android SDK, and potentially on other third-party libraries. Besides the code for the plugin, make sure you include:
-
-  - Tests.
-  - Javadoc that documents the plugin usage and purpose in detail.
-
-- Create a new activity inside the demo app that showcases how to use your plugin. As important as having a working plugin is to show how to use it so that anyone can include it in their projects easily.
-
-- Finally, once you're ready to share your code, list your plugin in this file and then open a PR for the `@mapbox/android` team to review.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ This might change in the future as we build more plugins and learn how you use t
 Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
 
 Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+
+## Contributing
+
+We welcome contributions to this plugin repository!
+
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/mapbox/mapbox-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-plugins-android/issues/31

The contributing info used to be at the bottom of this repo's readme file. For now, I just moved that writing into a separate `contributing.md` file.