### PR TITLE
bumped location plugin version in readme

### DIFF
--- a/plugin-locationlayer/README.md
+++ b/plugin-locationlayer/README.md
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.2.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.3.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-locationlayer/README.md
+++ b/plugin-locationlayer/README.md
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.3.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-locationlayer/README.md
+++ b/plugin-locationlayer/README.md
@@ -19,7 +19,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.1.0'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.2.0'
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.2.0-SNAPSHOT'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:0.3.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-locationlayer/gradle.properties
+++ b/plugin-locationlayer/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.2.0-SNAPSHOT
+VERSION_NAME=0.3.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-locationlayer
 POM_NAME=Mapbox Android Plugins
 POM_DESCRIPTION=Mapbox Android Plugins (Location Layer)


### PR DESCRIPTION
Part of [the 0.2.0 release of the location layer plugin](http://repo1.maven.org/maven2/com/mapbox/mapboxsdk/mapbox-android-plugin-locationlayer/0.2.0/)

Snapshot is now 0.3.0 