### PR TITLE
Prevent NPE if locationEngine is trying to connect

### DIFF
--- a/plugins/locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugins/locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -296,7 +296,9 @@ public class LocationLayerPlugin implements LocationEngineListener, CompassListe
   @Override
   @SuppressWarnings( {"MissingPermission"})
   public void onConnected() {
-    locationEngine.requestLocationUpdates();
+    if (locationEngine != null) {
+      locationEngine.requestLocationUpdates();
+    }
   }
 
   @Override


### PR DESCRIPTION
Seeing a intermittent NPE if location engine tries to activate and is null and we are manually pushing updates during nav session 