### PR TITLE
Few improvements to traffic plugin

### DIFF
--- a/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
+++ b/plugins/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
@@ -44,7 +44,7 @@ public class TrafficPluginTest {
   @Rule
   public ActivityTestRule<TrafficActivity> rule = new ActivityTestRule<>(TrafficActivity.class);
 
-  public static final String ROUND = "round";
+  private static final String ROUND = "round";
 
   private OnMapReadyIdlingResource idlingResource;
   private MapboxMap mapboxMap;
@@ -78,7 +78,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController uiController) {
-        assertTrue(trafficPlugin.isEnabled());
+        assertTrue(trafficPlugin.isVisible());
       }
     });
   }
@@ -88,8 +88,8 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController uiController) {
-        trafficPlugin.toggle();
-        assertFalse(trafficPlugin.isEnabled());
+        trafficPlugin.setVisibility(false);
+        assertFalse(trafficPlugin.isVisible());
       }
     });
   }
@@ -409,7 +409,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Local.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -420,7 +420,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Local.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -431,7 +431,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Secondary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -442,7 +442,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Secondary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -453,7 +453,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Primary.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -464,7 +464,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Primary.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -476,7 +476,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Trunk.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -487,7 +487,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(Trunk.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -498,7 +498,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(MotorWay.BASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });
@@ -509,7 +509,7 @@ public class TrafficPluginTest {
     executeTrafficTest(new TrafficPluginAction.OnPerformTrafficAction() {
       @Override
       public void onTrafficAction(TrafficPlugin trafficPlugin, MapboxMap mapboxMap, UiController controller) {
-        trafficPlugin.toggle();
+        trafficPlugin.setVisibility(false);
         assertTrue(mapboxMap.getLayer(MotorWay.CASE_LAYER_ID).getVisibility().getValue().equals(Property.NONE));
       }
     });

--- a/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java
+++ b/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java
@@ -48,14 +48,14 @@ public class TrafficActivity extends AppCompatActivity implements OnMapReadyCall
   public void onMapReady(final MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     this.trafficPlugin = new TrafficPlugin(mapView, mapboxMap);
-    this.trafficPlugin.toggle(); // Enable the traffic view by default
+    this.trafficPlugin.setVisibility(true); // Enable the traffic view by default
   }
 
   @OnClick(R.id.fabTraffic)
   public void onTrafficFabClick() {
     if (mapboxMap != null) {
-      trafficPlugin.toggle();
-      Timber.e("Traffic plugin is enabled :%s", trafficPlugin.isEnabled());
+      trafficPlugin.setVisibility(!trafficPlugin.isVisible());
+      Timber.e("Traffic plugin is enabled :%s", trafficPlugin.isVisible());
     }
   }
 

--- a/plugins/traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
+++ b/plugins/traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
@@ -188,16 +188,21 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
       Local.FUNCTION_LINE_OPACITY_CASE
     );
 
-    // #TODO https://github.com/mapbox/mapbox-plugins-android/issues/14
     addTrafficLayersToMap(localCase, local, placeLayerBelow());
   }
 
+  /**
+   * Attempts to find the layer which the traffic should be placed below. Depending on the style, this might not always
+   * be accurate.
+   */
   private String placeLayerBelow() {
     if (belowLayer == null || belowLayer.isEmpty()) {
       List<Layer> styleLayers = mapboxMap.getLayers();
+      Layer layer;
       for (int i = styleLayers.size() - 1; i >= 0; i--) {
-        if (!(styleLayers.get(i) instanceof SymbolLayer)) {
-          return styleLayers.get(i).getId();
+        layer = styleLayers.get(i);
+        if (!(layer instanceof SymbolLayer)) {
+          return layer.getId();
         }
       }
     }

--- a/plugins/traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
+++ b/plugins/traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.plugins.traffic;
 import android.graphics.Color;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -12,6 +13,8 @@ import com.mapbox.mapboxsdk.style.functions.stops.Stop;
 import com.mapbox.mapboxsdk.style.layers.Filter;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.style.sources.VectorSource;
 
@@ -35,21 +38,22 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
 /**
- * The traffic plugin allows to add Mapbox Traffic v1 to the Mapbox Android SDK v5.0.2.
+ * The Traffic Plugin allows you to add Mapbox Traffic v1 to the Mapbox Android SDK.
  * <p>
  * Initialise this plugin in the {@link com.mapbox.mapboxsdk.maps.OnMapReadyCallback#onMapReady(MapboxMap)} and provide
  * a valid instance of {@link MapView} and {@link MapboxMap}.
  * </p>
  * <p>
- * Use {@link #toggle()} to switch state of this plugin to enable or disabled.
- * Use {@link #isEnabled()} to validate if the plugin is active or not.
+ * Use {@link #setVisibility(boolean)} to switch state of this plugin to enable or disabled.
+ * Use {@link #isVisible()} to validate if the plugin is active or not.
  * </p>
  */
 public final class TrafficPlugin implements MapView.OnMapChangedListener {
 
   private MapboxMap mapboxMap;
   private List<String> layerIds;
-  private boolean enabled;
+  private String belowLayer;
+  private boolean visible;
 
   /**
    * Create a traffic plugin.
@@ -58,8 +62,21 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
    * @param mapboxMap the MapboxMap to apply traffic plugin with
    */
   public TrafficPlugin(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
+    this(mapView, mapboxMap, null);
+  }
+
+  /**
+   * Create a traffic plugin.
+   *
+   * @param mapView    the MapView to apply the traffic plugin to
+   * @param mapboxMap  the MapboxMap to apply traffic plugin with
+   * @param belowLayer the layer id where you'd like the traffic to display below
+   */
+  public TrafficPlugin(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable String belowLayer) {
     this.mapboxMap = mapboxMap;
+    this.belowLayer = belowLayer;
     mapView.addOnMapChangedListener(this);
+    updateState();
   }
 
   /**
@@ -67,20 +84,23 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
    *
    * @return true if enabled, false otherwise
    */
-  public boolean isEnabled() {
-    return enabled;
+  public boolean isVisible() {
+    return visible;
   }
 
   /**
-   * Toggles the traffic plugin state.
-   * <p>
-   * If the traffic plugin wasn't initialised yet, traffic source and layers will be added to the current map style.
-   * Else visibility will be toggled based on the current state.
-   * </p>
+   * Toggles the visibility of the traffic layers.
+   *
+   * @param visible true for visible, false for none
    */
-  public void toggle() {
-    enabled = !enabled;
-    updateState();
+  public void setVisibility(boolean visible) {
+    this.visible = visible;
+    List<Layer> layers = mapboxMap.getLayers();
+    for (Layer layer : layers) {
+      if (layerIds.contains(layer.getId())) {
+        layer.setProperties(visibility(visible ? Property.VISIBLE : Property.NONE));
+      }
+    }
   }
 
   /**
@@ -93,7 +113,7 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
    */
   @Override
   public void onMapChanged(int change) {
-    if (change == MapView.DID_FINISH_LOADING_STYLE && isEnabled()) {
+    if (change == MapView.DID_FINISH_LOADING_STYLE && isVisible()) {
       updateState();
     }
   }
@@ -107,7 +127,7 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
       initialise();
       return;
     }
-    setVisibility(enabled);
+    setVisibility(visible);
   }
 
   /**
@@ -169,7 +189,19 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
     );
 
     // #TODO https://github.com/mapbox/mapbox-plugins-android/issues/14
-    addTrafficLayersToMap(localCase, local, "bridge-motorway");
+    addTrafficLayersToMap(localCase, local, placeLayerBelow());
+  }
+
+  private String placeLayerBelow() {
+    if (belowLayer == null || belowLayer.isEmpty()) {
+      List<Layer> styleLayers = mapboxMap.getLayers();
+      for (int i = styleLayers.size() - 1; i >= 0; i--) {
+        if (!(styleLayers.get(i) instanceof SymbolLayer)) {
+          return styleLayers.get(i).getId();
+        }
+      }
+    }
+    return belowLayer;
   }
 
   /**
@@ -290,24 +322,10 @@ public final class TrafficPlugin implements MapView.OnMapChangedListener {
    * @param idAboveLayer the id of the layer above
    */
   private void addTrafficLayersToMap(Layer layerCase, Layer layer, String idAboveLayer) {
-    mapboxMap.addLayerAbove(layerCase, idAboveLayer);
+    mapboxMap.addLayerBelow(layerCase, idAboveLayer);
     mapboxMap.addLayerAbove(layer, layerCase.getId());
     layerIds.add(layerCase.getId());
     layerIds.add(layer.getId());
-  }
-
-  /**
-   * Toggles the visibility of the traffic layers.
-   *
-   * @param visible true for visible, false for none
-   */
-  private void setVisibility(boolean visible) {
-    List<Layer> layers = mapboxMap.getLayers();
-    for (Layer layer : layers) {
-      if (layerIds.contains(layer.getId())) {
-        layer.setProperties(visibility(visible ? "visible" : "none"));
-      }
-    }
   }
 
   private static class TrafficLayer {

--- a/plugins/traffic/src/test/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
+++ b/plugins/traffic/src/test/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
@@ -36,8 +36,8 @@ public class TrafficPluginTest {
   @Test
   public void testToggle() {
     TrafficPlugin trafficPlugin = new TrafficPlugin(mapView, mapboxMap);
-    assertFalse(trafficPlugin.isEnabled());
-    trafficPlugin.toggle();
-    assertTrue(trafficPlugin.isEnabled());
+    assertFalse(trafficPlugin.isVisible());
+    trafficPlugin.setVisibility(true);
+    assertTrue(trafficPlugin.isVisible());
   }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/60
Closes https://github.com/mapbox/mapbox-plugins-android/issues/55
Closes https://github.com/mapbox/mapbox-plugins-android/issues/14?

I've gone ahead and made a few changes to the traffic plugin to keep consistency across plugins and increase compatibility to all Mapbox map styles. Only issue we should resolve (@tobrun mentioned there's a better way to do this) is to change `if (!(styleLayers.get(i) instanceof SymbolLayer))` into something more performant. 