### PR TITLE
compile to implementation in plugins' readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.mapbox.mapboxsdk:PLUGIN_NAME:PLUGIN_VERSION_NUMBER'
+  implementation 'com.mapbox.mapboxsdk:PLUGIN_NAME:PLUGIN_VERSION_NUMBER'
 }
 ```
 5. Click the Sync Project with Gradle Files near the toolbar in Studio.

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -16,7 +16,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.1.0'
 }
 ```
 
@@ -33,7 +33,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.2.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-cluster/README.md
+++ b/plugin-cluster/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-cluster-utils:0.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-cluster-utils:0.1.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-	compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-cluster-utils:0.2.0-SNAPSHOT'
+	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-cluster-utils:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-geojson/README.md
+++ b/plugin-geojson/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-geojson:0.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-geojson:0.1.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-geojson:0.2.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-geojson:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -16,7 +16,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.1.0'
 }
 ```
 
@@ -33,7 +33,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-	compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.2.0-SNAPSHOT'
+	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.2.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-traffic/README.md
+++ b/plugin-traffic/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.4.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.4.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
This pr switches all mention of `compile` to `implementation` in the plugins' README files.