### PR TITLE
Android SDK renaming

### DIFF
--- a/plugin-building/src/main/java/com/mapbox/androidsdk/plugins/building/BuildingPlugin.java
+++ b/plugin-building/src/main/java/com/mapbox/androidsdk/plugins/building/BuildingPlugin.java
@@ -22,7 +22,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpa
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
 /**
- * The building plugin allows to add 3d buildings FillExtrusionLayer to the Mapbox Android SDK v5.1.0.
+ * The building plugin allows to add 3d buildings FillExtrusionLayer to the Mapbox Maps SDK for Android v5.1.0.
  * <p>
  * Initialise this plugin in the {@link com.mapbox.mapboxsdk.maps.OnMapReadyCallback#onMapReady(MapboxMap)} and provide
  * a valid instance of {@link MapView} and {@link MapboxMap}.

--- a/plugin-traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
+++ b/plugin-traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
@@ -38,7 +38,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
 /**
- * The Traffic Plugin allows you to add Mapbox Traffic v1 to the Mapbox Android SDK.
+ * The Traffic Plugin allows you to add Mapbox Traffic v1 to the Mapbox Maps SDK for Android.
  * <p>
  * Initialise this plugin in the {@link com.mapbox.mapboxsdk.maps.OnMapReadyCallback#onMapReady(MapboxMap)} and provide
  * a valid instance of {@link MapView} and {@link MapboxMap}.


### PR DESCRIPTION
This pr renames Android content that needs to be renamed, to Mapbox Maps SDK for Android.

related:

https://github.com/mapbox/mapbox-gl-native/issues/10385 and https://github.com/mapbox/android-docs/pull/249