### PR TITLE
Cancel animation as part of stopping the animation

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -429,11 +429,13 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
    */
   private void stopAllAnimations() {
     if (locationChangeAnimator != null) {
-      locationChangeAnimator.removeAllUpdateListeners();
+      locationChangeAnimator.removeAllListeners();
+      locationChangeAnimator.cancel();
       locationChangeAnimator = null;
     }
     if (bearingChangeAnimator != null) {
-      bearingChangeAnimator.removeAllUpdateListeners();
+      bearingChangeAnimator.removeAllListeners();
+      bearingChangeAnimator.cancel();
       bearingChangeAnimator = null;
     }
   }


### PR DESCRIPTION
This PR hardens the `LocationLayerPlugin#stopAllAnimations()` integration by cancelling the animation and removing all listeners (not only the update listeners).