### PR TITLE
POC nav mode

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
@@ -39,6 +39,7 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
   private LocationEngine locationEngine;
   private MapboxMap mapboxMap;
   private boolean customStyle;
+  private boolean navigationTrackingState;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -57,6 +58,7 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
     if (locationLayerPlugin == null) {
       return;
     }
+    navigationTrackingState = false;
     locationLayerPlugin.setLocationLayerEnabled(LocationLayerMode.NONE);
   }
 
@@ -66,6 +68,7 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
     if (locationLayerPlugin == null) {
       return;
     }
+    navigationTrackingState = false;
     locationLayerPlugin.setLocationLayerEnabled(LocationLayerMode.COMPASS);
   }
 
@@ -75,6 +78,7 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
     if (locationLayerPlugin == null) {
       return;
     }
+    navigationTrackingState =false;
     locationLayerPlugin.setLocationLayerEnabled(LocationLayerMode.TRACKING);
   }
 
@@ -84,7 +88,18 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
     if (locationLayerPlugin == null) {
       return;
     }
+    navigationTrackingState = false;
     locationLayerPlugin.setLocationLayerEnabled(LocationLayerMode.NAVIGATION);
+  }
+
+  @SuppressWarnings( {"MissingPermission"})
+  @OnClick(R.id.button_location_mode_navigation_tracking)
+  public void locationModeNavigationTracking(View view) {
+    if (locationLayerPlugin == null) {
+      return;
+    }
+    navigationTrackingState = true;
+    locationLayerPlugin.setLocationLayerEnabled(LocationLayerMode.NAVIGATION_TRACKING);
   }
 
   @Override
@@ -191,8 +206,10 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
 
   @Override
   public void onLocationChanged(Location location) {
-    mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
-      new LatLng(location.getLatitude(), location.getLongitude()), 16));
+    if(!navigationTrackingState) {
+      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
+        new LatLng(location.getLatitude(), location.getLongitude()), 16));
+    }
   }
 
   @Override

--- a/app/src/main/res/layout/activity_location_layer_mode.xml
+++ b/app/src/main/res/layout/activity_location_layer_mode.xml
@@ -24,7 +24,7 @@
     android:layout_height="wrap_content"
     android:background="@color/colorPrimary"
     android:orientation="horizontal"
-    android:weightSum="4"
+    android:weightSum="5"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintLeft_toLeftOf="parent"
     app:layout_constraintRight_toRightOf="parent"
@@ -66,6 +66,15 @@
       android:layout_height="wrap_content"
       android:layout_weight="1"
       android:text="@string/button_location_mode_navigation"
+      android:textColor="@android:color/white"/>
+
+    <Button
+      android:id="@+id/button_location_mode_navigation_tracking"
+      style="?android:attr/buttonBarButtonStyle"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="1"
+      android:text="@string/button_location_mode_navigation_tracking"
       android:textColor="@android:color/white"/>
 
   </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="button_location_mode_tracking">Tracking</string>
     <string name="button_location_mode_compass">Compass</string>
     <string name="button_location_mode_navigation">Nav</string>
+    <string name="button_location_mode_navigation_tracking">Nav2</string>
 
     <!-- Random -->
     <string name="min_zoom_textview">Min zoom: %1$d</string>

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerMode.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerMode.java
@@ -14,7 +14,7 @@ public class LocationLayerMode {
    *
    * @since 0.1.0
    */
-  @IntDef( {NONE, COMPASS, NAVIGATION, TRACKING})
+  @IntDef( {NONE, COMPASS, NAVIGATION, NAVIGATION_TRACKING, TRACKING})
   @Retention(RetentionPolicy.SOURCE)
   public @interface Mode {
   }
@@ -39,6 +39,13 @@ public class LocationLayerMode {
    * @since 0.1.0
    */
   public static final int NAVIGATION = 0x00000008;
+
+  /**
+   * Tracking the user location in navigation mode.
+   *
+   * @since 0.3.0
+   */
+  public static final int NAVIGATION_TRACKING = 0x00000016;
 
   /**
    * Basic tracking is enabled.

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/NavigationMode.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/NavigationMode.java
@@ -1,0 +1,273 @@
+package com.mapbox.mapboxsdk.plugins.locationlayer;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.TypeEvaluator;
+import android.animation.ValueAnimator;
+import android.graphics.Camera;
+import android.graphics.Matrix;
+import android.graphics.PointF;
+import android.location.Location;
+import android.os.SystemClock;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+
+class NavigationMode {
+
+  private final MapboxMap mapboxMap;
+  private final MapView mapView;
+
+  private ImageView imageView;
+  private boolean tracking;
+
+  private ValueAnimator locationAnimator;
+  private ValueAnimator bearingAnimator;
+  private long locationUpdateTime;
+
+  NavigationMode(MapboxMap mapboxMap, MapView mapView) {
+    this.mapboxMap = mapboxMap;
+    this.mapView = mapView;
+  }
+
+  void startTracking() {
+    if(tracking){
+      return;
+    }
+
+    tracking = true;
+    showLocationPuck();
+    enableFocalPoint();
+    enableTrackCameraChanges();
+  }
+
+  void stopTracking() {
+    if(!tracking){
+      return;
+    }
+
+    tracking = false;
+    hideLocationPuck();
+    disableTrackCameraChanges();
+    disableTrackCameraChanges();
+    resetLocationAnimator();
+    resetBearingAnimator();
+  }
+
+  //
+  // View code
+  //
+
+  private void showLocationPuck() {
+    // add image to map
+    if (imageView == null) {
+      imageView = new ImageView(mapView.getContext());
+      imageView.setImageResource(R.drawable.mapbox_user_puck_icon);
+
+      FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity.CENTER);
+      layoutParams.setMargins(0, mapView.getHeight() / 4, 0, 0);
+      imageView.setLayoutParams(layoutParams);
+      mapView.addView(imageView);
+    } else {
+      imageView.setVisibility(View.VISIBLE);
+    }
+  }
+
+  private void hideLocationPuck() {
+    imageView.setVisibility(View.GONE);
+  }
+
+  //
+  // Focal point
+  //
+
+  private void enableFocalPoint() {
+    float centerWidth = mapboxMap.getWidth() / 2;
+    float centerHeight = mapboxMap.getHeight() / 2;
+    float offset = mapView.getHeight() / 4;
+    mapboxMap.getUiSettings().setFocalPoint(new PointF(centerWidth, centerHeight + offset));
+  }
+
+  private void disableFocalPoint() {
+    mapboxMap.getUiSettings().setFocalPoint(null);
+  }
+
+  //
+  // Camera changes
+  //
+
+  private void enableTrackCameraChanges() {
+    mapboxMap.setOnCameraChangeListener(new CameraInvalidationListener(imageView));
+  }
+
+  private void disableTrackCameraChanges() {
+    mapboxMap.setOnCameraChangeListener(null);
+  }
+
+  //
+  // Location state
+  //
+
+  void onLocationChanged(Location newLocation) {
+    if (tracking) {
+      createLatLngAnimator(getLatLng(), new LatLng(newLocation), calculateAnimationDuration()).start();
+      createBearingAnimator(getBearing(), newLocation.getBearing());
+    }
+  }
+
+  private float getBearing() {
+    float previousHeading;
+    if (bearingAnimator != null) {
+      previousHeading = (Float) bearingAnimator.getAnimatedValue();
+      bearingAnimator.end();
+    } else {
+      previousHeading = (float) mapboxMap.getCameraPosition().bearing;
+    }
+    return previousHeading;
+  }
+
+  private LatLng getLatLng() {
+    LatLng current;
+    if (locationAnimator != null) {
+      current = (LatLng) locationAnimator.getAnimatedValue();
+      locationAnimator.end();
+    } else {
+      current = mapboxMap.getCameraPosition().target;
+    }
+    return current;
+  }
+
+
+  //
+  // Animator code
+  //
+
+  private Animator createLatLngAnimator(LatLng currentPosition, LatLng target, long duration) {
+    locationAnimator = ValueAnimator.ofObject(new LatLngEvaluator(), currentPosition, target);
+    locationAnimator.setDuration(duration);
+    locationAnimator.addUpdateListener(locationUpdateListener);
+    locationAnimator.addListener(locationEndListener);
+    return locationAnimator;
+  }
+
+  private Animator createBearingAnimator(float currentBearing, float targetBearing) {
+    bearingAnimator = ValueAnimator.ofFloat(currentBearing, targetBearing);
+    bearingAnimator.setDuration(450);
+    bearingAnimator.setInterpolator(new FastOutSlowInInterpolator());
+    bearingAnimator.addUpdateListener(bearingUpdateListener);
+    bearingAnimator.addListener(bearingEndListener);
+    return bearingAnimator;
+  }
+
+  private long calculateAnimationDuration() {
+    long locationUpdateTime = SystemClock.elapsedRealtime();
+    long duration = (long) ((locationUpdateTime - this.locationUpdateTime) * 1.1);
+    this.locationUpdateTime = locationUpdateTime;
+    return duration;
+  }
+
+  private void resetLocationAnimator() {
+    if (locationAnimator != null) {
+      locationAnimator.cancel();
+      locationAnimator.removeUpdateListener(locationUpdateListener);
+      locationAnimator.removeListener(locationEndListener);
+      locationAnimator.removeAllListeners();
+      locationAnimator = null;
+    }
+  }
+
+  private void resetBearingAnimator() {
+    if (bearingAnimator != null) {
+      bearingAnimator.cancel();
+      bearingAnimator.removeUpdateListener(locationUpdateListener);
+      bearingAnimator.removeListener(locationEndListener);
+      bearingAnimator.removeAllListeners();
+      bearingAnimator = null;
+    }
+  }
+
+  private ValueAnimator.AnimatorUpdateListener locationUpdateListener = new ValueAnimator.AnimatorUpdateListener() {
+    @Override
+    public void onAnimationUpdate(ValueAnimator animation) {
+      mapboxMap.setLatLng((LatLng) animation.getAnimatedValue());
+    }
+  };
+
+  private ValueAnimator.AnimatorListener locationEndListener = new AnimatorListenerAdapter() {
+    @Override
+    public void onAnimationEnd(Animator animation) {
+      super.onAnimationEnd(animation);
+      resetLocationAnimator();
+    }
+  };
+
+  private ValueAnimator.AnimatorUpdateListener bearingUpdateListener = new ValueAnimator.AnimatorUpdateListener() {
+    @Override
+    public void onAnimationUpdate(ValueAnimator animation) {
+      mapboxMap.setBearing((Float) animation.getAnimatedValue());
+    }
+  };
+
+  private ValueAnimator.AnimatorListener bearingEndListener = new AnimatorListenerAdapter() {
+    @Override
+    public void onAnimationEnd(Animator animation) {
+      super.onAnimationEnd(animation);
+      resetBearingAnimator();
+    }
+  };
+
+  /**
+   * Class that allows to evaluate two LatLng objects for a ValueAnimator
+   */
+  private static class LatLngEvaluator implements TypeEvaluator<LatLng> {
+
+    private final LatLng latLng = new LatLng();
+
+    @Override
+    public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
+      latLng.setLatitude(startValue.getLatitude()
+        + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
+      latLng.setLongitude(startValue.getLongitude()
+        + ((endValue.getLongitude() - startValue.getLongitude()) * fraction));
+      return latLng;
+    }
+  }
+
+  /**
+   * Class that listens to tilt changes and transforms the ImageView
+   */
+  private static class CameraInvalidationListener implements MapboxMap.OnCameraChangeListener {
+
+    private ImageView navigationView;
+    private float currentTilt;
+    private Camera camera = new Camera();
+    private Matrix matrix = new Matrix();
+
+    CameraInvalidationListener(ImageView navigationView) {
+      this.navigationView = navigationView;
+      this.navigationView.setScaleType(ImageView.ScaleType.MATRIX);
+    }
+
+    @Override
+    public void onCameraChange(CameraPosition cameraPosition) {
+      if (cameraPosition.tilt != currentTilt) {
+        currentTilt = (float) cameraPosition.tilt;
+        camera.save();
+        camera.rotate(currentTilt, 0, 0);
+        camera.getMatrix(matrix);
+        camera.restore();
+        navigationView.setImageMatrix(matrix);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR contains a small POC of a third person navigation mode, in this mode we have a fixed ImageView over the map and animate the map underneath. 

This PR tries to showcase:
 -  using a focal point with `MapboxMap#getUiSettings()#setFocalPoint(PointF)`. As a result all gesture interactions will occur around this point instead of the focal point of the gesture itself (eg. center point between two fingers while pinch zooming). The calculation isn't completely correct as it wobbles a bit, and we would need to add scaling to it, but you get the picture.

    -  ![ezgif com-video-to-gif 23](https://user-images.githubusercontent.com/2151639/34267037-aef94c1a-e67b-11e7-9af6-41990a17f8dc.gif)

 - you can listen to camera changes and validate if the tilt of the camera has changed. This allows to provide a hook to transform the location puck. Atm the transformation is incorrect but good enough to showcase it's feasibility.

     -  ![ezgif com-video-to-gif 24](https://user-images.githubusercontent.com/2151639/34267043-b4f135ba-e67b-11e7-83e5-38ce23e1b42f.gif)

  -  all animations in above gifs were done with Android SDK animators, it contains an example how to orchestrate multiple of them together to create an animation set. Atm animation duration is calculated based on the time it took for the previous location update to be triggerred. There will be better ways of getting a more smooth animation. 

cc @mapbox/navigation-android 





