### PR TITLE
Added demo app localization plugin link to readme

### DIFF
--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -46,7 +46,6 @@ dependencies {
 
 - [In the Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/master/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
 
-
 ## Help and Usage
 
 This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -44,6 +44,8 @@ dependencies {
 
 - [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/LocalizationActivity.java)
 
+- [In the Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/master/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
+
 
 ## Help and Usage
 


### PR DESCRIPTION
Localization plugin example was added to the demo app, so this pr adds a link in the localization plugin's README file