### PR TITLE
add tests for traffic

### DIFF
--- a/plugins/app/build.gradle
+++ b/plugins/app/build.gradle
@@ -1,42 +1,69 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
     defaultConfig {
         applicationId "com.mapbox.mapboxsdk.plugins.testapp"
-        minSdkVersion 15
-        targetSdkVersion 25
-        versionCode 1
-        versionName "0.1"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName rootProject.ext.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    dexOptions {
+        maxProcessCount 8
+        javaMaxHeapSize "2g"
+        preDexLibraries true
+    }
 }
 
 dependencies {
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    // Support libraries
+    compile rootProject.ext.dep.supportAnnotations
+    compile rootProject.ext.dep.supportAppcompatV7
+    compile rootProject.ext.dep.supportDesign
+    compile rootProject.ext.dep.supportRecyclerView
+    compile rootProject.ext.dep.supportConstraintLayout
+
+    // Unit testing
+    testCompile rootProject.ext.dep.junit
+    testCompile rootProject.ext.dep.mockito
+
+    // Instrumentation testing
+    androidTestCompile(rootProject.ext.dep.testRunner, {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    testCompile 'junit:junit:4.12'
+    androidTestCompile(rootProject.ext.dep.testRules, {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    androidTestCompile(rootProject.ext.dep.testEspressoCore, {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
 
-    compile 'com.jakewharton.timber:timber:4.5.1'
-    compile 'com.jakewharton:butterknife:8.5.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
+    // Square crew
+    compile rootProject.ext.dep.timber
+    compile rootProject.ext.dep.butterKnife
+    annotationProcessor rootProject.ext.dep.butterKnifeProcessor
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.1'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.1'
+    // Leak canary
+    debugCompile rootProject.ext.dep.leakCanaryDebug
+    releaseCompile rootProject.ext.dep.leakCanaryRelease
+    testCompile rootProject.ext.dep.leakCanaryTest
 
+    // Plugin modules
     compile project(':traffic')
 }
 

--- a/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginAction.java
+++ b/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginAction.java
@@ -1,0 +1,45 @@
+package com.mapbox.mapboxsdk.plugins.traffic;
+
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.view.View;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import org.hamcrest.Matcher;
+
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+class TrafficPluginAction implements ViewAction {
+
+  private MapboxMap mapboxMap;
+  private TrafficPlugin trafficPlugin;
+  private OnPerformTrafficAction onPerformTrafficAction;
+
+  TrafficPluginAction(MapboxMap mapboxMap, TrafficPlugin trafficPlugin, OnPerformTrafficAction onPerformTrafficAction) {
+    this.trafficPlugin = trafficPlugin;
+    this.mapboxMap = mapboxMap;
+    this.onPerformTrafficAction = onPerformTrafficAction;
+  }
+
+  @Override
+  public Matcher<View> getConstraints() {
+    return isDisplayed();
+  }
+
+  @Override
+  public String getDescription() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public void perform(UiController uiController, View view) {
+    if (onPerformTrafficAction != null) {
+      onPerformTrafficAction.onTrafficAction(trafficPlugin, mapboxMap, uiController);
+    }
+  }
+
+  interface OnPerformTrafficAction {
+    void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController uiController);
+  }
+}

--- a/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
+++ b/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
@@ -1,0 +1,1151 @@
+package com.mapbox.mapboxsdk.plugins.traffic;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResourceTimeoutException;
+import android.support.test.espresso.UiController;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.mapbox.mapboxsdk.constants.Style;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TrafficActivity;
+import com.mapbox.mapboxsdk.style.functions.CameraFunction;
+import com.mapbox.mapboxsdk.style.functions.stops.ExponentialStops;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.utils.OnMapReadyIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import timber.log.Timber;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.Local;
+import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.MotorWay;
+import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.Primary;
+import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.Secondary;
+import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.TrafficData;
+import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.Trunk;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class TrafficPluginTest {
+
+  @Rule
+  public ActivityTestRule<TrafficActivity> rule = new ActivityTestRule<>(TrafficActivity.class);
+
+  public static final String ROUND = "round";
+
+  private OnMapReadyIdlingResource idlingResource;
+  private MapboxMap mapboxMap;
+  private TrafficPlugin trafficPlugin;
+
+  @Before
+  public void beforeTest() {
+    try {
+      Timber.e("@Before: register idle resource");
+      idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
+      Espresso.registerIdlingResources(idlingResource);
+      onView(withId(android.R.id.content)).check(matches(isDisplayed()));
+      mapboxMap = idlingResource.getMapboxMap();
+      trafficPlugin = rule.getActivity().getTrafficPlugin();
+    } catch (IdlingResourceTimeoutException idlingResourceTimeoutException) {
+      Timber.e("Idling resource timed out. Couldn't not validate if map is ready.");
+      throw new RuntimeException("Could not start executeTrafficTest for " + this.getClass().getSimpleName() + ".\n"
+        + "The ViewHierarchy doesn't contain a view with resource id = R.id.mapView or \n"
+        + "the Activity doesn't contain an instance variable with a name equal to mapboxMap.\n");
+    }
+  }
+
+  @Test
+  public void sanity() throws Exception {
+    assertTrue(mapboxMap != null);
+    assertTrue(trafficPlugin != null);
+  }
+
+  @Test
+  public void enabled() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController uiController) {
+        assertTrue(trafficPlugin.isEnabled());
+      }
+    });
+  }
+
+  @Test
+  public void disabled() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController uiController) {
+        trafficPlugin.toggle();
+        assertFalse(trafficPlugin.isEnabled());
+      }
+    });
+  }
+
+  @Test
+  public void sourceAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getSource(TrafficData.SOURCE_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void motorWayBaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(MotorWay.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void motorWayCaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(MotorWay.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void trunkBaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Trunk.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void trunkCaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Trunk.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void secondaryBaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Secondary.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void secondaryCaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Secondary.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void primaryBaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void primaryCaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void localBaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Local.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void localCaseLayerAdded() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Local.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void localBaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Local.BASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void localCaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Local.CASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void secondaryBaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Secondary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void secondaryCaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Secondary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void primaryBaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void primaryCaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void trunkBaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void trunkCaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void motorWayBaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(MotorWay.BASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void motorWayCaseLayerVisible() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(MotorWay.CASE_LAYER_ID).getVisibility().getValue().equals(Property.VISIBLE));
+      }
+    });
+  }
+
+  @Test
+  public void localBaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Local.BASE_LAYER_ID).getMinZoom() == Local.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void localCaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Local.CASE_LAYER_ID).getMinZoom() == Local.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void secondaryBaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Secondary.BASE_LAYER_ID).getMinZoom() == Secondary.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void secondaryCaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Secondary.CASE_LAYER_ID).getMinZoom() == Secondary.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void primaryBaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID).getMinZoom() == Primary.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void primaryCaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID).getMinZoom() == Primary.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void trunkBaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Trunk.BASE_LAYER_ID).getMinZoom() == Trunk.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void trunkCaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(Trunk.CASE_LAYER_ID).getMinZoom() == Trunk.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void motorWayBaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(MotorWay.BASE_LAYER_ID).getMinZoom() == MotorWay.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void motorWayCaseLayerMinZoom() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertTrue(mapboxMap.getLayer(MotorWay.CASE_LAYER_ID).getMinZoom() == MotorWay.ZOOM_LEVEL);
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesLocalBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Local.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesLocalCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Local.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesSecondaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Secondary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesSecondaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Secondary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesPrimaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesPrimaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+
+  @Test
+  public void toggleHidesTrunkBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Trunk.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesTrunkCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(Trunk.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesMotorWayBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(MotorWay.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void toggleHidesMotorWayCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        trafficPlugin.toggle();
+        assertTrue(mapboxMap.getLayer(MotorWay.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
+      }
+    });
+  }
+
+  @Test
+  public void reattachLocalBaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Local.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachLocalCaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Local.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachSecondaryBaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Secondary.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachSecondaryCaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Secondary.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachPrimaryBaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachPrimaryCaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachTrunkBaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Trunk.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachTrunkCaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(Trunk.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachMotorWayBaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(MotorWay.BASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void reattachMotorWayCaseWithLoadNewStyle() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        mapboxMap.setStyleUrl(Style.DARK);
+        controller.loopMainThreadForAtLeast(500);
+        assertTrue(mapboxMap.getLayer(MotorWay.CASE_LAYER_ID) != null);
+      }
+    });
+  }
+
+  @Test
+  public void lineCapSecondaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Secondary.BASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapSecondaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Secondary.CASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapLocalBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Local.BASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapLocalCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Local.CASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapPrimaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Primary.BASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapPrimaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Primary.CASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapTrunkBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Trunk.BASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineCapTrunkCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Trunk.CASE_LAYER_ID)).getLineCap().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinLocalBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Local.BASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinLocalCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Local.CASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinSecondaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Secondary.BASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinSecondaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Secondary.CASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinPrimaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Primary.BASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinPrimaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Primary.CASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinTrunkBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Trunk.BASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinTrunkCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(Trunk.CASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinMotorWayBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(MotorWay.BASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineJoinMotorWayCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        assertEquals(ROUND, ((LineLayer) mapboxMap.getLayerAs(MotorWay.CASE_LAYER_ID)).getLineJoin().getValue());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionLocalBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Local.BASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(2, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionLocalCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Local.CASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(2, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+
+  @Test
+  public void lineWidthFunctionSecondaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Secondary.BASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(3, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionSecondaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Secondary.CASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(3, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionPrimaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Primary.BASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(3, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionPrimaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Primary.CASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(3, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionTrunkBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Trunk.BASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(3, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionTrunkCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Trunk.CASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionMotorwayBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(MotorWay.BASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineWidthFunctionMotorwayCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(MotorWay.CASE_LAYER_ID);
+        assertNotNull(layer.getLineWidth());
+        assertNotNull(layer.getLineWidth().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineWidth().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionLocalBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Local.BASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(2, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionLocalCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Local.CASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(2, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+
+  @Test
+  public void lineOffsetFunctionSecondaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Secondary.BASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionSecondaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Secondary.CASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionPrimaryBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Primary.BASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionPrimaryCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Primary.CASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionTrunkBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Trunk.BASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionTrunkCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(Trunk.CASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(4, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionMotorwayBaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(MotorWay.BASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(5, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  @Test
+  public void lineOffsetFunctionMotorwayCaseLayer() throws Exception {
+    executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
+      @Override
+      public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
+        LineLayer layer = mapboxMap.getLayerAs(MotorWay.CASE_LAYER_ID);
+        assertNotNull(layer.getLineOffset());
+        assertNotNull(layer.getLineOffset().getFunction());
+        assertEquals(CameraFunction.class, layer.getLineOffset().getFunction().getClass());
+        assertEquals(ExponentialStops.class, layer.getLineOffset().getFunction().getStops().getClass());
+        assertEquals(1.5f, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).getBase(), 0.001);
+        assertEquals(5, ((ExponentialStops) layer.getLineOffset().getFunction().getStops()).size());
+      }
+    });
+  }
+
+  // TODO add getFilter test https://github.com/mapbox/mapbox-gl-native/pull/9077
+
+  @After
+  public void afterTest() {
+    Timber.e("@After: unregister idle resource");
+    Espresso.unregisterIdlingResources(idlingResource);
+  }
+
+  public void executeTrafficTest(TrafficPluginAction.OnPerformTrafficAction listener) {
+    onView(withId(android.R.id.content)).perform(new TrafficPluginAction(mapboxMap, trafficPlugin, listener));
+  }
+}

--- a/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/utils/OnMapReadyIdlingResource.java
+++ b/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/utils/OnMapReadyIdlingResource.java
@@ -1,0 +1,57 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.app.Activity;
+import android.support.test.espresso.IdlingResource;
+
+import timber.log.Timber;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import java.lang.reflect.Field;
+
+public class OnMapReadyIdlingResource implements IdlingResource {
+
+  private final Activity activity;
+  private MapboxMap mapboxMap;
+  private IdlingResource.ResourceCallback resourceCallback;
+
+  public OnMapReadyIdlingResource(Activity activity) {
+    this.activity = activity;
+  }
+
+  @Override
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean isIdleNow() {
+    boolean idle = isMapboxMapReady();
+    if (idle && resourceCallback != null) {
+      resourceCallback.onTransitionToIdle();
+    }
+    return idle;
+  }
+
+  @Override
+  public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+    this.resourceCallback = resourceCallback;
+  }
+
+  private boolean isMapboxMapReady() {
+    try {
+      Field field = activity.getClass().getDeclaredField("mapboxMap");
+      field.setAccessible(true);
+      mapboxMap = (MapboxMap) field.get(activity);
+      Timber.e("isMapboxReady called with value " + (mapboxMap != null));
+      return mapboxMap != null;
+    } catch (Exception exception) {
+      Timber.e("could not reflect", exception);
+      return false;
+    }
+  }
+
+  public MapboxMap getMapboxMap() {
+    return mapboxMap;
+  }
+}

--- a/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/utils/WaitLoopAction.java
+++ b/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/utils/WaitLoopAction.java
@@ -1,0 +1,43 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.view.View;
+
+import org.hamcrest.Matcher;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class WaitLoopAction implements ViewAction {
+
+  private long loopTime;
+
+  public WaitLoopAction(long loopTime) {
+    this.loopTime = loopTime;
+  }
+
+  @Override
+  public Matcher<View> getConstraints() {
+    return isDisplayed();
+  }
+
+  @Override
+  public String getDescription() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public void perform(UiController uiController, View view) {
+    uiController.loopMainThreadForAtLeast(loopTime);
+  }
+
+  public static void performWaitLoop(long loopTime) {
+    onView(withId(android.R.id.content)).perform(new WaitLoopAction(loopTime));
+  }
+
+  public static void performWaitLoop(UiController controller, long waitTime) {
+    controller.loopMainThreadForAtLeast(waitTime);
+  }
+}

--- a/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java
+++ b/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java
@@ -46,7 +46,7 @@ public class TrafficActivity extends AppCompatActivity implements OnMapReadyCall
   }
 
   @Override
-  public void onMapReady(MapboxMap mapboxMap) {
+  public void onMapReady(final MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     this.trafficPlugin = new TrafficPlugin(mapView, mapboxMap);
     this.trafficPlugin.toggle(); // Enable the traffic view by default
@@ -107,6 +107,10 @@ public class TrafficActivity extends AppCompatActivity implements OnMapReadyCall
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  public TrafficPlugin getTrafficPlugin() {
+    return trafficPlugin;
   }
 
   private static class StyleCycle {

--- a/plugins/app/src/main/res/layout/activity_traffic.xml
+++ b/plugins/app/src/main/res/layout/activity_traffic.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical">
 
     <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@+id/mapView"
+        android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:mapbox_cameraTargetLat="37.769145"

--- a/plugins/app/src/main/res/values/ids.xml
+++ b/plugins/app/src/main/res/values/ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="item_click_support" type="id"/>
+    <item name="mapView" type="id"/>
 </resources>

--- a/plugins/bitrise.yml
+++ b/plugins/bitrise.yml
@@ -41,18 +41,26 @@ workflows:
             echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
             curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
             sudo apt-get update && sudo apt-get install -y google-cloud-sdk
-    - script:
-        title: Run Firebase Roboto tests
-        inputs:
-        - content: |-
-            #!/bin/bash
+            # Configure
             set -euo pipefail
             echo "Downloading Google Cloud authentication:"
             wget -O google-services.json "$BITRISEIO_GOOGLE_SERVICES_JSON_URL"
-
-            echo "Run tests on firebase:"
             gcloud auth activate-service-account --key-file google-services.json --project mapbox-plugins-android-4e407
+    - script:
+        title: Run Firebase Roboto tests on test application
+        inputs:
+        - content: |-
+            #!/bin/bash
             gcloud firebase test android run --type robo --app "$BITRISE_APK_PATH" --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+    - gradle-runner@1.5.4:
+        inputs:
+        - gradle_task: "$INSTRUMENTATIONTEST_TASK"
+    - script:
+        title: Run Firebase Instrumentation tests
+        inputs:
+        - content: |-
+            #!/bin/bash
+            gcloud beta test android run --type instrumentation --app ./plugins/app/build/outputs/apk/app-debug.apk --test ./plugins/app/build/outputs/apk/app-debug-androidTest.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 15m
     - deploy-to-bitrise-io@1.2.9: {}
     - slack:
         title: Post to Slack
@@ -129,6 +137,9 @@ app:
   - opts:
       is_expand: false
     UNITTEST_TASK: test
+  - opts:
+      is_expand: false
+    INSTRUMENTATIONTEST_TASK: assembleAndroidTest
   - opts:
       is_expand: false
     GRADLEW_PATH: plugins/gradlew

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -16,3 +16,6 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply from: rootProject.file('dependencies.gradle')
+

--- a/plugins/dependencies.gradle
+++ b/plugins/dependencies.gradle
@@ -1,0 +1,52 @@
+ext {
+    minSdkVersion = 15
+    targetSdkVersion = 25
+    compileSdkVersion = 25
+    buildToolsVersion = "25.0.3"
+
+    versionCode = 2
+    versionName = "0.2.0"
+
+    supportLibVersion = "25.3.1"
+    leakCanaryVersion = '1.5'
+    wearableVersion = '2.0.0'
+
+    espressoVersion = '2.2.2'
+    testRunnerVersion = '0.5'
+
+    dep = [
+            // unit test
+            junit                  : 'junit:junit:4.12',
+            mockito                : 'org.mockito:mockito-core:2.2.27',
+
+            // instrumentation test
+            testSpoonRunner        : 'com.squareup.spoon:spoon-client:1.6.2',
+            testRunner             : "com.android.support.test:runner:${testRunnerVersion}",
+            testRules              : "com.android.support.test:rules:${testRunnerVersion}",
+            testEspressoCore       : "com.android.support.test.espresso:espresso-core:${espressoVersion}",
+            testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${espressoVersion}",
+
+            // support
+            supportAnnotations     : "com.android.support:support-annotations:${supportLibVersion}",
+            supportAppcompatV7     : "com.android.support:appcompat-v7:${supportLibVersion}",
+            supportV4              : "com.android.support:support-v4:${supportLibVersion}",
+            supportDesign          : "com.android.support:design:${supportLibVersion}",
+            supportRecyclerView    : "com.android.support:recyclerview-v7:${supportLibVersion}",
+            supportConstraintLayout: "com.android.support.constraint:constraint-layout:1.0.2",
+
+            // butterknife
+            butterKnife            : "com.jakewharton:butterknife:8.5.1",
+            butterKnifeProcessor   : "com.jakewharton:butterknife-compiler:8.5.1",
+
+            // wear
+            wearCompile            : "com.google.android.support:wearable:${wearableVersion}",
+            wearProvided           : "com.google.android.wearable:wearable:${wearableVersion}",
+
+            // square crew
+            timber                 : 'com.jakewharton.timber:timber:4.5.1',
+            okhttp3                : 'com.squareup.okhttp3:okhttp:3.6.0',
+            leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}",
+            leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}",
+            leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
+    ]
+}

--- a/plugins/traffic/build.gradle
+++ b/plugins/traffic/build.gradle
@@ -1,14 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "0.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     configurations {
@@ -17,6 +18,11 @@ android {
 }
 
 dependencies {
+    // Unit testing
+    testCompile rootProject.ext.dep.junit
+    testCompile rootProject.ext.dep.mockito
+
+    // Mapbox dependencies
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar') {
         transitive = true
     }

--- a/plugins/traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
+++ b/plugins/traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
@@ -115,8 +115,15 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
    */
   private void initialise() {
     layerIds = new ArrayList<>();
-    addTrafficSource();
-    addTrafficLayers();
+
+    try {
+      addTrafficSource();
+      addTrafficLayers();
+    } catch (Exception exception) {
+      Timber.e("Unable to attach Traffic to current style: ", exception);
+    } catch (UnsatisfiedLinkError error) {
+      Timber.e("Unable to load native libraries: ", error);
+    }
   }
 
   /**
@@ -131,15 +138,11 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
    * Adds traffic layers to the map.
    */
   private void addTrafficLayers() {
-    try {
-      addLocalLayer();
-      addSecondaryLayer();
-      addPrimaryLayer();
-      addTrunkLayer();
-      addMotorwayLayer();
-    } catch (Exception exception) {
-      Timber.e("Unable to attach Traffic Layers to current style.");
-    }
+    addLocalLayer();
+    addSecondaryLayer();
+    addPrimaryLayer();
+    addTrunkLayer();
+    addMotorwayLayer();
   }
 
   /**
@@ -156,7 +159,7 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
     );
 
     LineLayer localCase = TrafficLayer.getLineLayer(
-      Local.LOCAL_CASE_LAYER_ID,
+      Local.CASE_LAYER_ID,
       Local.ZOOM_LEVEL,
       Local.FILTER,
       Local.FUNCTION_LINE_COLOR_CASE,
@@ -363,105 +366,105 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
     }
   }
 
-  private static class TrafficData {
-    private static final String SOURCE_ID = "traffic";
-    private static final String SOURCE_LAYER = "traffic";
-    private static final String SOURCE_URL = "mapbox://mapbox.mapbox-traffic-v1";
+  static class TrafficData {
+    static final String SOURCE_ID = "traffic";
+    static final String SOURCE_LAYER = "traffic";
+    static final String SOURCE_URL = "mapbox://mapbox.mapbox-traffic-v1";
   }
 
-  private static class TrafficType {
+  static class TrafficType {
     static final Function FUNCTION_LINE_COLOR = TrafficFunction.getLineColorFunction(TrafficColor.BASE_GREEN,
       TrafficColor.BASE_YELLOW, TrafficColor.BASE_ORANGE, TrafficColor.BASE_RED);
     static final Function FUNCTION_LINE_COLOR_CASE = TrafficFunction.getLineColorFunction(
       TrafficColor.CASE_GREEN, TrafficColor.CASE_YELLOW, TrafficColor.CASE_ORANGE, TrafficColor.CASE_RED);
   }
 
-  private static class MotorWay extends TrafficType {
-    private static final String BASE_LAYER_ID = "traffic-motorway";
-    private static final String CASE_LAYER_ID = "traffic-motorway-bg";
-    private static final float ZOOM_LEVEL = 6.0f;
-    private static final Filter.Statement FILTER = in("class", "motorway");
-    private static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
+  static class MotorWay extends TrafficType {
+    static final String BASE_LAYER_ID = "traffic-motorway";
+    static final String CASE_LAYER_ID = "traffic-motorway-bg";
+    static final float ZOOM_LEVEL = 6.0f;
+    static final Filter.Statement FILTER = in("class", "motorway");
+    static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
       stop(6, lineWidth(0.5f)), stop(9, lineWidth(1.5f)), stop(18.0f, lineWidth(14.0f)),
       stop(20.0f, lineWidth(18.0f)));
-    private static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
+    static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
       stop(6, lineWidth(0.5f)), stop(9, lineWidth(3.0f)), stop(18.0f, lineWidth(16.0f)),
       stop(20.0f, lineWidth(20.0f)));
-    private static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
+    static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
       stop(7, lineOffset(0.0f)), stop(9, lineOffset(1.2f)), stop(11, lineOffset(1.2f)),
       stop(18, lineOffset(10.0f)), stop(20, lineOffset(15.5f)));
   }
 
-  private static class Trunk extends TrafficType {
-    private static final String BASE_LAYER_ID = "traffic-trunk";
-    private static final String CASE_LAYER_ID = "traffic-trunk-bg";
-    private static final float ZOOM_LEVEL = 6.0f;
-    private static final Filter.Statement FILTER = in("class", "trunk");
-    private static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
+  static class Trunk extends TrafficType {
+    static final String BASE_LAYER_ID = "traffic-trunk";
+    static final String CASE_LAYER_ID = "traffic-trunk-bg";
+    static final float ZOOM_LEVEL = 6.0f;
+    static final Filter.Statement FILTER = in("class", "trunk");
+    static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
       stop(8, lineWidth(0.75f)), stop(18, lineWidth(11f)), stop(20f, lineWidth(15.0f)));
-    private static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
+    static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
       stop(8, lineWidth(0.5f)), stop(9, lineWidth(2.25f)), stop(18.0f, lineWidth(13.0f)),
       stop(20.0f, lineWidth(17.5f)));
-    private static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
+    static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
       stop(7, lineOffset(0.0f)), stop(9, lineOffset(1f)), stop(18, lineOffset(13f)),
       stop(20, lineOffset(18.0f)));
   }
 
-  private static class Primary extends TrafficType {
-    private static final String BASE_LAYER_ID = "traffic-primary";
-    private static final String CASE_LAYER_ID = "traffic-primary-bg";
-    private static final float ZOOM_LEVEL = 6.0f;
-    private static final Filter.Statement FILTER = in("class", "primary");
-    private static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
+  static class Primary extends TrafficType {
+    static final String BASE_LAYER_ID = "traffic-primary";
+    static final String CASE_LAYER_ID = "traffic-primary-bg";
+    static final float ZOOM_LEVEL = 6.0f;
+    static final Filter.Statement FILTER = in("class", "primary");
+    static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
       stop(10, lineWidth(1.0f)), stop(15, lineWidth(4.0f)), stop(20, lineWidth(16f)));
-    private static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
+    static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
       stop(10, lineWidth(0.75f)), stop(15, lineWidth(6f)), stop(20.0f, lineWidth(18.0f)));
-    private static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
+    static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
       stop(10, lineOffset(0.0f)), stop(12, lineOffset(1.5f)), stop(18, lineOffset(13f)),
       stop(20, lineOffset(16.0f)));
-    private static final Function FUNCTION_LINE_OPACITY_CASE = TrafficFunction.getOpacityFunction(
+    static final Function FUNCTION_LINE_OPACITY_CASE = TrafficFunction.getOpacityFunction(
       stop(11, lineOpacity(0.0f)), stop(12, lineOpacity(1.0f)));
   }
 
-  private static class Secondary extends TrafficType {
-    private static final String BASE_LAYER_ID = "traffic-secondary-tertiary";
-    private static final String CASE_LAYER_ID = "traffic-secondary-tertiary-bg";
-    private static final float ZOOM_LEVEL = 6.0f;
-    private static final Filter.Statement FILTER = in("class", "secondary", "tertiary");
-    private static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
+  static class Secondary extends TrafficType {
+    static final String BASE_LAYER_ID = "traffic-secondary-tertiary";
+    static final String CASE_LAYER_ID = "traffic-secondary-tertiary-bg";
+    static final float ZOOM_LEVEL = 6.0f;
+    static final Filter.Statement FILTER = in("class", "secondary", "tertiary");
+    static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
       stop(9, lineWidth(0.5f)), stop(18, lineWidth(9.0f)), stop(20, lineWidth(14f)));
-    private static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
+    static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
       stop(9, lineWidth(1.5f)), stop(18, lineWidth(11f)), stop(20.0f, lineWidth(16.5f)));
-    private static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
+    static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
       stop(10, lineOffset(0.5f)), stop(15, lineOffset(5f)), stop(18, lineOffset(11f)),
       stop(20, lineOffset(14.5f)));
-    private static final Function FUNCTION_LINE_OPACITY_CASE = TrafficFunction.getOpacityFunction(
+    static final Function FUNCTION_LINE_OPACITY_CASE = TrafficFunction.getOpacityFunction(
       stop(13, lineOpacity(0.0f)), stop(14, lineOpacity(1.0f)));
   }
 
-  private static class Local extends TrafficType {
-    private static final String BASE_LAYER_ID = "traffic-local";
-    private static final String LOCAL_CASE_LAYER_ID = "traffic-local-case";
-    private static final float ZOOM_LEVEL = 15.0f;
-    private static final Filter.Statement FILTER = in("class", "motorway_link", "service", "street");
-    private static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
+  static class Local extends TrafficType {
+    static final String BASE_LAYER_ID = "traffic-local";
+    static final String CASE_LAYER_ID = "traffic-local-case";
+    static final float ZOOM_LEVEL = 15.0f;
+    static final Filter.Statement FILTER = in("class", "motorway_link", "service", "street");
+    static final CameraFunction FUNCTION_LINE_WIDTH = TrafficFunction.getWidthFunction(
       stop(14, lineWidth(1.5f)), stop(20, lineWidth(13.5f)));
-    private static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
+    static final CameraFunction FUNCTION_LINE_WIDTH_CASE = TrafficFunction.getWidthFunction(
       stop(14, lineWidth(2.5f)), stop(20, lineWidth(15.5f)));
-    private static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
+    static final CameraFunction FUNCTION_LINE_OFFSET = TrafficFunction.getOffsetFunction(
       stop(14, lineOffset(2f)), stop(20, lineOffset(18f)));
-    private static final Function FUNCTION_LINE_OPACITY_CASE = TrafficFunction.getOpacityFunction(
+    static final Function FUNCTION_LINE_OPACITY_CASE = TrafficFunction.getOpacityFunction(
       stop(15, lineOpacity(0.0f)), stop(16, lineOpacity(1.0f)));
   }
 
-  private static class TrafficColor {
-    private static final int BASE_GREEN = Color.parseColor("#39c66d");
-    private static final int CASE_GREEN = Color.parseColor("#059441");
-    private static final int BASE_YELLOW = Color.parseColor("#ff8c1a");
-    private static final int CASE_YELLOW = Color.parseColor("#d66b00");
-    private static final int BASE_ORANGE = Color.parseColor("#ff0015");
-    private static final int CASE_ORANGE = Color.parseColor("#bd0010");
-    private static final int BASE_RED = Color.parseColor("#981b25");
-    private static final int CASE_RED = Color.parseColor("#5f1117");
+  static class TrafficColor {
+    static final int BASE_GREEN = Color.parseColor("#39c66d");
+    static final int CASE_GREEN = Color.parseColor("#059441");
+    static final int BASE_YELLOW = Color.parseColor("#ff8c1a");
+    static final int CASE_YELLOW = Color.parseColor("#d66b00");
+    static final int BASE_ORANGE = Color.parseColor("#ff0015");
+    static final int CASE_ORANGE = Color.parseColor("#bd0010");
+    static final int BASE_RED = Color.parseColor("#981b25");
+    static final int CASE_RED = Color.parseColor("#5f1117");
   }
 }

--- a/plugins/traffic/src/test/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
+++ b/plugins/traffic/src/test/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
@@ -1,0 +1,43 @@
+package com.mapbox.mapboxsdk.plugins.traffic;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TrafficPluginTest {
+
+  @Mock
+  MapView mapView;
+
+  @Mock
+  MapboxMap mapboxMap;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Test(expected = NullPointerException.class)
+  public void testNonNullAnnotatedArgs() {
+    new TrafficPlugin(null, null);
+  }
+
+  @Test
+  public void testSanity() {
+    new TrafficPlugin(mapView, mapboxMap);
+  }
+
+  @Test
+  public void testToggle() {
+    TrafficPlugin trafficPlugin = new TrafficPlugin(mapView, mapboxMap);
+    assertFalse(trafficPlugin.isEnabled());
+    trafficPlugin.toggle();
+    assertTrue(trafficPlugin.isEnabled());
+  }
+}

--- a/plugins/traffic/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/plugins/traffic/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
As first official plugin to this repo, we need to set a good example for others and add tests!
  - Unit tests for traffic module 
  - Instrumentation tests for the test app (we need an activity to run these)
  - dependencies.gradle setup cfr mapbox-java/mapbox-gl-native

What does it test:
 - if mapboxmap and traffic plugin are correctly created
 - If traffic source is added on init
 - If traffic layers are added on init
 - if traffic layers are visible on init
 - if traffic layers are invisble after toggling the plugin
 - if traffic min zoom level = expected value
 - loading a new style should readd the source/layers
 - lineWidth
 - filter