### PR TITLE
Bumped maps sdk to 5.5.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '5.5.0',
+      mapboxMapSdk       : '5.5.1',
       mapboxGeocoding    : '3.0.0-beta.3',
       mapboxGeoJson      : '3.0.0-beta.3',
       mapboxServices     : '2.2.9',


### PR DESCRIPTION
Part of the Mapbox Maps SDK for Android 5.5.1 release: mapbox/mapbox-gl-native#11525 (comment)

