### PR TITLE
Gestures logic for camera tracking, new telemetry library

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/FeatureOverviewActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/FeatureOverviewActivity.java
@@ -26,9 +26,9 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
-import com.mapbox.services.android.telemetry.permissions.PermissionsListener;
-import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/CompassListenerActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/CompassListenerActivity.java
@@ -3,17 +3,17 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.location;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.plugins.locationlayer.CompassListener;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
-import com.mapbox.services.android.location.LostLocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngine;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -38,7 +38,7 @@ public class CompassListenerActivity extends AppCompatActivity implements OnMapR
 
   @Override
   public void onMapReady(final MapboxMap mapboxMap) {
-    LocationEngine locationEngine = new LostLocationEngine(this);
+    LocationEngine locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();
     locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap, locationEngine);
     locationLayerPlugin.setRenderMode(RenderMode.COMPASS);
     locationLayerPlugin.addCompassListener(new CompassListener() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerMapChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerMapChangeActivity.java
@@ -6,16 +6,16 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEnginePriority;
+import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.services.android.location.LostLocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -48,11 +48,12 @@ public class LocationLayerMapChangeActivity extends AppCompatActivity implements
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    locationEngine = LostLocationEngine.getLocationEngine(this);
+    locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
     locationEngine.activate();
     locationPlugin = new LocationLayerPlugin(mapView, mapboxMap, locationEngine);
     locationPlugin.setRenderMode(RenderMode.COMPASS);
+    getLifecycle().addObserver(locationPlugin);
   }
 
   @OnClick(R.id.fabStyles)

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
@@ -23,7 +23,9 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerOptions;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.OnCameraTrackingChangedListener;
 import com.mapbox.mapboxsdk.plugins.locationlayer.OnLocationLayerClickListener;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
@@ -37,7 +39,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 public class LocationLayerModesActivity extends AppCompatActivity implements OnMapReadyCallback,
-  LocationEngineListener, OnLocationLayerClickListener {
+  LocationEngineListener, OnLocationLayerClickListener, OnCameraTrackingChangedListener {
 
   @BindView(R.id.map_view)
   MapView mapView;
@@ -90,8 +92,12 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
     locationEngine.addLocationEngineListener(this);
     locationEngine.activate();
-    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap, locationEngine);
+    LocationLayerOptions options = LocationLayerOptions.builder(this)
+      .padding(new int[] {0, 650, 0, 0})
+      .build();
+    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap, locationEngine, options);
     locationLayerPlugin.addOnLocationClickListener(this);
+    locationLayerPlugin.addOnCameraTrackingChangedListener(this);
     getLifecycle().addObserver(locationLayerPlugin);
   }
 
@@ -259,5 +265,15 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
       listPopup.dismiss();
     });
     listPopup.show();
+  }
+
+  @Override
+  public void onCameraTrackingDismissed() {
+    locationTrackingBtn.setText("None");
+  }
+
+  @Override
+  public void onCameraTrackingChanged(int currentMode) {
+    // do nothing
   }
 }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
@@ -14,20 +14,20 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineListener;
+import com.mapbox.android.core.location.LocationEnginePriority;
+import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.OnLocationLayerClickListener;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
-import com.mapbox.services.android.location.LostLocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngineListener;
-import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,7 +86,7 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    locationEngine = new LostLocationEngine(this);
+    locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
     locationEngine.addLocationEngineListener(this);
     locationEngine.activate();

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/ManualLocationUpdatesActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/ManualLocationUpdatesActivity.java
@@ -7,17 +7,17 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineListener;
+import com.mapbox.android.core.location.LocationEnginePriority;
+import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.services.android.telemetry.location.LocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngineListener;
-import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
-import com.mapbox.services.android.telemetry.location.LostLocationEngine;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -66,7 +66,7 @@ public class ManualLocationUpdatesActivity extends AppCompatActivity implements 
   @SuppressWarnings( {"MissingPermission"})
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    locationEngine = new LostLocationEngine(this);
+    locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();
     locationEngine.addLocationEngineListener(this);
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
     locationEngine.activate();

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '5.4.0',
+      mapboxMapSdk       : '6.0.0-20180227.174508-171',
       mapboxGeocoding    : '3.0.0-beta.2',
       mapboxGeoJson      : '3.0.0-beta.2',
       mapboxServices     : '2.2.9',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.0.0-20180227.174508-171',
+      mapboxMapSdk       : '6.0.0-20180301.094208-178',
       mapboxGeocoding    : '3.0.0-beta.2',
       mapboxGeoJson      : '3.0.0-beta.2',
       mapboxServices     : '2.2.9',

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -78,11 +78,11 @@ final class LocationLayer implements LocationLayerAnimator.OnAnimationsValuesCha
   LocationLayer(MapView mapView, MapboxMap mapboxMap, LocationLayerOptions options) {
     this.mapboxMap = mapboxMap;
     this.context = mapView.getContext();
-    initializeComponents();
+    initializeComponents(options);
     setRenderMode(RenderMode.NORMAL);
   }
 
-  void initializeComponents() {
+  void initializeComponents(LocationLayerOptions options) {
     addLocationSource();
     addLayers();
     applyStyle(options);

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -9,6 +9,9 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -19,9 +22,6 @@ import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-import com.mapbox.services.commons.geojson.Feature;
-import com.mapbox.services.commons.geojson.FeatureCollection;
-import com.mapbox.services.commons.geojson.Point;
 
 import java.util.HashMap;
 import java.util.List;
@@ -320,7 +320,7 @@ final class LocationLayer implements LocationLayerAnimator.OnAnimationsValuesCha
 
   @Override
   public void onNewLatLngValue(LatLng latLng) {
-    Point point = Point.fromCoordinates(new double[] {latLng.getLongitude(), latLng.getLatitude()});
+    Point point = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
     setLocationPoint(point);
   }
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.locationlayer;
 
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
@@ -25,11 +26,11 @@ public class LocationLayerCamera implements LocationLayerAnimator.OnAnimationsVa
   }
 
   private void setBearing(float bearing) {
-    mapboxMap.setBearing(bearing);
+    mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(bearing));
   }
 
   private void setLatLng(LatLng latLng) {
-    mapboxMap.setLatLng(latLng);
+    mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(latLng));
   }
 
   @Override
@@ -62,8 +63,3 @@ public class LocationLayerCamera implements LocationLayerAnimator.OnAnimationsVa
     }
   }
 }
-
-
-/*
-
-  float targetBearing = Utils.shortestRotation(0, (float) bearing);*/

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
@@ -1,27 +1,52 @@
 package com.mapbox.mapboxsdk.plugins.locationlayer;
 
+import android.graphics.PointF;
+
+import com.mapbox.android.gestures.MoveGestureDetector;
+import com.mapbox.android.gestures.RotateGestureDetector;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
 
-public class LocationLayerCamera implements LocationLayerAnimator.OnAnimationsValuesChangeListener {
+final class LocationLayerCamera implements LocationLayerAnimator.OnAnimationsValuesChangeListener {
 
   @CameraMode.Mode
   private int cameraMode;
 
-  private MapboxMap mapboxMap;
+  private final MapboxMap mapboxMap;
+  private final OnCameraTrackingChangedListener internalCameraTrackingChangedListener;
+  private LocationLayerOptions options;
+  private boolean adjustFocalPoint;
 
-  public LocationLayerCamera(MapboxMap mapboxMap) {
+  private final MoveGestureDetector moveGestureDetector;
+
+  LocationLayerCamera(
+    MapboxMap mapboxMap,
+    OnCameraTrackingChangedListener internalCameraTrackingChangedListener,
+    LocationLayerOptions options) {
     this.mapboxMap = mapboxMap;
+    this.internalCameraTrackingChangedListener = internalCameraTrackingChangedListener;
+    initializeOptions(options);
+
+    moveGestureDetector = mapboxMap.getGesturesManager().getMoveGestureDetector();
+    mapboxMap.addOnMoveListener(onMoveListener);
+    mapboxMap.addOnRotateListener(onRotateListener);
   }
 
-  public void setCameraMode(@CameraMode.Mode int cameraMode) {
+  void initializeOptions(LocationLayerOptions options) {
+    this.options = options;
+  }
+
+  void setCameraMode(@CameraMode.Mode int cameraMode) {
+    boolean wasTracking = isLocationTracking();
     this.cameraMode = cameraMode;
     mapboxMap.cancelTransitions();
+    adjustGesturesThresholds();
+    notifyCameraTrackingChangeListener(wasTracking);
   }
 
-  public int getCameraMode() {
+  int getCameraMode() {
     return cameraMode;
   }
 
@@ -40,6 +65,12 @@ public class LocationLayerCamera implements LocationLayerAnimator.OnAnimationsVa
       || cameraMode == CameraMode.TRACKING_GPS
       || cameraMode == CameraMode.TRACKING_GPS_NORTH) {
       setLatLng(latLng);
+    }
+
+    if (adjustFocalPoint) {
+      PointF focalPoint = mapboxMap.getProjection().toScreenLocation(latLng);
+      mapboxMap.getUiSettings().setFocalPoint(focalPoint);
+      adjustFocalPoint = false;
     }
   }
 
@@ -62,4 +93,88 @@ public class LocationLayerCamera implements LocationLayerAnimator.OnAnimationsVa
       setBearing(compassBearing);
     }
   }
+
+  private void adjustGesturesThresholds() {
+    if (isLocationTracking()) {
+      adjustFocalPoint = true;
+      moveGestureDetector.setMoveThreshold(options.trackingInitialMoveThreshold());
+    }
+  }
+
+  private boolean isLocationTracking() {
+    return cameraMode == CameraMode.TRACKING
+      || cameraMode == CameraMode.TRACKING_COMPASS
+      || cameraMode == CameraMode.TRACKING_GPS
+      || cameraMode == CameraMode.TRACKING_GPS_NORTH;
+  }
+
+  private boolean isBearingTracking() {
+    return cameraMode == CameraMode.NONE_COMPASS
+      || cameraMode == CameraMode.TRACKING_COMPASS
+      || cameraMode == CameraMode.NONE_GPS
+      || cameraMode == CameraMode.TRACKING_GPS
+      || cameraMode == CameraMode.TRACKING_GPS_NORTH;
+  }
+
+  private void notifyCameraTrackingChangeListener(boolean wasTracking) {
+    internalCameraTrackingChangedListener.onCameraTrackingChanged(cameraMode);
+    if (wasTracking && !isLocationTracking()) {
+      mapboxMap.getUiSettings().setFocalPoint(null);
+      moveGestureDetector.setMoveThreshold(moveGestureDetector.getDefaultMoveThreshold());
+      internalCameraTrackingChangedListener.onCameraTrackingDismissed();
+    }
+  }
+
+  private MapboxMap.OnMoveListener onMoveListener = new MapboxMap.OnMoveListener() {
+    private boolean interrupt;
+
+    @Override
+    public void onMoveBegin(MoveGestureDetector detector) {
+      if (detector.getPointersCount() > 1
+        && detector.getMoveThreshold() != options.trackingMultiFingerMoveThreshold()
+        && isLocationTracking()) {
+        detector.setMoveThreshold(options.trackingMultiFingerMoveThreshold());
+        interrupt = true;
+      }
+    }
+
+    @Override
+    public void onMove(MoveGestureDetector detector) {
+      if (interrupt) {
+        detector.interrupt();
+        return;
+      }
+
+      if (isLocationTracking()) {
+        setCameraMode(CameraMode.NONE);
+      }
+    }
+
+    @Override
+    public void onMoveEnd(MoveGestureDetector detector) {
+      if (!interrupt && isLocationTracking()) {
+        moveGestureDetector.setMoveThreshold(options.trackingInitialMoveThreshold());
+      }
+      interrupt = false;
+    }
+  };
+
+  private MapboxMap.OnRotateListener onRotateListener = new MapboxMap.OnRotateListener() {
+    @Override
+    public void onRotateBegin(RotateGestureDetector detector) {
+      if (isBearingTracking()) {
+        setCameraMode(CameraMode.NONE);
+      }
+    }
+
+    @Override
+    public void onRotate(RotateGestureDetector detector) {
+      // no implementation
+    }
+
+    @Override
+    public void onRotateEnd(RotateGestureDetector detector) {
+      // no implementation
+    }
+  };
 }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptions.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptions.java
@@ -129,6 +129,15 @@ public abstract class LocationLayerOptions implements Parcelable {
       R.styleable.LocationLayer_accuracyAlpha, ACCURACY_ALPHA_DEFAULT));
     builder.elevation(elevation);
 
+    float defaultTrackingInitialMoveThreshold =
+      context.getResources().getDimension(R.dimen.mapbox_locationLayerTrackingInitialMoveThreshold);
+
+    float defaultTrackingMultiFingerMoveThreshold =
+      context.getResources().getDimension(R.dimen.mapbox_locationLayerTrackingMultiFingerMoveThreshold);
+
+    builder.trackingInitialMoveThreshold(defaultTrackingInitialMoveThreshold);
+    builder.trackingMultiFingerMoveThreshold(defaultTrackingMultiFingerMoveThreshold);
+
     typedArray.recycle();
 
     return builder.build();
@@ -372,6 +381,22 @@ public abstract class LocationLayerOptions implements Parcelable {
   public abstract double minZoom();
 
   /**
+   * Minimum single pointer movement in pixels required to break camera tracking.
+   *
+   * @return the minimum movement
+   * @since 0.5.0
+   */
+  public abstract float trackingInitialMoveThreshold();
+
+  /**
+   * Minimum multi pointer movement in pixels required to break camera tracking (for example during scale gesture).
+   *
+   * @return the minimum movement
+   * @since 0.5.0
+   */
+  public abstract float trackingMultiFingerMoveThreshold();
+
+  /**
    * Builder class for constructing a new instance of {@link LocationLayerOptions}.
    *
    * @since 0.4.0
@@ -578,6 +603,23 @@ public abstract class LocationLayerOptions implements Parcelable {
      * @param minZoom The new minimum zoom level.
      */
     public abstract Builder minZoom(double minZoom);
+
+    /**
+     * Sets minimum single pointer movement (map pan) in pixels required to break camera tracking.
+     *
+     * @param moveThreshold the minimum movement
+     * @since 0.5.0
+     */
+    public abstract Builder trackingInitialMoveThreshold(float moveThreshold);
+
+    /**
+     * Sets minimum multi pointer movement (map pan) in pixels required to break camera tracking
+     * (for example during scale gesture).
+     *
+     * @param moveThreshold the minimum movement
+     * @since 0.5.0
+     */
+    public abstract Builder trackingMultiFingerMoveThreshold(float moveThreshold);
 
     abstract LocationLayerOptions autoBuild();
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -228,11 +228,13 @@ public final class LocationLayerPlugin implements LifecycleObserver {
    * @since 0.4.0
    */
   public void applyStyle(LocationLayerOptions options) {
+    this.options = options;
     locationLayer.applyStyle(options);
     if (!options.enableStaleState()) {
       staleStateManager.onStop();
     }
     staleStateManager.setDelayTime(options.staleStateTimeout());
+    updateMapWithOptions(options);
   }
 
   /**
@@ -600,7 +602,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
       if (change == MapView.WILL_START_LOADING_MAP) {
         onStop();
       } else if (change == MapView.DID_FINISH_LOADING_STYLE) {
-        locationLayer.initializeComponents();
+        locationLayer.initializeComponents(options);
         setRenderMode(locationLayer.getRenderMode());
         onStart();
       }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -11,6 +11,8 @@ import android.support.annotation.RequiresPermission;
 import android.support.annotation.StyleRes;
 import android.support.v7.app.AppCompatDelegate;
 
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineListener;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -20,8 +22,6 @@ import com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener;
 import com.mapbox.mapboxsdk.maps.MapboxMap.OnMapClickListener;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
-import com.mapbox.services.android.telemetry.location.LocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -46,7 +46,7 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
  * to disable the Location Layer but keep the instance around till the activity is destroyed.
  * <p>
  * Using this plugin requires you to request permission beforehand manually or using
- * {@link com.mapbox.services.android.telemetry.permissions.PermissionsManager}. Either
+ * {@link com.mapbox.android.core.permissions.PermissionsManager}. Either
  * {@code ACCESS_COARSE_LOCATION} or {@code ACCESS_FINE_LOCATION} permissions can be requested and
  * this plugin work as expected.
  *

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/OnCameraTrackingChangedListener.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/OnCameraTrackingChangedListener.java
@@ -1,0 +1,21 @@
+package com.mapbox.mapboxsdk.plugins.locationlayer;
+
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
+
+/**
+ * Listener that gets invoked when camera tracking state changes.
+ */
+public interface OnCameraTrackingChangedListener {
+  /**
+   * Invoked whenever camera tracking is broken.
+   * This callback gets invoked just after {@link #onCameraTrackingChanged(int)}, if needed.
+   */
+  void onCameraTrackingDismissed();
+
+  /**
+   * Invoked on every {@link CameraMode} change.
+   *
+   * @param currentMode current active {@link CameraMode}.
+   */
+  void onCameraTrackingChanged(@CameraMode.Mode int currentMode);
+}

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.locationlayer;
 
-import android.animation.TypeEvaluator;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -12,8 +11,6 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
-
-import com.mapbox.services.commons.geojson.Point;
 
 public final class Utils {
 
@@ -76,24 +73,6 @@ public final class Utils {
       drawable.mutate().setColorFilter(tintColor, PorterDuff.Mode.SRC_IN);
     }
     return drawable;
-  }
-
-  /**
-   * Used for animating the user location icon
-   *
-   * @since 0.1.0
-   */
-  static class PointEvaluator implements TypeEvaluator<Point> {
-    // Method is used to interpolate the user icon animation.
-    @Override
-    public Point evaluate(float fraction, Point startValue, Point endValue) {
-      return Point.fromCoordinates(new double[] {
-        startValue.getCoordinates().getLongitude() + (
-          (endValue.getCoordinates().getLongitude() - startValue.getCoordinates().getLongitude()) * fraction),
-        startValue.getCoordinates().getLatitude() + (
-          (endValue.getCoordinates().getLatitude() - startValue.getCoordinates().getLatitude()) * fraction)
-      });
-    }
   }
 
   /**

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/camera/MapAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/camera/MapAnimator.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.locationlayer.Utils;
@@ -80,7 +81,7 @@ public class MapAnimator {
       latLngAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
         @Override
         public void onAnimationUpdate(ValueAnimator animation) {
-          mapboxMap.setLatLng((LatLng) animation.getAnimatedValue());
+          mapboxMap.moveCamera(CameraUpdateFactory.newLatLng((LatLng) animation.getAnimatedValue()));
         }
       });
 
@@ -99,7 +100,7 @@ public class MapAnimator {
       zoomAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
         @Override
         public void onAnimationUpdate(ValueAnimator animation) {
-          mapboxMap.setZoom((Float) animation.getAnimatedValue());
+          mapboxMap.moveCamera(CameraUpdateFactory.zoomTo((Float) animation.getAnimatedValue()));
         }
       });
 
@@ -119,7 +120,7 @@ public class MapAnimator {
       bearingAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
         @Override
         public void onAnimationUpdate(ValueAnimator animation) {
-          mapboxMap.setBearing((Float) animation.getAnimatedValue());
+          mapboxMap.moveCamera(CameraUpdateFactory.bearingTo((Float) animation.getAnimatedValue()));
         }
       });
 
@@ -138,14 +139,13 @@ public class MapAnimator {
       tiltAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
         @Override
         public void onAnimationUpdate(ValueAnimator animation) {
-          mapboxMap.setTilt((Float) animation.getAnimatedValue());
+          mapboxMap.moveCamera(CameraUpdateFactory.tiltTo((Float) animation.getAnimatedValue()));
         }
       });
 
       animators.add(tiltAnimator);
       return this;
     }
-
 
 
     public MapAnimator build() {

--- a/plugin-locationlayer/src/main/res/values/dimens.xml
+++ b/plugin-locationlayer/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="mapbox_locationLayerTrackingInitialMoveThreshold">50dp</dimen>
+    <dimen name="mapbox_locationLayerTrackingMultiFingerMoveThreshold">100dp</dimen>
+</resources>

--- a/plugin-locationlayer/src/test/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptionsTest.java
+++ b/plugin-locationlayer/src/test/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptionsTest.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.locationlayer;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
 
 import org.junit.Before;
@@ -21,6 +22,8 @@ public class LocationLayerOptionsTest {
   private Context context;
   @Mock
   private TypedArray array;
+  @Mock
+  private Resources resources;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -31,6 +34,7 @@ public class LocationLayerOptionsTest {
       .thenReturn(array);
     when(array.getResourceId(R.styleable.LocationLayer_foregroundDrawable, -1))
       .thenReturn(R.drawable.mapbox_user_icon);
+    when(context.getResources()).thenReturn(resources);
   }
 
   @Test


### PR DESCRIPTION
This PR adds gestures logic on top of camera tracking alongside with the fixes of breaking changes introduced with new telemetry library within the Maps SDK.

Camera mode will be reverted back to `CameraMode.None` whenever movement threshold (of single or multi pointers is exceeded). Both of those values are settable through `LocationLayerOptions`.

Additionally, whenever the camera is in any of the tracking modes the focal point of all gestures will be located close to the user location on the map.

Currently in use is `SNAPSHOT` of the Maps SDK that includes new gestures implementation. We will need to change it to the `6.0.0-beta.3` before `0.5.0-beta` release of the plugin.

/cc @cammace @Guardiola31337 