### PR TITLE
Cancelable downloads

### DIFF
--- a/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.java
+++ b/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.java
@@ -46,11 +46,181 @@ import butterknife.OnClick;
  */
 public class OfflineRegionDetailActivity extends AppCompatActivity {
 
-  static final String KEY_ID_OFFLINE_REGION = "com.mapbox.mapboxsdk.plugins.testapp.activity.offline.region.id";
-
   private OfflineRegion offlineRegion;
   private OfflineDownloadResultReceiver resultReceiver;
+  private DownloadService.DownloadServiceBinder downloadServiceBinder;
   private boolean boundDownloadService = false;
+
+  @BindView(R.id.mapView)
+  MapView mapView;
+
+  @BindView(R.id.fab_delete)
+  FloatingActionButton deleteView;
+
+  @BindView(R.id.region_state)
+  TextView stateView;
+
+  @BindView(R.id.region_state_progress)
+  ProgressBar progressBar;
+
+  @BindView(R.id.region_name)
+  TextView nameView;
+
+  @BindView(R.id.region_style_url)
+  TextView styleView;
+
+  @BindView(R.id.region_min_zoom)
+  TextView minZoomView;
+
+  @BindView(R.id.region_max_zoom)
+  TextView maxZoomView;
+
+  @BindView(R.id.region_lat_lng_bounds)
+  TextView latLngBoundsView;
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_offline_region_detail);
+    ButterKnife.bind(this);
+    mapView.onCreate(savedInstanceState);
+
+    Bundle bundle = getIntent().getExtras();
+    if (bundle != null) {
+      OfflineUtils.getRegion(
+        OfflineManager.getInstance(this),
+        getIntent().getExtras().getLong(DownloadService.RegionConstants.ID),
+        offlineRegionCallback
+      );
+    } else {
+      Toast.makeText(this, "invalid bundle for Activity", Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  private void setupUI(final OfflineTilePyramidRegionDefinition definition) {
+    // update map
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap mapboxMap) {
+        // correct style
+        mapboxMap.setStyle(definition.getStyleURL());
+
+        // position map on top of offline region
+        CameraPosition cameraPosition = OfflineUtils.getCameraPosition(definition);
+        mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
+
+        // restrict camera movement
+        mapboxMap.setMinZoomPreference(definition.getMinZoom());
+        mapboxMap.setMaxZoomPreference(definition.getMaxZoom());
+        mapboxMap.setLatLngBoundsForCameraTarget(definition.getBounds());
+      }
+    });
+
+    // update textview data
+    nameView.setText(OfflineUtils.convertRegionName(offlineRegion.getMetadata()));
+    styleView.setText(definition.getStyleURL());
+    latLngBoundsView.setText(definition.getBounds().toString());
+    minZoomView.setText(String.valueOf(definition.getMinZoom()));
+    maxZoomView.setText(String.valueOf(definition.getMaxZoom()));
+    offlineRegion.getStatus(offlineRegionStatusCallback);
+  }
+
+  @OnClick(R.id.fab_delete)
+  public void onFabClick(View view) {
+    if ((boolean) view.getTag()) {
+      if (offlineRegion != null) {
+        deleteView.setEnabled(false);
+        offlineRegion.delete(offlineRegionDeleteCallback);
+      }
+    } else {
+      // cancel ongoing downloads
+      downloadServiceBinder.getService().cancelOngoingDownloads();
+      stateView.setText("CANCELED");
+    }
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+
+    // listen to download status change updates (Success, Cancel & Error)
+    LocalBroadcastManager.getInstance(this).registerReceiver(
+      resultReceiver = new OfflineDownloadResultReceiver(),
+      OfflineDownload.INTENT_FILTER
+    );
+
+    // bind Activity to Service to receive download status updates (percentage of downloaded offline region)
+    Intent intent = new Intent(this, DownloadService.class);
+    getApplicationContext().bindService(intent, connection, Context.BIND_AUTO_CREATE);
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+
+    // stop listening to download status change updates
+    LocalBroadcastManager.getInstance(this).unregisterReceiver(resultReceiver);
+
+    // unbind from service to stop receiving download states updates
+    if (boundDownloadService) {
+      getApplicationContext().unbindService(connection);
+      boundDownloadService = false;
+    }
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  //TODO make static inner class
+  private class OfflineDownloadResultReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      String actionName = intent.getStringExtra(OfflineDownload.KEY_STATE);
+      if (actionName.equals(OfflineDownload.STATE_FINISHED)) {
+        //OfflineDownload offlineDownload = intent.getParcelableExtra(OfflineDownload.KEY_BUNDLE_OFFLINE_REGION);
+        stateView.setText("DOWNLOADED");
+        progressBar.setVisibility(View.INVISIBLE);
+      } else if (actionName.equals(OfflineDownload.STATE_CANCEL)) {
+        stateView.setText("CANCELED");
+        finish(); // nothing to do in this screen, cancel = delete
+      } else if (actionName.equals(OfflineDownload.STATE_ERROR)) {
+        stateView.setText("ERROR");
+        String error = intent.getStringExtra(OfflineDownload.KEY_BUNDLE_OFFLINE_REGION);
+        String message = intent.getStringExtra(OfflineDownload.KEY_BUNDLE_ERROR);
+        Toast.makeText(context, "Offline Download error: " + error + " " + message, Toast.LENGTH_SHORT).show();
+      }
+    }
+  }
 
   /**
    * Connection to a the bound {@link DownloadService}. This connection is used to set a responder which is invoked
@@ -59,8 +229,8 @@ public class OfflineRegionDetailActivity extends AppCompatActivity {
   private final ServiceConnection connection = new ServiceConnection() {
     @Override
     public void onServiceConnected(ComponentName name, IBinder service) {
-      DownloadService.DownloadServiceBinder binder = (DownloadService.DownloadServiceBinder) service;
-      binder.getService().setDownloadServiceResponder(downloadServiceResponder);
+      downloadServiceBinder = (DownloadService.DownloadServiceBinder) service;
+      downloadServiceBinder.getService().setDownloadServiceResponder(downloadServiceResponder);
       boundDownloadService = true;
     }
 
@@ -92,7 +262,23 @@ public class OfflineRegionDetailActivity extends AppCompatActivity {
     new OfflineRegion.OfflineRegionStatusCallback() {
       @Override
       public void onStatus(OfflineRegionStatus status) {
-        stateView.setText(status.isComplete() ? "DOWNLOADED" : "DOWNLOADING");
+        int downloadState = status.getDownloadState();
+        if (downloadState == OfflineRegion.STATE_ACTIVE) {
+          FloatingActionButton actionButton = (FloatingActionButton) findViewById(R.id.fab_delete);
+          if (!status.isComplete()) {
+            // set fab to cancel
+            actionButton.setImageResource(R.drawable.ic_cancel_black_24dp);
+            findViewById(R.id.fab_delete).setTag(false);
+            stateView.setText("DOWNLOADING");
+          } else {
+            // set fab to delete
+            actionButton.setImageResource(R.drawable.ic_delete);
+            findViewById(R.id.fab_delete).setTag(true);
+            stateView.setText("DOWNLOADED");
+          }
+        } else {
+          stateView.setText("PAUSED");
+        }
       }
 
       @Override
@@ -141,163 +327,4 @@ public class OfflineRegionDetailActivity extends AppCompatActivity {
           Toast.LENGTH_SHORT).show();
       }
     };
-
-  @BindView(R.id.mapView)
-  MapView mapView;
-
-  @BindView(R.id.fab_delete)
-  FloatingActionButton deleteView;
-
-  @BindView(R.id.region_state)
-  TextView stateView;
-
-  @BindView(R.id.region_state_progress)
-  ProgressBar progressBar;
-
-  @BindView(R.id.region_name)
-  TextView nameView;
-
-  @BindView(R.id.region_style_url)
-  TextView styleView;
-
-  @BindView(R.id.region_min_zoom)
-  TextView minZoomView;
-
-  @BindView(R.id.region_max_zoom)
-  TextView maxZoomView;
-
-  @BindView(R.id.region_lat_lng_bounds)
-  TextView latLngBoundsView;
-
-  @Override
-  protected void onCreate(@Nullable Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_offline_region_detail);
-    ButterKnife.bind(this);
-    mapView.onCreate(savedInstanceState);
-
-    OfflineUtils.getRegion(
-      OfflineManager.getInstance(this),
-      getIntent().getExtras().getLong(KEY_ID_OFFLINE_REGION),
-      offlineRegionCallback
-    );
-  }
-
-  private void setupUI(final OfflineTilePyramidRegionDefinition definition) {
-    // update map
-    mapView.getMapAsync(new OnMapReadyCallback() {
-      @Override
-      public void onMapReady(MapboxMap mapboxMap) {
-        // correct style
-        mapboxMap.setStyle(definition.getStyleURL());
-
-        // position map on top of offline region
-        CameraPosition cameraPosition = OfflineUtils.getCameraPosition(definition);
-        mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
-
-        // restrict camera movement
-        mapboxMap.setMinZoomPreference(definition.getMinZoom());
-        mapboxMap.setMaxZoomPreference(definition.getMaxZoom());
-        mapboxMap.setLatLngBoundsForCameraTarget(definition.getBounds());
-      }
-    });
-
-    // update textview data
-    nameView.setText(OfflineUtils.convertRegionName(offlineRegion.getMetadata()));
-    styleView.setText(definition.getStyleURL());
-    latLngBoundsView.setText(definition.getBounds().toString());
-    minZoomView.setText(String.valueOf(definition.getMinZoom()));
-    maxZoomView.setText(String.valueOf(definition.getMaxZoom()));
-    offlineRegion.getStatus(offlineRegionStatusCallback);
-  }
-
-  @OnClick(R.id.fab_delete)
-  public void onDeleteRegion() {
-    if (offlineRegion != null) {
-      deleteView.setEnabled(false);
-      offlineRegion.delete(offlineRegionDeleteCallback);
-    }
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-
-    // listen to download status change updates (Success, Cancel & Error)
-    LocalBroadcastManager.getInstance(this).registerReceiver(
-      resultReceiver = new OfflineDownloadResultReceiver(),
-      OfflineDownload.INTENT_FILTER
-    );
-
-    // bind Activity to Service to receive download status updates (percentage of downloaded offline region)
-    Intent intent = new Intent(this, DownloadService.class);
-    bindService(intent, connection, Context.BIND_AUTO_CREATE);
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-
-    // stop listening to download status change updates
-    LocalBroadcastManager.getInstance(this).unregisterReceiver(resultReceiver);
-
-    // unbind from service to stop receiving download states updates
-    if (boundDownloadService) {
-      unbindService(connection);
-      boundDownloadService = false;
-    }
-  }
-
-  @Override
-  protected void onSaveInstanceState(Bundle outState) {
-    super.onSaveInstanceState(outState);
-    mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
-
-  @Override
-  public void onLowMemory() {
-    super.onLowMemory();
-    mapView.onLowMemory();
-  }
-
-  //TODO make static inner class
-  private class OfflineDownloadResultReceiver extends BroadcastReceiver {
-
-    @Override
-    public void onReceive(Context context, Intent intent) {
-      String actionName = intent.getStringExtra(OfflineDownload.KEY_STATE);
-      if (actionName.equals(OfflineDownload.STATE_FINISHED)) {
-        //OfflineDownload offlineDownload = intent.getParcelableExtra(OfflineDownload.KEY_BUNDLE_OFFLINE_REGION);
-        stateView.setText("DOWNLOADED");
-        progressBar.setVisibility(View.INVISIBLE);
-      } else if (actionName.equals(OfflineDownload.STATE_CANCEL)) {
-        stateView.setText("CANCELED");
-      } else if (actionName.equals(OfflineDownload.STATE_ERROR)) {
-        stateView.setText("ERROR");
-        String error = intent.getStringExtra(OfflineDownload.KEY_BUNDLE_OFFLINE_REGION);
-        String message = intent.getStringExtra(OfflineDownload.KEY_BUNDLE_ERROR);
-        Toast.makeText(context, "Offline Download error: " + error + " " + message, Toast.LENGTH_SHORT).show();
-      }
-    }
-  }
 }

--- a/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionListActivity.java
+++ b/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionListActivity.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 import com.mapbox.mapboxsdk.offline.OfflineManager;
 import com.mapbox.mapboxsdk.offline.OfflineRegion;
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
+import com.mapbox.mapboxsdk.plugins.offline.DownloadService;
 import com.mapbox.mapboxsdk.plugins.offline.OfflineUtils;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 
@@ -45,7 +46,7 @@ public class OfflineRegionListActivity extends AppCompatActivity implements Adap
   public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
     OfflineRegion region = adapter.getItem(position);
     Intent intent = new Intent(this, OfflineRegionDetailActivity.class);
-    intent.putExtra(OfflineRegionDetailActivity.KEY_ID_OFFLINE_REGION, region.getID());
+    intent.putExtra(DownloadService.RegionConstants.ID, region.getID());
     startActivity(intent);
   }
 

--- a/plugins/app/src/main/res/layout/activity_offline_region_detail.xml
+++ b/plugins/app/src/main/res/layout/activity_offline_region_detail.xml
@@ -43,7 +43,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="16dp"
                         android:layout_marginStart="16dp"
-                        android:layout_marginTop="8dp"
+                        android:layout_marginTop="16dp"
                         android:text="Loading status.."
                         android:textAllCaps="true"
                         android:textColor="?android:colorBackground"
@@ -57,7 +57,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="32dp"
                         android:layout_marginRight="16dp"
-                        android:layout_marginTop="8dp"
+                        android:layout_marginTop="16dp"
                         android:max="100"
                         android:visibility="invisible"/>
 
@@ -67,11 +67,11 @@
                     android:id="@+id/region_name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="24dp"
+                    android:layout_marginBottom="16dp"
                     android:layout_marginLeft="16dp"
                     android:layout_marginStart="16dp"
                     android:layout_marginTop="8dp"
-                    android:text="56sp"
+                    android:text=""
                     android:textColor="@android:color/white"
                     android:textSize="20sp"
                     android:textStyle="bold"/>

--- a/plugins/dependencies.gradle
+++ b/plugins/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 26
     compileSdkVersion = 26
-    buildToolsVersion = "26.0.1"
+    buildToolsVersion = "26.0.2"
 
     versionCode = 2
     versionName = "0.2.0"

--- a/plugins/locationlayer/README.md
+++ b/plugins/locationlayer/README.md
@@ -12,6 +12,7 @@ To use the location layer plugin, you include it in your `build.gradle` file.
 // In the root build.gradle file
 repositories {
     mavenCentral()
+    maven { url 'https://maven.google.com' }
 }
 
 ...
@@ -28,6 +29,7 @@ The location layer plugin is published to Maven Central and nightly SNAPSHOTs ar
 // In the root build.gradle file
 repositories {
     mavenCentral()
+    maven { url 'https://maven.google.com' }
     maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
 }
 

--- a/plugins/locationlayer/build.gradle
+++ b/plugins/locationlayer/build.gradle
@@ -15,6 +15,17 @@ android {
   configurations {
     javadocDeps
   }
+
+  configurations.all {
+    resolutionStrategy.force "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:cardview-v7:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:recyclerview-v7:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:design:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:percent:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:preference-v14:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:customtabs:${rootProject.ext.supportLibVersion}"
+    resolutionStrategy.force "com.android.support:support-annotations:${rootProject.ext.supportLibVersion}"
+  }
 }
 
 dependencies {
@@ -31,6 +42,8 @@ dependencies {
 
   javadocDeps rootProject.ext.dep.mapSdk
 }
+
+
 
 apply from: 'javadoc.gradle'
 apply from: '../mvn-push-android.gradle'


### PR DESCRIPTION
WIP (still need to fine tune some interactions).This PR adds a cancel button to the notification and allows to cancel ongoing offline downloads. When such a situation occurs we dispatch a broadcast indicating that the download was cancelled. 