### PR TITLE
OfflinePlugin intermediate abstraction implementation

### DIFF
--- a/plugins/app/src/main/AndroidManifest.xml
+++ b/plugins/app/src/main/AndroidManifest.xml
@@ -131,12 +131,18 @@
         <activity
             android:name=".activity.offline.OfflineRegionDetailActivity"
             android:description="@string/description_offline_regions"
-            android:theme="@style/Translucent"
-            android:label="@string/title_offline_regions"/>
+            android:label="@string/title_offline_regions"
+            android:theme="@style/Translucent"/>
 
         <service
             android:name="com.mapbox.mapboxsdk.plugins.offline.DownloadService"
             android:exported="false"/>
+
+        <receiver android:name="com.mapbox.mapboxsdk.plugins.offline.OfflineStateReceiver">
+            <intent-filter>
+                <action android:name="com.mapbox.mapboxsdk.plugins.offline"/>
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
+++ b/plugins/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
@@ -130,6 +130,6 @@ public class OfflineDownloadActivity extends AppCompatActivity {
       .setNotificationsOptions(notificationOptions)
       .build();
 
-    new OfflinePlugin().downloadRegion(this, offlineDownload);
+    OfflinePlugin.getInstance().downloadRegion(this, offlineDownload);
   }
 }

--- a/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/DownloadService.java
+++ b/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/DownloadService.java
@@ -11,7 +11,6 @@ import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
-import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.util.LongSparseArray;
 import android.widget.Toast;
 
@@ -97,6 +96,10 @@ public class DownloadService extends Service implements ConnectivityListener {
             public void onCreate(OfflineRegion offlineRegion) {
               Timber.e("offline region created with %s", offlineRegion.getID());
               offlineDownload.setRegionId(offlineRegion.getID());
+
+              // dispatch start download broadcast
+              dispatchStartBroadcast(offlineDownload);
+
               offlineRegion.setDeliverInactiveMessages(false);
               regionLongSparseArray.put(offlineDownload.getServiceId(), offlineRegion);
               launchDownload(offlineDownload, offlineRegion);
@@ -265,11 +268,18 @@ public class DownloadService extends Service implements ConnectivityListener {
     offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE);
   }
 
+  private void dispatchStartBroadcast(OfflineDownload offlineDownload) {
+    Intent intent = new Intent(OfflineDownload.ACTION_OFFLINE);
+    intent.putExtra(OfflineDownload.KEY_STATE, OfflineDownload.STATE_STARTED);
+    intent.putExtra(OfflineDownload.KEY_OBJECT, offlineDownload);
+    getApplicationContext().sendBroadcast(intent);
+  }
+
   private void dispatchSuccessBroadcast(OfflineDownload offlineDownload) {
     Intent intent = new Intent(OfflineDownload.ACTION_OFFLINE);
     intent.putExtra(OfflineDownload.KEY_STATE, OfflineDownload.STATE_FINISHED);
     intent.putExtra(OfflineDownload.KEY_OBJECT, offlineDownload);
-    LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
+    getApplicationContext().sendBroadcast(intent);
   }
 
   private void dispatchErrorBroadcast(OfflineDownload offlineDownload, String error, String message) {
@@ -278,14 +288,14 @@ public class DownloadService extends Service implements ConnectivityListener {
     intent.putExtra(OfflineDownload.KEY_OBJECT, offlineDownload);
     intent.putExtra(OfflineDownload.KEY_BUNDLE_ERROR, error);
     intent.putExtra(OfflineDownload.KEY_BUNDLE_MESSAGE, message);
-    LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
+    getApplicationContext().sendBroadcast(intent);
   }
 
   private void dispatchCancelBroadcast(OfflineDownload offlineDownload) {
     Intent intent = new Intent(OfflineDownload.ACTION_OFFLINE);
     intent.putExtra(OfflineDownload.KEY_STATE, OfflineDownload.STATE_CANCEL);
     intent.putExtra(OfflineDownload.KEY_OBJECT, offlineDownload);
-    LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
+    getApplicationContext().sendBroadcast(intent);
   }
 
   @Override

--- a/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineDownload.java
+++ b/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineDownload.java
@@ -16,6 +16,7 @@ public class OfflineDownload implements Parcelable {
 
   public static final String KEY_OBJECT = "com.mapbox.mapboxsdk.plugins.offline.download.object";
   public static final String KEY_STATE = "com.mapbox.mapboxsdk.plugins.offline.state";
+  public static final String STATE_STARTED = "com.mapbox.mapboxsdk.plugins.offline.state.started";
   public static final String STATE_FINISHED = "com.mapbox.mapboxsdk.plugins.offline.state.complete";
   public static final String STATE_ERROR = "com.mapbox.mapboxsdk.plugins.offline.state.error";
   public static final String STATE_CANCEL = "com.mapbox.mapboxsdk.plugins.offline.state.cancel";

--- a/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePlugin.java
+++ b/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePlugin.java
@@ -3,14 +3,85 @@ package com.mapbox.mapboxsdk.plugins.offline;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.mapbox.mapboxsdk.offline.OfflineRegion;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class OfflinePlugin {
 
+  private static OfflinePlugin INSTANCE;
+
+  private List<OfflineDownload> offlineDownloads = new ArrayList<>();
+
+  public static synchronized OfflinePlugin getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = new OfflinePlugin();
+    }
+    return INSTANCE;
+  }
+
+  private OfflinePlugin() {
+
+  }
+
+  /**
+   * Download a offline region based on an offline download.
+   *
+   * @param context the context to derive the application context of
+   * @param offlineDownload the offline download model
+   */
   public void downloadRegion(@NonNull Context context, OfflineDownload offlineDownload) {
     Context appContext = context.getApplicationContext();
     Intent intent = new Intent(appContext, DownloadService.class);
     intent.setAction(DownloadService.ACTION_START_DOWNLOAD);
     intent.putExtra(OfflineDownload.KEY_OBJECT, offlineDownload);
     appContext.startService(intent);
+  }
+
+  /**
+   * Called when the DownloadService has created an offline region for an offlineDownload and
+   * has assigned a region and service id.
+   *
+   * @param offlineDownload the offline download to track
+   */
+  void addDownload(OfflineDownload offlineDownload) {
+    if (offlineDownload.getRegionId() == -1 || offlineDownload.getServiceId() == -1) {
+      throw new RuntimeException();
+    }
+    offlineDownloads.add(offlineDownload);
+  }
+
+  /**
+   * Called when the DownloadService has finished downloading.
+   *
+   * @param offlineDownload the offline download to stop tracking
+   */
+  void removeDownload(OfflineDownload offlineDownload) {
+    offlineDownloads.remove(offlineDownload);
+  }
+
+  /**
+   * Get the OfflineDownload for an offline region, returns null if no download is active for region.
+   *
+   * @param offlineRegion the offline region to get related offline download for
+   * @return the active offline download, null if not downloading the region.
+   */
+  @Nullable
+  public OfflineDownload getDownloadForRegion(OfflineRegion offlineRegion) {
+    OfflineDownload offlineDownload = null;
+    if (!offlineDownloads.isEmpty()) {
+      for (OfflineDownload download : offlineDownloads) {
+        if (download.getRegionId() == -1) {
+          throw new RuntimeException("All downloads in OfflinePlugin should be initialized (region id + service id)");
+        }
+        if (download.getRegionId() == offlineRegion.getID()) {
+          offlineDownload = download;
+        }
+      }
+    }
+    return offlineDownload;
   }
 }

--- a/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineStateReceiver.java
+++ b/plugins/offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineStateReceiver.java
@@ -1,0 +1,37 @@
+package com.mapbox.mapboxsdk.plugins.offline;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+public class OfflineStateReceiver extends BroadcastReceiver {
+
+  private OfflinePlugin offlinePlugin;
+
+  public OfflineStateReceiver() {
+    offlinePlugin = OfflinePlugin.getInstance();
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    String actionName = intent.getStringExtra(OfflineDownload.KEY_STATE);
+    OfflineDownload offlineDownload = intent.getParcelableExtra(OfflineDownload.KEY_OBJECT);
+    if (actionName.equals(OfflineDownload.STATE_STARTED)) {
+      Toast.makeText(context, "Download started", Toast.LENGTH_SHORT).show();
+      offlinePlugin.addDownload(offlineDownload);
+    } else {
+      offlinePlugin.removeDownload(offlineDownload);
+    }
+
+    if (actionName.equals(OfflineDownload.STATE_FINISHED)) {
+      Toast.makeText(context, "Download finished", Toast.LENGTH_SHORT).show();
+    } else if (actionName.equals(OfflineDownload.STATE_CANCEL)) {
+      Toast.makeText(context, "Download cancel", Toast.LENGTH_SHORT).show();
+    } else if (actionName.equals(OfflineDownload.STATE_ERROR)) {
+      String error = intent.getStringExtra(OfflineDownload.KEY_BUNDLE_OFFLINE_REGION);
+      String message = intent.getStringExtra(OfflineDownload.KEY_BUNDLE_ERROR);
+      Toast.makeText(context, "Offline Download error: " + error + " " + message, Toast.LENGTH_SHORT).show();
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an abstraction in OfflinePlugin to allow for communication with the DownloadService.
 - OfflinePlugin was made a Singleton 
 - OfflineStateReceiver is a app wide broadcast receiver that will post updates to OfflinePlugin
 - OfflinePlugin is responsible for mangaging all different (ongoing) offline downloads 
 - OfflinePlugin allows to convert an offline region to an offline download (if that region is downloading)

cc @zugaldia 