### PR TITLE
Location layer asset update

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -16,7 +16,6 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -16,6 +16,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -169,7 +170,8 @@ final class LocationLayer {
   }
 
   private void addAccuracyLayer() {
-    CircleLayer locationAccuracyLayer = new CircleLayer(ACCURACY_LAYER, LOCATION_SOURCE);
+    CircleLayer locationAccuracyLayer = new CircleLayer(ACCURACY_LAYER, LOCATION_SOURCE)
+      .withProperties(circleRadius(0f));
     addLayerToMap(locationAccuracyLayer, BACKGROUND_LAYER);
   }
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -13,7 +13,6 @@ import android.support.v4.content.ContextCompat;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.style.functions.Function;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.Property;
@@ -38,7 +37,10 @@ import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.LOCATION_SOURCE;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.NAVIGATION_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.PUCK_ICON;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.SHADOW_ICON;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.SHADOW_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.Utils.getBitmapFromDrawable;
+import static com.mapbox.mapboxsdk.style.functions.Function.zoom;
 import static com.mapbox.mapboxsdk.style.functions.stops.Stop.stop;
 import static com.mapbox.mapboxsdk.style.functions.stops.Stops.exponential;
 import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ROTATION_ALIGNMENT_MAP;
@@ -49,10 +51,10 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circlePitchAlignment;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColor;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotate;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotationAlignment;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize;
@@ -75,6 +77,7 @@ final class LocationLayer {
   }
 
   private void addLayers() {
+    addSymbolLayerToMap(SHADOW_LAYER, BACKGROUND_LAYER);
     addSymbolLayerToMap(BACKGROUND_LAYER, FOREGROUND_LAYER);
     addSymbolLayerToMap(FOREGROUND_LAYER, null);
     addSymbolLayerToMap(LocationLayerConstants.BEARING_LAYER, null);
@@ -90,6 +93,8 @@ final class LocationLayer {
     TypedArray typedArray = context.obtainStyledAttributes(styleRes, R.styleable.LocationLayer);
 
     try {
+      styleShadow(ContextCompat.getDrawable(context, R.drawable.mapbox_user_icon_shadow));
+
       int drawableResId = typedArray.getResourceId(R.styleable.LocationLayer_foregroundDrawable, -1);
       styleForeground(ContextCompat.getDrawable(context, drawableResId));
 
@@ -121,6 +126,7 @@ final class LocationLayer {
   //
 
   void setLayersVisibility(boolean visible) {
+    layerMap.get(SHADOW_LAYER).setProperties(visibility(visible ? VISIBLE : NONE));
     layerMap.get(FOREGROUND_LAYER).setProperties(visibility(visible ? VISIBLE : NONE));
     layerMap.get(BACKGROUND_LAYER).setProperties(visibility(visible ? VISIBLE : NONE));
     layerMap.get(BEARING_LAYER).setProperties(visibility(visible ? VISIBLE : NONE));
@@ -149,7 +155,7 @@ final class LocationLayer {
     SymbolLayer navigationLayer = new SymbolLayer(NAVIGATION_LAYER, LOCATION_SOURCE).withProperties(
       iconAllowOverlap(true),
       iconIgnorePlacement(true),
-      iconSize(Function.zoom(
+      iconSize(zoom(
         exponential(
           stop(22f, iconSize(1f)),
           stop(12f, iconSize(1f)),
@@ -208,7 +214,13 @@ final class LocationLayer {
     layer.setProperties(
       iconAllowOverlap(true),
       iconIgnorePlacement(true),
-      iconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP)
+      iconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP),
+      iconSize(zoom(
+        exponential(
+          stop(16f, iconSize(1.2f)),
+          stop(0f, iconSize(1f))
+        )
+      ))
     );
     addLayerToMap(layer, beforeLayerId);
   }
@@ -219,12 +231,20 @@ final class LocationLayer {
 
   private void styleBackground(Drawable backgroundDrawable) {
     mapboxMap.addImage(BACKGROUND_ICON, getBitmapFromDrawable(backgroundDrawable));
-    layerMap.get(BACKGROUND_LAYER).setProperties(iconImage(BACKGROUND_ICON));
+    layerMap.get(BACKGROUND_LAYER).setProperties(
+      iconImage(BACKGROUND_ICON));
+  }
+
+  private void styleShadow(Drawable shadowDrawable) {
+    mapboxMap.addImage(SHADOW_ICON, getBitmapFromDrawable(shadowDrawable));
+    layerMap.get(SHADOW_LAYER).setProperties(
+      iconImage(SHADOW_ICON));
   }
 
   private void styleForeground(Drawable foregroundDrawable) {
     mapboxMap.addImage(LOCATION_ICON, getBitmapFromDrawable(foregroundDrawable));
-    layerMap.get(FOREGROUND_LAYER).setProperties(iconImage(LOCATION_ICON));
+    layerMap.get(FOREGROUND_LAYER).setProperties(
+      iconImage(LOCATION_ICON));
   }
 
   private void styleNavigation(Drawable navigationDrawable) {
@@ -234,7 +254,8 @@ final class LocationLayer {
 
   private void styleBearing(Drawable bearingDrawable) {
     mapboxMap.addImage(BEARING_ICON, getBitmapFromDrawable(bearingDrawable));
-    layerMap.get(BEARING_LAYER).setProperties(iconImage(BEARING_ICON));
+    layerMap.get(BEARING_LAYER).setProperties(
+      iconImage(BEARING_ICON));
   }
 
   private void styleAccuracy(float accuracyAlpha, @ColorInt int accuracyColor) {
@@ -242,9 +263,15 @@ final class LocationLayer {
       circleColor(accuracyColor),
       circleOpacity(accuracyAlpha),
       circlePitchAlignment(Property.CIRCLE_PITCH_ALIGNMENT_MAP),
-      circleStrokeWidth(0.5f),
       circleStrokeColor(accuracyColor)
     );
+  }
+
+  void updateForegroundOffset(double tilt) {
+    layerMap.get(FOREGROUND_LAYER).setProperties(
+      iconOffset(new Float[] {0f, (float) (-0.05 * tilt)}));
+    layerMap.get(SHADOW_LAYER).setProperties(
+      iconOffset(new Float[] {0f, (float) (0.05 * tilt)}));
   }
 
   //

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -44,7 +44,6 @@ import static com.mapbox.mapboxsdk.style.functions.Function.zoom;
 import static com.mapbox.mapboxsdk.style.functions.stops.Stop.stop;
 import static com.mapbox.mapboxsdk.style.functions.stops.Stops.exponential;
 import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ROTATION_ALIGNMENT_MAP;
-import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ROTATION_ALIGNMENT_VIEWPORT;
 import static com.mapbox.mapboxsdk.style.layers.Property.NONE;
 import static com.mapbox.mapboxsdk.style.layers.Property.VISIBLE;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
@@ -55,7 +54,6 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColo
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconKeepUpright;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotate;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotationAlignment;

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -44,6 +44,7 @@ import static com.mapbox.mapboxsdk.style.functions.Function.zoom;
 import static com.mapbox.mapboxsdk.style.functions.stops.Stop.stop;
 import static com.mapbox.mapboxsdk.style.functions.stops.Stops.exponential;
 import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ROTATION_ALIGNMENT_MAP;
+import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ROTATION_ALIGNMENT_VIEWPORT;
 import static com.mapbox.mapboxsdk.style.layers.Property.NONE;
 import static com.mapbox.mapboxsdk.style.layers.Property.VISIBLE;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
@@ -54,6 +55,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColo
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconKeepUpright;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotate;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotationAlignment;
@@ -244,7 +246,8 @@ final class LocationLayer {
   private void styleForeground(Drawable foregroundDrawable) {
     mapboxMap.addImage(LOCATION_ICON, getBitmapFromDrawable(foregroundDrawable));
     layerMap.get(FOREGROUND_LAYER).setProperties(
-      iconImage(LOCATION_ICON));
+      iconImage(LOCATION_ICON),
+      iconRotate(90f));
   }
 
   private void styleNavigation(Drawable navigationDrawable) {
@@ -272,6 +275,11 @@ final class LocationLayer {
       iconOffset(new Float[] {0f, (float) (-0.05 * tilt)}));
     layerMap.get(SHADOW_LAYER).setProperties(
       iconOffset(new Float[] {0f, (float) (0.05 * tilt)}));
+  }
+
+  void updateForegroundBearing(float bearing) {
+    layerMap.get(FOREGROUND_LAYER).setProperties(iconRotate(bearing));
+    layerMap.get(SHADOW_LAYER).setProperties(iconRotate(bearing));
   }
 
   //

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
@@ -21,6 +21,7 @@ final class LocationLayerConstants {
   static final String LOCATION_SOURCE = "mapbox-location-source";
 
   // Layers
+  static final String SHADOW_LAYER = "mapbox-location-shadow";
   static final String FOREGROUND_LAYER = "mapbox-location-layer";
   static final String BACKGROUND_LAYER = "mapbox-location-stroke-layer";
   static final String ACCURACY_LAYER = "mapbox-location-accuracy-layer";
@@ -28,6 +29,7 @@ final class LocationLayerConstants {
   static final String NAVIGATION_LAYER = "mapbox-location-navigation-layer";
 
   // Icons
+  static final String SHADOW_ICON = "mapbox-location-shadow-icon";
   static final String LOCATION_ICON = "mapbox-location-icon";
   static final String BEARING_ICON = "mapbox-location-bearing-icon";
   static final String BACKGROUND_ICON = "mapbox-location-stroke-icon";

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -29,9 +29,13 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.ACCURACY_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.BEARING_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.COMPASS_UPDATE_RATE_MS;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.FOREGROUND_LAYER;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.LOCATION_ICON;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.MAX_ANIMATION_DURATION_MS;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.NAVIGATION_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.Utils.shortestRotation;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
 
 /**
  * The Location layer plugin provides location awareness to your mobile application. Enabling this
@@ -496,6 +500,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
   @Override
   public void onCameraMove() {
     locationLayer.updateAccuracyRadius(location);
+    locationLayer.updateForegroundOffset(mapboxMap.getCameraPosition().tilt);
   }
 
   /**
@@ -539,9 +544,12 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
 
     locationChangeAnimator = ValueAnimator.ofObject(new Utils.PointEvaluator(), currentSourcePoint,
       newPoint);
-    locationChangeAnimator.setDuration(linearAnimation || (location.getSpeed() > 0)
+
+    float speed = location == null ? 0 : location.getSpeed();
+
+    locationChangeAnimator.setDuration(linearAnimation || speed > 0
       ? getLocationUpdateDuration() : LocationLayerConstants.LOCATION_UPDATE_DELAY_MS);
-    if (linearAnimation || location.getSpeed() > 0) {
+    if (linearAnimation || speed > 0) {
       locationChangeAnimator.setInterpolator(new LinearInterpolator());
     } else {
       locationChangeAnimator.setInterpolator(new AccelerateDecelerateInterpolator());

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -138,6 +138,10 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   public void setLocationLayerEnabled(@LocationLayerMode.Mode int locationLayerMode) {
+    // Don't run through enabling layer if the mode is the same as current
+    if (this.locationLayerMode == locationLayerMode) {
+      return;
+    }
     if (locationLayerMode != LocationLayerMode.NONE) {
       locationLayer.setLayersVisibility(true);
 
@@ -162,10 +166,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
         setNavigationEnabled(false);
       }
     } else {
-      // Check that the mode isn't already none
-      if (this.locationLayerMode != LocationLayerMode.NONE) {
-        disableLocationLayerPlugin();
-      }
+      disableLocationLayerPlugin();
     }
     this.locationLayerMode = locationLayerMode;
   }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -14,6 +14,7 @@ import android.support.v7.app.AppCompatDelegate;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.LinearInterpolator;
 
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapView.OnMapChangedListener;
@@ -151,7 +152,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
         locationEngine.addLocationEngineListener(this);
       }
 
-      addCameraListener();
+      toggleCameraListener();
 
       if (locationLayerMode == LocationLayerMode.COMPASS) {
         setLinearAnimation(false);
@@ -377,7 +378,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
     // Currently don't handle this inside SDK
   }
 
-  private void addCameraListener() {
+  private void toggleCameraListener() {
     if (locationLayerMode == LocationLayerMode.NAVIGATION) {
       mapboxMap.removeOnCameraMoveListener(this);
       return;
@@ -503,9 +504,10 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
 
   @Override
   public void onCameraMove() {
+    CameraPosition position = mapboxMap.getCameraPosition();
     locationLayer.updateAccuracyRadius(location);
-    locationLayer.updateForegroundOffset(mapboxMap.getCameraPosition().tilt);
-    locationLayer.updateForegroundBearing((float) mapboxMap.getCameraPosition().bearing);
+    locationLayer.updateForegroundOffset(position.tilt);
+    locationLayer.updateForegroundBearing((float) position.bearing);
   }
 
   /**

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -65,16 +65,15 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
   private int locationLayerMode;
 
   // Previous compass and location values
-  private Location lastLocation;
   private float previousMagneticHeading;
   private Point previousPoint;
+  private Location location;
 
   // Animators
   private ValueAnimator locationChangeAnimator;
   private ValueAnimator bearingChangeAnimator;
 
   private long locationUpdateTimestamp;
-  private Location location;
   private boolean linearAnimation;
 
   private OnLocationLayerClickListener onLocationLayerClickListener;
@@ -421,7 +420,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
    */
   @Nullable
   public Location getLastKnownLocation() {
-    return lastLocation;
+    return location;
   }
 
   /**
@@ -495,6 +494,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
 
   @Override
   public void onCameraMove() {
+    System.out.println(location != null ? location.getAccuracy() : 0);
     locationLayer.updateAccuracyRadius(location);
     locationLayer.updateForegroundOffset(mapboxMap.getCameraPosition().tilt);
     locationLayer.updateForegroundBearing((float) mapboxMap.getCameraPosition().bearing);
@@ -507,7 +507,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
    * @since 0.1.0
    */
   private void setLocation(final Location location) {
-    lastLocation = location;
+    this.location = location;
 
     // Convert the new location to a Point object.
     Point newPoint = Point.fromCoordinates(new double[] {location.getLongitude(),

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -29,13 +29,9 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.ACCURACY_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.BEARING_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.COMPASS_UPDATE_RATE_MS;
-import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.FOREGROUND_LAYER;
-import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.LOCATION_ICON;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.MAX_ANIMATION_DURATION_MS;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.NAVIGATION_LAYER;
 import static com.mapbox.mapboxsdk.plugins.locationlayer.Utils.shortestRotation;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
 
 /**
  * The Location layer plugin provides location awareness to your mobile application. Enabling this
@@ -501,6 +497,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
   public void onCameraMove() {
     locationLayer.updateAccuracyRadius(location);
     locationLayer.updateForegroundOffset(mapboxMap.getCameraPosition().tilt);
+    locationLayer.updateForegroundBearing((float) mapboxMap.getCameraPosition().bearing);
   }
 
   /**

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -147,7 +147,7 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
         locationEngine.addLocationEngineListener(this);
       }
 
-      mapboxMap.addOnCameraMoveListener(this);
+      addCameraListener();
 
       if (locationLayerMode == LocationLayerMode.COMPASS) {
         setLinearAnimation(false);
@@ -376,6 +376,14 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
     // Currently don't handle this inside SDK
   }
 
+  private void addCameraListener() {
+    if (locationLayerMode == LocationLayerMode.NAVIGATION) {
+      mapboxMap.removeOnCameraMoveListener(this);
+      return;
+    }
+    mapboxMap.addOnCameraMoveListener(this);
+  }
+
   private void updateLocation(Location location) {
     this.location = location;
     if (location == null) {
@@ -494,7 +502,6 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
 
   @Override
   public void onCameraMove() {
-    System.out.println(location != null ? location.getAccuracy() : 0);
     locationLayer.updateAccuracyRadius(location);
     locationLayer.updateForegroundOffset(mapboxMap.getCameraPosition().tilt);
     locationLayer.updateForegroundBearing((float) mapboxMap.getCameraPosition().bearing);

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.widget.LinearLayout;
 
 import com.mapbox.services.commons.geojson.Point;
 
@@ -36,7 +37,13 @@ final class Utils {
     if (drawable instanceof BitmapDrawable) {
       return ((BitmapDrawable) drawable).getBitmap();
     } else {
-      Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(),
+      // width and height are equal for all assets since they are ovals.
+      int widthHeight = drawable.getIntrinsicWidth();
+      if (widthHeight == -1) {
+        // if the widthHeight is equal to -1 give it a default value.
+        widthHeight = 115;
+      }
+      Bitmap bitmap = Bitmap.createBitmap(widthHeight, widthHeight,
         Bitmap.Config.ARGB_8888);
       Canvas canvas = new Canvas(bitmap);
       drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.widget.LinearLayout;
 
 import com.mapbox.services.commons.geojson.Point;
 

--- a/plugin-locationlayer/src/main/res/drawable/mapbox_user_bearing_icon.xml
+++ b/plugin-locationlayer/src/main/res/drawable/mapbox_user_bearing_icon.xml
@@ -1,11 +1,10 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="36dp"
-        android:height="36dp"
-        android:viewportWidth="36.0"
-        android:viewportHeight="36.0">
-    <path
-        android:pathData="M18,0L23,7L13,7L18,0ZM22.8,7C21.33,6.36 19.71,6 18,6C16.29,6 14.67,6.36 13.2,7L22.8,7Z"
-        android:strokeColor="#00000000"
-        android:fillColor="#4882C6"
-        android:strokeWidth="1"/>
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="44dp"
+  android:height="44dp"
+  android:viewportHeight="36.0"
+  android:viewportWidth="36.0">
+  <path
+    android:fillColor="@color/mapbox_plugin_location_layer_blue"
+    android:pathData="M18,0L23,7L13,7L18,0ZM22.8,7C21.33,6.36 19.71,6 18,6C16.29,6 14.67,6.36 13.2,7L22.8,7Z"/>
 </vector>

--- a/plugin-locationlayer/src/main/res/drawable/mapbox_user_icon.xml
+++ b/plugin-locationlayer/src/main/res/drawable/mapbox_user_icon.xml
@@ -1,10 +1,10 @@
 <vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="14dp"
-    android:height="14dp"
-    android:viewportHeight="14.0"
-    android:viewportWidth="14.0">
-    <path
-        android:fillColor="#4882C6"
-        android:pathData="M7,7m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"/>
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="14dp"
+  android:height="14dp"
+  android:viewportHeight="14.0"
+  android:viewportWidth="14.0">
+  <path
+    android:fillColor="@color/mapbox_plugin_location_layer_blue"
+    android:pathData="M7,7m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"/>
 </vector>

--- a/plugin-locationlayer/src/main/res/drawable/mapbox_user_icon_shadow.xml
+++ b/plugin-locationlayer/src/main/res/drawable/mapbox_user_icon_shadow.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:opacity="opaque">
+  <item
+    android:gravity="center">
+    <shape
+      android:shape="rectangle">
+      <gradient
+        android:endColor="#00000000"
+        android:gradientRadius="57.5"
+        android:startColor="#59000000"
+        android:type="radial">
+      </gradient>
+    </shape>
+  </item>
+</layer-list>

--- a/plugin-locationlayer/src/main/res/drawable/mapbox_user_puck_icon.xml
+++ b/plugin-locationlayer/src/main/res/drawable/mapbox_user_puck_icon.xml
@@ -1,23 +1,17 @@
 <vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="75dp"
-    android:height="75dp"
-    android:viewportHeight="75.0"
-    android:viewportWidth="75.0">
-    <path
-        android:fillAlpha="0.16"
-        android:fillColor="#263D57"
-        android:pathData="M37.5,37.5m-37.5,0a37.5,37.5 0,1 1,75 0a37.5,37.5 0,1 1,-75 0"
-        android:strokeColor="#00000000"
-        android:strokeWidth="1"/>
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M37.5,37.5m-28.5,0a28.5,28.5 0,1 1,57 0a28.5,28.5 0,1 1,-57 0"
-        android:strokeColor="#00000000"
-        android:strokeWidth="1"/>
-    <path
-        android:fillColor="#4882C6"
-        android:pathData="M39.2,28.46C39.01,27.99 38.54,27.68 38.02,27.69C37.5,27.7 37.02,28.01 36.81,28.49L27.05,45.83C26.83,46.32 26.92,46.89 27.28,47.26C27.65,47.64 28.21,47.75 28.71,47.54L37.07,44.03C37.39,43.89 37.75,43.89 38.06,44.02L46.27,47.34C46.75,47.54 47.33,47.42 47.71,47.03C48.09,46.64 48.21,46.07 48,45.59L39.2,28.46Z"
-        android:strokeColor="#00000000"
-        android:strokeWidth="1"/>
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="75dp"
+  android:height="75dp"
+  android:viewportHeight="75.0"
+  android:viewportWidth="75.0">
+  <path
+    android:fillAlpha="0.16"
+    android:fillColor="#263D57"
+    android:pathData="M37.5,37.5m-37.5,0a37.5,37.5 0,1 1,75 0a37.5,37.5 0,1 1,-75 0"/>
+  <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M37.5,37.5m-28.5,0a28.5,28.5 0,1 1,57 0a28.5,28.5 0,1 1,-57 0"/>
+  <path
+    android:fillColor="@color/mapbox_plugin_location_layer_blue"
+    android:pathData="M39.2,28.46C39.01,27.99 38.54,27.68 38.02,27.69C37.5,27.7 37.02,28.01 36.81,28.49L27.05,45.83C26.83,46.32 26.92,46.89 27.28,47.26C27.65,47.64 28.21,47.75 28.71,47.54L37.07,44.03C37.39,43.89 37.75,43.89 38.06,44.02L46.27,47.34C46.75,47.54 47.33,47.42 47.71,47.03C48.09,46.64 48.21,46.07 48,45.59L39.2,28.46Z"/>
 </vector>

--- a/plugin-locationlayer/src/main/res/drawable/mapbox_user_stroke_icon.xml
+++ b/plugin-locationlayer/src/main/res/drawable/mapbox_user_stroke_icon.xml
@@ -1,10 +1,10 @@
 <vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20dp"
-    android:height="20dp"
-    android:viewportHeight="14.0"
-    android:viewportWidth="14.0">
-    <path
-        android:fillColor="#ffffff"
-        android:pathData="M7,7m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"/>
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="22dp"
+  android:height="22dp"
+  android:viewportHeight="14.0"
+  android:viewportWidth="14.0">
+  <path
+    android:fillColor="#ffffff"
+    android:pathData="M7,7m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"/>
 </vector>

--- a/plugin-locationlayer/src/main/res/values/colors.xml
+++ b/plugin-locationlayer/src/main/res/values/colors.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <color name="mapbox_plugin_location_layer_blue">#4882C6</color>
-    <color name="mapbox_plugin_location_layer_gray">#263D57</color>
+    <color name="mapbox_plugin_location_layer_blue">#4A90E2</color>
 
 </resources>


### PR DESCRIPTION
#This PR optimizes/updates some of the location layer assets. The main difference is now we are adding a more 3D effect to the icons so that the user location pops out more and is easier to find (especially on a white background). 

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/5652865/35117706-77735630-fc5d-11e7-9d72-2deb702538a3.gif)

I've also fixed an issue with the accuracy layer getting initialized with the default radius of 5 and then immediately going back to zero since the `location` variable was null. `lastLocation` variable has been removed since `location` is virtually identical.