### PR TITLE
Adding plugin installation info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ dependencies {
   compile 'com.mapbox.mapboxsdk:PLUGIN_NAME:PLUGIN_VERSION_NUMBER'
 }
 ```
-
 5. Click the Sync Project with Gradle Files near the toolbar in Studio.
 
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Note that depending on the plugin you add, there might be required permissions a
 2. Open up your application's `build.gradle`
 3. Make sure that your project's `minSdkVersion` is at API 15 or higher
 4. Under dependencies, add a new build rule for the latest plugin version you are trying to use.
-5. Click the Sync Project with Gradle Files near the toolbar in Studio.
-
 ```gradle
 repositories {
   mavenCentral()
@@ -35,6 +33,9 @@ dependencies {
   compile 'com.mapbox.mapboxsdk:PLUGIN_NAME:PLUGIN_VERSION_NUMBER'
 }
 ```
+
+5. Click the Sync Project with Gradle Files near the toolbar in Studio.
+
 
 ## Help and Usage
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Plugins are single-purpose libraries built on top of the [Mapbox Maps SDK for An
 
 * [**GeoJSON:** Load GeoJSON data from a URL, an asset file, or path.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-geojson)
 
-## Install a plugin
+## Installing a plugin
 
-By using a plugin, you also include the Android Map SDK which means that you'll need to setup your project to use the Map SDK if you haven't already. Head over to the [Map SDK for Android Overview page](https://www.mapbox.com/android-docs/map-sdk/overview/) to learn more.
+By using a plugin, you also include the Android Map SDK which means that you'll need to setup your project to use the Map SDK if you haven't already. Head over to the [overview page for the Mapbox Maps SDK](https://www.mapbox.com/android-docs/map-sdk/overview/) to learn more.
 
 Note that depending on the plugin you add, there might be required permissions and additional setup steps. You'll find more information on whether or not more configuration steps are involved when looking at the specific plugin documentation.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ Plugins are single-purpose libraries built on top of the [Mapbox Maps SDK for An
 
 * [**GeoJSON:** Load GeoJSON data from a URL, an asset file, or path.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-geojson)
 
+## Install a plugin
+
+By using a plugin, you also include the Android Map SDK which means that you'll need to setup your project to use the Map SDK if you haven't already. Head over to the [Map SDK for Android Overview page](https://www.mapbox.com/android-docs/map-sdk/overview/) to learn more.
+
+Note that depending on the plugin you add, there might be required permissions and additional setup steps. You'll find more information on whether or not more configuration steps are involved when looking at the specific plugin documentation.
+
+1. Start Android Studio
+2. Open up your application's `build.gradle`
+3. Make sure that your project's `minSdkVersion` is at API 15 or higher
+4. Under dependencies, add a new build rule for the latest plugin version you are trying to use.
+5. Click the Sync Project with Gradle Files near the toolbar in Studio.
+
+```gradle
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'com.mapbox.mapboxsdk:PLUGIN_NAME:PLUGIN_VERSION_NUMBER'
+}
+```
+
 ## Help and Usage
 
 This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that depending on the plugin you add, there might be required permissions a
 
 1. Start Android Studio
 2. Open up your application's `build.gradle`
-3. Make sure that your project's `minSdkVersion` is at API 15 or higher
+3. Make sure that your project's `minSdkVersion` is at API 14 or higher
 4. Under dependencies, add a new build rule for the latest plugin version you are trying to use.
 ```gradle
 repositories {


### PR DESCRIPTION
This pr adds plugin installation info to this repo's README. Right now, these instructions only currently live on [the Android docs' plugins page](https://www.mapbox.com/android-docs/plugins/overview/#install-a-plugin)

Adding the info to this repo was @LouisCAD 's idea in [this ticket](https://github.com/mapbox/mapbox-plugins-android/issues/162#issuecomment-343242012). I agree with him, et voilá!