### PR TITLE
Disable leak canary when test are running

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,19 @@ android {
   }
 }
 
+// Disable Leak Canary for UI and unit test.
+configurations.all { config ->
+  if (config.name.contains('UnitTest') || config.name.contains('AndroidTest')) {
+    config.resolutionStrategy.eachDependency { details ->
+      if (details.requested.group == 'com.squareup.leakcanary'
+          && details.requested.name == 'leakcanary-android') {
+        details.useTarget(group: details.requested.group, name: 'leakcanary-android-no-op',
+            version: details.requested.version)
+      }
+    }
+  }
+}
+
 dependencies {
   // Mapbox
   implementation dependenciesList.mapboxMapSdk


### PR DESCRIPTION
Occasionally, leak canary can disrupt our testing. This PR adds configuration to disable leak canary when these tests are running. This comes from the [Leak Canary readme document](https://github.com/square/leakcanary)