### PR TITLE
Adding min/max zoom textview for offline download seekbar

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/FeatureOverviewActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/FeatureOverviewActivity.java
@@ -253,10 +253,12 @@ public class FeatureOverviewActivity extends AppCompatActivity implements Permis
       return category;
     }
 
+    @Override
     public int describeContents() {
       return 0;
     }
 
+    @Override
     public void writeToParcel(Parcel out, int flags) {
       out.writeString(name);
       out.writeString(label);
@@ -265,10 +267,12 @@ public class FeatureOverviewActivity extends AppCompatActivity implements Permis
     }
 
     public static final Parcelable.Creator<Feature> CREATOR = new Parcelable.Creator<Feature>() {
+      @Override
       public Feature createFromParcel(Parcel in) {
         return new Feature(in);
       }
 
+      @Override
       public Feature[] newArray(int size) {
         return new Feature[size];
       }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.offline;
 
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
@@ -69,14 +68,14 @@ public class OfflineDownloadActivity extends AppCompatActivity {
     setContentView(R.layout.activity_offline_download);
     ButterKnife.bind(this);
     initUi();
-    initSeekbarListening();
+    initSeekbarListeners();
   }
 
   private void initUi() {
     initEditTexts();
     initSeekbars();
     initSpinner();
-    initTextviews();
+    initZoomLevelTextviews();
   }
 
   private void initEditTexts() {
@@ -106,12 +105,12 @@ public class OfflineDownloadActivity extends AppCompatActivity {
     styleUrlView.setAdapter(spinnerArrayAdapter);
   }
 
-  private void initTextviews() {
+  private void initZoomLevelTextviews() {
     maxTextView.setText(getString(R.string.max_zoom_textview, maxZoomView.getProgress()));
     minTextView.setText(getString(R.string.min_zoom_textview, minZoomView.getProgress()));
   }
 
-  private void initSeekbarListening() {
+  private void initSeekbarListeners() {
     maxZoomView.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
       @Override
       public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.java
@@ -1,11 +1,13 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.offline;
 
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.Spinner;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
@@ -46,6 +48,12 @@ public class OfflineDownloadActivity extends AppCompatActivity {
   @BindView(R.id.edittext_lon_west)
   EditText lonWestView;
 
+  @BindView(R.id.min_text_view)
+  TextView minTextView;
+
+  @BindView(R.id.max_text_view)
+  TextView maxTextView;
+
   @BindView(R.id.spinner_style_url)
   Spinner styleUrlView;
 
@@ -61,12 +69,14 @@ public class OfflineDownloadActivity extends AppCompatActivity {
     setContentView(R.layout.activity_offline_download);
     ButterKnife.bind(this);
     initUi();
+    initSeekbarListening();
   }
 
   private void initUi() {
     initEditTexts();
     initSeekbars();
     initSpinner();
+    initTextviews();
   }
 
   private void initEditTexts() {
@@ -96,6 +106,47 @@ public class OfflineDownloadActivity extends AppCompatActivity {
     styleUrlView.setAdapter(spinnerArrayAdapter);
   }
 
+  private void initTextviews() {
+    maxTextView.setText(getString(R.string.max_zoom_textview, maxZoomView.getProgress()));
+    minTextView.setText(getString(R.string.min_zoom_textview, minZoomView.getProgress()));
+  }
+
+  private void initSeekbarListening() {
+    maxZoomView.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+      @Override
+      public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        maxTextView.setText(getString(R.string.max_zoom_textview, progress));
+      }
+
+      @Override
+      public void onStartTrackingTouch(SeekBar seekBar) {
+
+      }
+
+      @Override
+      public void onStopTrackingTouch(SeekBar seekBar) {
+
+      }
+    });
+
+    minZoomView.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+      @Override
+      public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        minTextView.setText(getString(R.string.min_zoom_textview, progress));
+      }
+
+      @Override
+      public void onStartTrackingTouch(SeekBar seekBar) {
+
+      }
+
+      @Override
+      public void onStopTrackingTouch(SeekBar seekBar) {
+
+      }
+    });
+  }
+
   @OnClick(R.id.fab)
   public void onDownloadRegion() {
     // get data from UI
@@ -108,7 +159,7 @@ public class OfflineDownloadActivity extends AppCompatActivity {
     float maxZoom = maxZoomView.getProgress();
     float minZoom = minZoomView.getProgress();
 
-    if (!validCoordinates(latitudeNorth, longitudeEast, latitudeSouth,longitudeWest)) {
+    if (!validCoordinates(latitudeNorth, longitudeEast, latitudeSouth, longitudeWest)) {
       Toast.makeText(this, "coordinates need to be in valid range", Toast.LENGTH_LONG).show();
       return;
     }

--- a/app/src/main/res/layout/activity_offline_download.xml
+++ b/app/src/main/res/layout/activity_offline_download.xml
@@ -150,10 +150,10 @@
                 android:layout_marginBottom="8dp"/>
 
             <TextView
+                android:id="@+id/min_text_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:text="Min zoom:"/>
+                android:layout_marginBottom="4dp"/>
 
             <SeekBar
                 android:id="@+id/seekbar_min_zoom"
@@ -162,10 +162,10 @@
                 android:layout_marginBottom="12dp"/>
 
             <TextView
+                android:id="@+id/max_text_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:text="Max zoom:"/>
+                android:layout_marginBottom="4dp"/>
 
             <SeekBar
                 android:id="@+id/seekbar_max_zoom"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,45 +1,49 @@
 <resources>
-  <string name="app_name">Mapbox Android Plugins</string>
+    <string name="app_name">Mapbox Android Plugins</string>
 
-  <!-- Categories -->
-  <string name="category">category</string>
-  <string name="category_extrusions">Extrusions</string>
-  <string name="category_navigation">Navigation</string>
-  <string name="category_location">Location</string>
-  <string name="category_runtime_loading">Navigation</string>
-  <string name="category_annotations">Annotations</string>
-  <string name="category_places">Places</string>
-  <string name="category_offline">Offline</string>
+    <!-- Categories -->
+    <string name="category">category</string>
+    <string name="category_extrusions">Extrusions</string>
+    <string name="category_navigation">Navigation</string>
+    <string name="category_location">Location</string>
+    <string name="category_runtime_loading">Navigation</string>
+    <string name="category_annotations">Annotations</string>
+    <string name="category_places">Places</string>
+    <string name="category_offline">Offline</string>
 
-  <!-- Titles -->
-  <string name="title_traffic">Traffic Plugin</string>
-  <string name="title_building">Building Plugin</string>
-  <string name="title_location_modes">Location Modes</string>
-  <string name="title_location_map_change">Location Layer Map Change</string>
-  <string name="title_location_manual_update">Toggle Manual Location Updates</string>
-  <string name="title_compass_listener">Compass Listener</string>
-  <string name="title_geojson">GeoJson Plugin</string>
-  <string name="title_cluster">Cluster Plugin</string>
-  <string name="title_places_autocomplete">Places Autocomplete</string>
-  <string name="title_offline_plugin">Create region</string>
-  <string name="title_offline_regions">List regions</string>
+    <!-- Titles -->
+    <string name="title_traffic">Traffic Plugin</string>
+    <string name="title_building">Building Plugin</string>
+    <string name="title_location_modes">Location Modes</string>
+    <string name="title_location_map_change">Location Layer Map Change</string>
+    <string name="title_location_manual_update">Toggle Manual Location Updates</string>
+    <string name="title_compass_listener">Compass Listener</string>
+    <string name="title_geojson">GeoJson Plugin</string>
+    <string name="title_cluster">Cluster Plugin</string>
+    <string name="title_places_autocomplete">Places Autocomplete</string>
+    <string name="title_offline_plugin">Create region</string>
+    <string name="title_offline_regions">List regions</string>
 
-  <!-- Descriptions -->
-  <string name="description_traffic">Add Traffic layers to any Mapbox basemap.</string>
-  <string name="description_building">Add 3D Building layer to a Mapbox map.</string>
-  <string name="description_location_modes">Switch between the different location modes.</string>
-  <string name="description_location_map_change">Change map styles while the location layers on the map.</string>
-  <string name="description_location_manual_update">Toggle the user location manual mode on and off.</string>
-  <string name="description_compass_listener">Add a compass listener to know when heading changes or when the accuracy dropsx</string>
-  <string name="description_geojson">Load GeoJson file from assets, path or url to the Mapbox.</string>
-  <string name="description_cluster">Add marker clustering to a Mapbox map.</string>
-  <string name="description_autocomplete">Launch the autocomplete activity.</string>
-  <string name="description_offline_plugin">Use a form to create an offline region.</string>
-  <string name="description_offline_regions">List all offline regions.</string>
+    <!-- Descriptions -->
+    <string name="description_traffic">Add Traffic layers to any Mapbox basemap.</string>
+    <string name="description_building">Add 3D Building layer to a Mapbox map.</string>
+    <string name="description_location_modes">Switch between the different location modes.</string>
+    <string name="description_location_map_change">Change map styles while the location layers on the map.</string>
+    <string name="description_location_manual_update">Toggle the user location manual mode on and off.</string>
+    <string name="description_compass_listener">Add a compass listener to know when heading changes or when the accuracy dropsx</string>
+    <string name="description_geojson">Load GeoJson file from assets, path or url to the Mapbox.</string>
+    <string name="description_cluster">Add marker clustering to a Mapbox map.</string>
+    <string name="description_autocomplete">Launch the autocomplete activity.</string>
+    <string name="description_offline_plugin">Use a form to create an offline region.</string>
+    <string name="description_offline_regions">List all offline regions.</string>
 
-  <!-- Buttons -->
-  <string name="button_location_mode_none">None</string>
-  <string name="button_location_mode_tracking">Tracking</string>
-  <string name="button_location_mode_compass">Compass</string>
-  <string name="button_location_mode_navigation">Nav</string>
+    <!-- Buttons -->
+    <string name="button_location_mode_none">None</string>
+    <string name="button_location_mode_tracking">Tracking</string>
+    <string name="button_location_mode_compass">Compass</string>
+    <string name="button_location_mode_navigation">Nav</string>
+
+    <!-- Random -->
+    <string name="min_zoom_textview">Min zoom: %1$d</string>
+    <string name="max_zoom_textview">Max zoom: %1$d</string>
 </resources>


### PR DESCRIPTION
The offline plugin test app `OfflineDownloadActivity` has seekbars but there's no way to know what the min and max values are. This pr just adds textviews to indicate where the sliders' values are.

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/33571537-2534770a-d8e5-11e7-966a-fcc28c6fc493.gif)
