### PR TITLE
Update gradle configuration with implementation setup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,10 @@ android {
 }
 
 dependencies {
+  // Mapbox
+  implementation dependenciesList.mapboxMapSdk
+  implementation dependenciesList.mapboxServices
+
   // Support libraries
   implementation dependenciesList.supportAnnotation
   implementation dependenciesList.supportAppcompatV7

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
       junit              : '4.12',
       supportLibVersion  : '26.1.0',
       constraintLayout   : '1.0.2',
-      mockito            : '2.10.0',
+      mockito            : '2.12.0',
       hamcrest           : '2.0.0.0',
       errorprone         : '2.0.21',
       butterknife        : '8.8.1',
@@ -28,7 +28,8 @@ ext {
       commonsIO          : '2.5',
       robolectric        : '3.4.2',
       lifecycleCompiler  : '1.0.0',
-      lifecycleRuntime   : '1.0.3'
+      lifecycleRuntime   : '1.0.3',
+      okhttp             : '3.9.0'
   ]
 
   pluginVersion = [
@@ -46,6 +47,7 @@ ext {
       // mapbox
       mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}@aar",
       mapboxServices         : "com.mapbox.mapboxsdk:mapbox-android-services:${version.mapboxServices}",
+      geojson                : "com.mapbox.mapboxsdk:mapbox-java-geojson:${version.mapboxServices}",
 
       // AutoValue
       autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
@@ -84,16 +86,19 @@ ext {
 
       // unit test
       junit                  : "junit:junit:${version.junit}",
-      mockito                : "org.mockito:mockito-core:${version.mockito}",
+      mockito                : "org.mockito:mockito-inline:${version.mockito}",
       hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
       commonsIO              : "commons-io:commons-io:${version.commonsIO}",
       robolectric            : "org.robolectric:robolectric:${version.robolectric}",
 
+      // okhttp
+      okhttp                 : "com.squareup.okhttp3:okhttp:${version.okhttp}",
+
       // aws polly
       polly                  : "com.amazonaws:aws-android-sdk-polly:${version.awsPolly}",
 
+      // errorprone
       errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
-
   ]
 
   pluginDependencies = [

--- a/plugin-building/build.gradle
+++ b/plugin-building/build.gradle
@@ -16,9 +16,8 @@ android {
 }
 
 dependencies {
-  api (dependenciesList.mapboxMapSdk) {
-    transitive = true
-  }
+  implementation dependenciesList.mapboxMapSdk
+  implementation dependenciesList.supportAnnotation
 
   // Unit testing
   testImplementation dependenciesList.junit

--- a/plugin-cluster/build.gradle
+++ b/plugin-cluster/build.gradle
@@ -24,9 +24,8 @@ android {
 
 dependencies {
   implementation dependenciesList.supportAppcompatV7
-  api (dependenciesList.mapboxMapSdk) {
-    transitive = true
-  }
+  implementation dependenciesList.mapboxMapSdk
+  implementation dependenciesList.timber
 
   // Unit testing
   testImplementation dependenciesList.junit

--- a/plugin-geojson/build.gradle
+++ b/plugin-geojson/build.gradle
@@ -17,10 +17,10 @@ android {
 
 dependencies {
   implementation dependenciesList.supportAppcompatV7
-  api (dependenciesList.mapboxMapSdk) {
-    transitive = true
-  }
-
+  implementation dependenciesList.mapboxMapSdk
+  implementation dependenciesList.geojson
+  implementation dependenciesList.okhttp
+  implementation dependenciesList.timber
   javadocDeps dependenciesList.mapboxMapSdk
 }
 

--- a/plugin-locationlayer/build.gradle
+++ b/plugin-locationlayer/build.gradle
@@ -17,12 +17,9 @@ android {
 }
 
 dependencies {
-
   implementation dependenciesList.supportAppcompatV7
-  api dependenciesList.mapboxServices
-  api (dependenciesList.mapboxMapSdk) {
-    transitive = true
-  }
+  implementation dependenciesList.mapboxServices
+  implementation dependenciesList.mapboxMapSdk
 
   // Unit testing
   testImplementation dependenciesList.junit

--- a/plugin-traffic/build.gradle
+++ b/plugin-traffic/build.gradle
@@ -17,14 +17,14 @@ android {
 }
 
 dependencies {
-  // Unit testing
+  implementation dependenciesList.mapboxMapSdk
+  implementation dependenciesList.supportAnnotation
+  implementation dependenciesList.timber
+  implementation dependenciesList.mapboxServices
+
+    // Unit testing
   testImplementation dependenciesList.junit
   testImplementation dependenciesList.mockito
-
-  // Mapbox dependencies
-  api (dependenciesList.mapboxMapSdk) {
-    transitive = true
-  }
 
   javadocDeps dependenciesList.mapboxMapSdk
 }


### PR DESCRIPTION
Closes #140, this PR updates the configuration to not leak the Maps SDK dependency. For a true "plugin" concept we need to allow end developers providing the SDK dependency, our plugins need to hook into the provided one at runtime.  

cc @zugaldia 