### PR TITLE
MapSnapshotter and icon configuration

### DIFF
--- a/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
+++ b/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
@@ -116,6 +116,10 @@ public class OfflineDownloadActivity extends AppCompatActivity {
       .setMaxZoom(maxZoom)
       .build();
 
-    new OfflinePlugin().downloadRegion(this, offlineDownload, OfflineRegionDetailActivity.class.getName());
+    new OfflinePlugin().downloadRegion(this,
+      offlineDownload,
+      OfflineRegionDetailActivity.class.getName(),
+      R.drawable.mapbox_logo_icon
+    );
   }
 }

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -11,6 +11,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'https://maven.google.com' }
+        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 

--- a/plugins/dependencies.gradle
+++ b/plugins/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
 
     dep = [
             // mapbox
-            mapSdk                 : 'com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.3',
+            mapSdk                 : 'com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0-SNAPSHOT',
             mapboxServices         : 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.1',
 
             // lifecycle

--- a/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePlugin.java
+++ b/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePlugin.java
@@ -2,23 +2,14 @@ package com.mapbox.mapboxsdk.plugins.offline;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
-
 
 public class OfflinePlugin {
 
-  //  private WeakReference<Context> context;
-  //  private static OfflinePlugin instance;
-
-  //  public static synchronized OfflinePlugin getInstance(@NonNull Context context) {
-  //    if (instance == null) {
-  //      instance = new OfflinePlugin(context);
-  //    }
-  //    return instance;
-  //  }
-
-  public void downloadRegion(@NonNull Context context, OfflineDownload offlineDownload, String returnActivity) {
-    //    Context appContext = context.get();
+  // TODO replace with options/builder pattern
+  public void downloadRegion(@NonNull Context context, OfflineDownload offlineDownload, String returnActivity,
+                             @DrawableRes int iconRes) {
     Context appContext = context.getApplicationContext();
     Intent intent = new Intent(appContext, DownloadService.class);
     intent.setAction(DownloadService.ACTION_START_DOWNLOAD);
@@ -32,6 +23,7 @@ public class OfflinePlugin {
     intent.putExtra(DownloadService.RegionConstants.MIN_ZOOM, offlineDownload.getMinZoom());
     intent.putExtra(DownloadService.RegionConstants.MAX_ZOOM, offlineDownload.getMaxZoom());
     intent.putExtra(DownloadService.RegionConstants.STYLE, offlineDownload.getStyleUrl());
+    intent.putExtra(DownloadService.NotificationConstants.ICON_RES, iconRes);
     appContext.startService(intent);
   }
 }


### PR DESCRIPTION
closes #107 

This PR adds the configuration of changing the icon shown in the notification while downloading a region. 
Additionally it will try creating a bitmap of the offline region using the MapSnapshotter introduced in the v5.2.0 of the maps sdk. 

![image](https://user-images.githubusercontent.com/2151639/30954080-1b86c4aa-a42f-11e7-9c64-c147efec1ba5.png)
