### PR TITLE
Changing LocationEngine (#292)

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -249,12 +249,14 @@ public final class LocationLayerPlugin implements LocationEngineListener, Compas
    */
   @SuppressWarnings( {"MissingPermission"})
   public void setLocationEngine(@Nullable LocationEngine locationEngine) {
+    if (this.locationEngine != null) {
+      this.locationEngine.removeLocationEngineListener(this);
+      this.locationEngine = null;
+    }
+    
     if (locationEngine != null) {
       this.locationEngine = locationEngine;
       setLocationLayerEnabled(locationLayerMode);
-    } else if (this.locationEngine != null) {
-      this.locationEngine.removeLocationEngineListener(this);
-      this.locationEngine = null;
     }
   }
 


### PR DESCRIPTION
When replacing the Location from LocationLayerPlugin, the LocationLayerPlugin was still listening the previous LocationEngine. I also remove first, then set the new one in `setLocationEngine` method.