### PR TITLE
Update support lib and build tools

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,9 +2,9 @@ ext {
 
   androidVersions = [
       minSdkVersion    : 15,
-      targetSdkVersion : 26,
-      compileSdkVersion: 26,
-      buildToolsVersion: '26.0.2'
+      targetSdkVersion : 27,
+      compileSdkVersion: 27,
+      buildToolsVersion: '27.0.1'
   ]
 
   version = [
@@ -13,7 +13,7 @@ ext {
       autoValue          : '1.4.1',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',
-      supportLibVersion  : '26.1.0',
+      supportLibVersion  : '27.0.0',
       constraintLayout   : '1.0.2',
       mockito            : '2.10.0',
       hamcrest           : '2.0.0.0',


### PR DESCRIPTION
This PR tests integration with the latest build tools, target SDK version and support libraries.
To be discussed if we want to include this change to the 0.2.0 release. Currently targets to be merged into https://github.com/mapbox/mapbox-plugins-android/pull/153 but can be re targeted for master after.