### PR TITLE
Add consumer proguard rules to all plugins

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
       testCoverageEnabled true
     }
     release {
-      minifyEnabled false
+      minifyEnabled true
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Mapbox Plugin testapp ProGuard rules.
+
+-keep class com.google.**
+-dontwarn com.google.**

--- a/circle.yml
+++ b/circle.yml
@@ -41,6 +41,9 @@ jobs:
             ./gradlew accessToken
             ./gradlew app:assembleDebug
       - run:
+          name: Build release to test ProGuard rules
+          command: ./gradlew app:assembleRelease
+      - run:
           name: Log in to Google Cloud Platform
           shell: /bin/bash -euo pipefail
           command: |

--- a/plugin-geojson/build.gradle
+++ b/plugin-geojson/build.gradle
@@ -8,6 +8,8 @@ android {
     minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+    consumerProguardFiles 'proguard-consumer.pro'
   }
 
   configurations {

--- a/plugin-geojson/proguard-consumer.pro
+++ b/plugin-geojson/proguard-consumer.pro
@@ -1,0 +1,26 @@
+# Consumer proguard rules for GeoJson plugin
+
+# --- AutoValue ---
+# AutoValue annotations are retained but dependency is compileOnly.
+-dontwarn com.google.auto.value.AutoValue
+
+# --- Retrofit ---
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain service method parameters.
+-keepclassmembernames,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# --- Java ---
+-dontwarn java.awt.Color

--- a/plugin-locationlayer/build.gradle
+++ b/plugin-locationlayer/build.gradle
@@ -9,6 +9,8 @@ android {
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true
+
+    consumerProguardFiles 'proguard-consumer.pro'
   }
 
   configurations {

--- a/plugin-locationlayer/proguard-consumer.pro
+++ b/plugin-locationlayer/proguard-consumer.pro
@@ -1,0 +1,26 @@
+# Consumer proguard rules for LocationLayer plugin
+
+# --- AutoValue ---
+# AutoValue annotations are retained but dependency is compileOnly.
+-dontwarn com.google.auto.value.AutoValue
+
+# --- Retrofit ---
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain service method parameters.
+-keepclassmembernames,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# --- Java ---
+-dontwarn java.awt.Color

--- a/plugin-offline/build.gradle
+++ b/plugin-offline/build.gradle
@@ -8,6 +8,7 @@ android {
     minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     vectorDrawables.useSupportLibrary = true
+    consumerProguardFiles 'proguard-consumer.pro'
   }
   buildTypes {
     release {

--- a/plugin-offline/proguard-consumer.pro
+++ b/plugin-offline/proguard-consumer.pro
@@ -1,0 +1,26 @@
+# Consumer proguard rules for Offline plugin
+
+# --- AutoValue ---
+# AutoValue annotations are retained but dependency is compileOnly.
+-dontwarn com.google.auto.value.AutoValue
+
+# --- Retrofit ---
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain service method parameters.
+-keepclassmembernames,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# --- Java ---
+-dontwarn java.awt.Color

--- a/plugin-places/build.gradle
+++ b/plugin-places/build.gradle
@@ -9,6 +9,8 @@ android {
     targetSdkVersion androidVersions.targetSdkVersion
     vectorDrawables.useSupportLibrary = true
 
+    consumerProguardFiles 'proguard-consumer.pro'
+
     // Write out the current schema of Room
     javaCompileOptions {
       annotationProcessorOptions {

--- a/plugin-places/proguard-consumer.pro
+++ b/plugin-places/proguard-consumer.pro
@@ -1,0 +1,26 @@
+# Consumer proguard rules for Places plugin
+
+# --- AutoValue ---
+# AutoValue annotations are retained but dependency is compileOnly.
+-dontwarn com.google.auto.value.AutoValue
+
+# --- Retrofit ---
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain service method parameters.
+-keepclassmembernames,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# --- Java ---
+-dontwarn java.awt.Color


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/369


Adds proguard rules for plugins, as well as, adds a step to the CI build to attempt to check if proguard rules work.