### PR TITLE
Changelogs for individual plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 Each Mapbox plugin for Android has a separate changelog that highlights changes relevant to the plugin:
 
-* [Location layer plugin](platform/android/CHANGELOG.md)
-* [Building plugin](platform/ios/CHANGELOG.md)
-* [Traffic plugin](platform/macos/CHANGELOG.md)
+* [Location layer plugin](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/locationlayer/CHANGELOG.md)
+* [Building plugin](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/building/CHANGELOG.md)
+* [Traffic plugin](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/traffic/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Each Mapbox plugin for Android has a separate changelog that highlights changes relevant to the plugin:
+
+* [Location layer plugin](platform/android/CHANGELOG.md)
+* [Building plugin](platform/ios/CHANGELOG.md)
+* [Traffic plugin](platform/macos/CHANGELOG.md)

--- a/plugins/building/CHANGELOG.md
+++ b/plugins/building/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog for the Mapbox building plugin

--- a/plugins/locationlayer/CHANGELOG.md
+++ b/plugins/locationlayer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog for the Mapbox localization layer plugin

--- a/plugins/traffic/CHANGELOG.md
+++ b/plugins/traffic/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog for the Mapbox traffic plugin


### PR DESCRIPTION
Fixes #75  by adding changelogs for the 3 current plugins

Also adds [a changelog in this general repo](https://github.com/mapbox/mapbox-plugins-android/blob/ls-adding-changelogs/CHANGELOG.md) pointing to the specific plugins' changelogs.