### PR TITLE
bumped maps sdk to 5.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '5.2.0-beta.4',
+      mapboxMapSdk       : '5.2.0',
       mapboxServices     : '2.2.9',
       autoValue          : '1.4.1',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
Part of [the 5.2.0 stable maps sdk release](https://github.com/mapbox/mapbox-gl-native/issues/10486)