### PR TITLE
Don't use bearing for navigation if it doesn't exist

### DIFF
--- a/plugins/locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugins/locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -347,9 +347,9 @@ public class LocationLayerPlugin implements LocationEngineListener, CompassListe
       locationUpdateTimestamp = SystemClock.elapsedRealtime();
       return;
     }
-    if (locationLayerMode == LocationLayerMode.NAVIGATION) {
+    if (locationLayerMode == LocationLayerMode.NAVIGATION && location.hasBearing()) {
       bearingChangeAnimate(location.getBearing());
-    } else {
+    } else if (locationLayerMode != LocationLayerMode.NAVIGATION) {
       setAccuracy(location);
     }
     setLocation(location);


### PR DESCRIPTION
Closes #97 

The default value for [`location.getBearing()`](https://developer.android.com/reference/android/location/Location.html#getBearing()) is 0.0 if it does not exist. Which caused the issue, usually when standing still in `NAVIGATION` mode. 
Tiny change