### PR TITLE
Fix order of interpolator expression

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -167,10 +167,10 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
       iconIgnorePlacement(true),
       iconSize(
         interpolate(exponential(1f), zoom(),
-          stop(22f, 1f),
-          stop(12f, 1f),
+          stop(0f, 0.6f),
           stop(10f, 0.6f),
-          stop(0f, 0.6f)
+          stop(12f, 1f),
+          stop(22f, 1f)
         )
       ),
       iconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP));

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -168,9 +168,7 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
       iconSize(
         interpolate(exponential(1f), zoom(),
           stop(0f, 0.6f),
-          stop(10f, 0.6f),
-          stop(12f, 1f),
-          stop(22f, 1f)
+          stop(18f, 1.2f)
         )
       ),
       iconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP));


### PR DESCRIPTION
This PR fixes the issue of:

>  E/mbgl: {plugins.testapp}[JNI]: Error setting property: icon-size [5]: Input/output pairs for “interpolate” expressions must be arranged with input values in strictly ascending order.

