### PR TITLE
bumped maps sdk to 5.3.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '5.3.0',
+      mapboxMapSdk       : '5.3.2',
       mapboxGeocoding    : '3.0.0-SNAPSHOT', // TODO SNAPSHOT used since several fixes have been made since last beta release
       mapboxGeoJson      : '3.0.0-beta.1',
       mapboxServices     : '2.2.9',


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/252 by bumping the test app's maps sdk dependency to 5.3.2