### PR TITLE
Plugin README additions/updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ dependencies {
 
 ## Available Plugins
 
-These plugins are currently available:
-
 * [**Traffic plugin:** Adds a real-time traffic layer to any Mapbox basemap.](https://github.com/mapbox/mapbox-plugins-android/plugins/traffic/)
 
 * [**Location layer:** Add a location marker on your map indicating the users location.](https://github.com/mapbox/mapbox-plugins-android/plugins/locationlayer/)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Plugins are single-purpose libraries built on top of the [Mapbox Android SDK](ht
 
 ## Available Plugins
 
-* [**Traffic plugin:** Adds a real-time traffic layer to any Mapbox basemap.](https://github.com/mapbox/mapbox-plugins-android/plugins/traffic/)
+* [**Traffic plugin:** Adds a real-time traffic layer to any Mapbox base map.](https://github.com/mapbox/mapbox-plugins-android/plugins/traffic/)
 
-* [**Location layer:** Add a location marker on your map indicating the users location.](https://github.com/mapbox/mapbox-plugins-android/plugins/locationlayer/)
+* [**Location layer:** Add a location marker on your map indicating the user's location.](https://github.com/mapbox/mapbox-plugins-android/plugins/locationlayer/)
 
 * [**Building:** Add extruded buildings in your map style.](https://github.com/mapbox/mapbox-plugins-android/plugins/building/)
 

--- a/README.md
+++ b/README.md
@@ -43,23 +43,11 @@ dependencies {
 
 These plugins are currently available:
 
-* **Traffic plugin:** Adds a real-time traffic layer to any Mapbox basemap.
+* [**Traffic plugin:** Adds a real-time traffic layer to any Mapbox basemap.](https://github.com/mapbox/mapbox-plugins-android/plugins/traffic/)
 
-Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'`
+* [**Location layer:** Add a location marker on your map indicating the users location.](https://github.com/mapbox/mapbox-plugins-android/plugins/locationlayer/)
 
-![ezgif com-crop](https://cloud.githubusercontent.com/assets/4394910/24972279/bf88b170-1f6f-11e7-8638-6afe08369d9d.gif)
-
-* **Location layer:** Add a location marker on your map indicating the users location.
-
-Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'`
-
-![location-plugin](https://user-images.githubusercontent.com/4394910/28844322-1c52a672-76b9-11e7-904a-fcf6f51c1481.gif)
-
-* **Building:** Add extruded buildings in your map style.
-
-Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'`
-
-![buildings-plugin](https://user-images.githubusercontent.com/4394910/28844435-71442d04-76b9-11e7-8866-ee6a94306353.gif)
+* [**Building:** Add extruded buildings in your map style.](https://github.com/mapbox/mapbox-plugins-android/plugins/building/)
 
 ## Help and Usage
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'`
 * **Location layer:** Add a location marker on your map indicating the users location.
 
 Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'`
+
 ![location-plugin](https://user-images.githubusercontent.com/4394910/28844322-1c52a672-76b9-11e7-904a-fcf6f51c1481.gif)
 
 * **Building:** Add extruded buildings in your map style.
 
 Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'`
+
 ![buildings-plugin](https://user-images.githubusercontent.com/4394910/28844435-71442d04-76b9-11e7-8866-ee6a94306353.gif)
 
 ## Help and Usage

--- a/README.md
+++ b/README.md
@@ -4,41 +4,6 @@
 
 Plugins are single-purpose libraries built on top of the [Mapbox Android SDK](https://www.mapbox.com/android-docs/) that you can include in your apps like any other Android dependency. You'll [find documentation](https://www.mapbox.com/android-docs/plugins/overview/) for each plugin on our website. A full list of the current plugins is available below.
 
-## Getting Started
-
-To use a plugin you include it in your `build.gradle` file. For example, to add the traffic plugin to your app include the following:
-
-```
-// In the root build.gradle file
-repositories {
-    mavenCentral()
-}
-
-...
-
-// In the app build.gradle file
-dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'
-}
-```
-
-All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
-
-```
-// In the root build.gradle file
-repositories {
-    mavenCentral()
-    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
-}
-
-...
-
-// In the app build.gradle file
-dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.1.0-SNAPSHOT'
-}
-```
-
 ## Available Plugins
 
 * [**Traffic plugin:** Adds a real-time traffic layer to any Mapbox basemap.](https://github.com/mapbox/mapbox-plugins-android/plugins/traffic/)

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'`
 * **Location layer:** Add a location marker on your map indicating the users location.
 
 Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'`
+![location-plugin](https://user-images.githubusercontent.com/4394910/28843948-ea669282-76b7-11e7-94cc-dfac2772c952.gif)
 
 * **Building:** Add extruded buildings in your map style.
 
 Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'`
+![buildings-plugin](https://user-images.githubusercontent.com/4394910/28843945-e726691c-76b7-11e7-93b0-8c371be87b67.gif)
 
 ## Help and Usage
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'`
 * **Location layer:** Add a location marker on your map indicating the users location.
 
 Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'`
-![location-plugin](https://user-images.githubusercontent.com/4394910/28843948-ea669282-76b7-11e7-94cc-dfac2772c952.gif)
+![location-plugin](https://user-images.githubusercontent.com/4394910/28844322-1c52a672-76b9-11e7-904a-fcf6f51c1481.gif)
 
 * **Building:** Add extruded buildings in your map style.
 
 Dependency: `compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'`
-![buildings-plugin](https://user-images.githubusercontent.com/4394910/28843945-e726691c-76b7-11e7-93b0-8c371be87b67.gif)
+![buildings-plugin](https://user-images.githubusercontent.com/4394910/28844435-71442d04-76b9-11e7-8866-ee6a94306353.gif)
 
 ## Help and Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This might change in the future as we build more plugins and learn how you use t
 
 Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
 
-Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+The Mapbox Android team creates plugins but this plugins repository is an open-source project similar to the various Mapbox Android SDKs.
+Plugins' lightweight nature makes them much easier for you and anyone else to contribute rather than trying to add the same feature to the more robust Map SDK. The Mapbox team can also more easily accept contributed plugins and keep the plugin list growing.
 
 ## Contributing
 

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -1,0 +1,68 @@
+[![Build Status](https://www.bitrise.io/app/a3a5f64a6d4a78c3.svg?token=RJY5I160EZSKZr1e0KgLrw&branch=master)](https://www.bitrise.io/app/a3a5f64a6d4a78c3)
+
+# Mapbox building plugin
+
+
+![buildings-plugin](https://user-images.githubusercontent.com/4394910/28844435-71442d04-76b9-11e7-8866-ee6a94306353.gif)
+
+## Getting Started
+
+To use a plugin you include it in your `build.gradle` file. For example, to add the traffic plugin to your app include the following:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'
+}
+```
+
+All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0-SNAPSHOT'
+}
+```
+
+## Examples
+
+- [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
+
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java)
+
+
+## Help and Usage
+
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.
+
+Plugins are easy to use. A plugin is simply a library module built on top of the Mapbox Android SDK. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
+
+This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues).
+
+## Why Plugins
+
+Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
+
+Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+
+## Contributing
+
+We welcome contributions to this plugin repository!
+
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/mapbox/mapbox-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -44,7 +44,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
 
 
 ## Help and Usage

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -44,7 +44,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
 
 
 ## Help and Usage

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -7,7 +7,7 @@
 
 ## Getting Started
 
-To use a plugin you include it in your `build.gradle` file.
+To use the building plugin you include it in your `build.gradle` file.
 
 ```
 // In the root build.gradle file
@@ -44,7 +44,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo))
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
 
 ## Help and Usage

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -59,7 +59,9 @@ This might change in the future as we build more plugins and learn how you use t
 
 Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
 
-Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+The Mapbox Android team creates plugins but this plugins repository is an open-source project similar to the various Mapbox Android SDKs.
+Plugins' lightweight nature makes them much easier for you and anyone else to contribute rather than trying to add the same feature to the more robust Map SDK. The Mapbox team can also more easily accept contributed plugins and keep the plugin list growing.
+
 
 ## Contributing
 

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -36,7 +36,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -7,7 +7,7 @@
 
 ## Getting Started
 
-To use a plugin you include it in your `build.gradle` file. For example, to add the traffic plugin to your app include the following:
+To use a plugin you include it in your `build.gradle` file.
 
 ```
 // In the root build.gradle file
@@ -44,7 +44,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo))
 
 
 ## Help and Usage

--- a/plugins/building/README.md
+++ b/plugins/building/README.md
@@ -23,7 +23,7 @@ dependencies {
 }
 ```
 
-All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
+The building plugins is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
 
 ```
 // In the root build.gradle file
@@ -40,20 +40,18 @@ dependencies {
 }
 ```
 
-## Examples
+## Building plugin examples
 
-- [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
+- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/BuildingActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
+- [In the Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
 
 ## Help and Usage
 
 This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.
 
-Plugins are easy to use. A plugin is simply a library module built on top of the Mapbox Android SDK. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
-
-This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues).
+We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues) as we build more plugins and learn how you use them.
 
 ## Why Plugins
 

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -22,7 +22,7 @@ dependencies {
 }
 ```
 
-All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
+The location layer plugin is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
 
 ```
 // In the root build.gradle file
@@ -39,20 +39,18 @@ dependencies {
 }
 ```
 
-## Examples
+## Location layer examples
 
-- [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/tree/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location)
+- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/tree/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
+- [In the Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
 
 ## Help and Usage
 
 This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.
 
-Plugins are easy to use. A plugin is simply a library module built on top of the Mapbox Android SDK. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
-
-This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues).
+We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues) as we build more plugins and learn how you use them.
 
 ## Why Plugins
 

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -41,9 +41,9 @@ dependencies {
 
 ## Examples
 
-- [This repo's test app]()
+- [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/tree/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
 
 
 ## Help and Usage

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -43,7 +43,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/tree/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
 
 ## Help and Usage

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -1,0 +1,67 @@
+[![Build Status](https://www.bitrise.io/app/a3a5f64a6d4a78c3.svg?token=RJY5I160EZSKZr1e0KgLrw&branch=master)](https://www.bitrise.io/app/a3a5f64a6d4a78c3)
+
+# Mapbox location layer plugin
+
+![location-plugin](https://user-images.githubusercontent.com/4394910/28844322-1c52a672-76b9-11e7-904a-fcf6f51c1481.gif)
+
+## Getting Started
+
+To use the location layer plugin, you include it in your `build.gradle` file.
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'
+}
+```
+
+All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0-SNAPSHOT'
+}
+```
+
+## Examples
+
+- [This repo's test app]()
+
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+
+
+## Help and Usage
+
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.
+
+Plugins are easy to use. A plugin is simply a library module built on top of the Mapbox Android SDK. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
+
+This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues).
+
+## Why Plugins
+
+Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
+
+Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+
+## Contributing
+
+We welcome contributions to this plugin repository!
+
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/mapbox/mapbox-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -58,7 +58,8 @@ This might change in the future as we build more plugins and learn how you use t
 
 Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
 
-Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+The Mapbox Android team creates plugins but this plugins repository is an open-source project similar to the various Mapbox Android SDKs.
+Plugins' lightweight nature makes them much easier for you and anyone else to contribute rather than trying to add the same feature to the more robust Map SDK. The Mapbox team can also more easily accept contributed plugins and keep the plugin list growing.
 
 ## Contributing
 

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -43,7 +43,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/tree/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
 
 
 ## Help and Usage

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -60,7 +60,8 @@ This might change in the future as we build more plugins and learn how you use t
 
 Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
 
-Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+The Mapbox Android team creates plugins but this plugins repository is an open-source project similar to the various Mapbox Android SDKs.
+Plugins' lightweight nature makes them much easier for you and anyone else to contribute rather than trying to add the same feature to the more robust Map SDK. The Mapbox team can also more easily accept contributed plugins and keep the plugin list growing.
 
 ## Contributing
 

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -24,7 +24,7 @@ dependencies {
 }
 ```
 
-All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
+The traffic plugin is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
 
 ```
 // In the root build.gradle file
@@ -41,11 +41,11 @@ dependencies {
 }
 ```
 
-## Examples
+## Traffic plugin examples
 
-- [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java)
+- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
+- [In the Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
 
 ## Help and Usage
@@ -54,7 +54,7 @@ This repository includes an app that shows how to use each plugins in this repos
 
 Plugins are easy to use. A plugin is simply a library module built on top of the Mapbox Android SDK. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
 
-This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues).
+We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues) as we build more plugins and learn how you use them.
 
 ## Why Plugins
 

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -45,7 +45,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
 
 
 ## Help and Usage

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -45,7 +45,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – [Download from Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
 
 
 ## Help and Usage

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -1,0 +1,69 @@
+[![Build Status](https://www.bitrise.io/app/a3a5f64a6d4a78c3.svg?token=RJY5I160EZSKZr1e0KgLrw&branch=master)](https://www.bitrise.io/app/a3a5f64a6d4a78c3)
+
+# Mapbox traffic plugin
+
+The traffic plugin adds a real-time traffic layer to any Mapbox basemap. 
+
+![ezgif com-crop](https://cloud.githubusercontent.com/assets/4394910/24972279/bf88b170-1f6f-11e7-8638-6afe08369d9d.gif)
+
+## Getting Started
+
+To use a plugin you include it in your `build.gradle` file. For example, to add the traffic plugin to your app include the following:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'
+}
+```
+
+All plugins are published to Maven Central, and nightly SNAPSHOTs are available on Sonatype:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0-SNAPSHOT'
+}
+```
+
+## Examples
+
+- [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java)
+
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java)
+
+
+## Help and Usage
+
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.
+
+Plugins are easy to use. A plugin is simply a library module built on top of the Mapbox Android SDK. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
+
+This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues).
+
+## Why Plugins
+
+Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
+
+Also, because it's easier to build a plugin than a SDK feature, it's easier to [contribute plugins](https://github.com/mapbox/mapbox-plugins-android#contributing).
+
+## Contributing
+
+We welcome contributions to this plugin repository!
+
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/mapbox/mapbox-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -8,7 +8,7 @@ The traffic plugin adds a real-time traffic layer to any Mapbox basemap.
 
 ## Getting Started
 
-To use a plugin you include it in your `build.gradle` file.
+To use the traffic plugin, you include it in your `build.gradle` file.
 
 ```
 // In the root build.gradle file

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -8,7 +8,7 @@ The traffic plugin adds a real-time traffic layer to any Mapbox basemap.
 
 ## Getting Started
 
-To use a plugin you include it in your `build.gradle` file. For example, to add the traffic plugin to your app include the following:
+To use a plugin you include it in your `build.gradle` file.
 
 ```
 // In the root build.gradle file
@@ -45,7 +45,7 @@ dependencies {
 
 - [This repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/ls-readme-updates/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TrafficActivity.java)
 
-- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo)
+- [The Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
 
 ## Help and Usage

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.4.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
cc @tobrun @zugaldia 

Fixes #69 by adding a README to each individual plugin's folder. For example, [here's the one for the building plugin](https://github.com/mapbox/mapbox-plugins-android/tree/ls-readme-updates/plugins/building).

_Couple of things:_

1. In the `Available Plugins` section of this repo's README file, I now directly link to each plugin 👇 

![screen shot 2017-08-01 at 1 47 53 pm](https://user-images.githubusercontent.com/4394910/28846415-31ddd2da-76c0-11e7-8569-7180e9418e37.png)

2. I've removed the `Getting Started` section from the repo's general README. Info about gradle and dependency lines now lives in each plugin's README file.

3. _Updating the plugin's dependency line in its README will need to be added to the checklist for a new plugin release._