### PR TITLE
Adds text under location icon

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,8 +71,8 @@ dependencies {
   implementation dependenciesList.roomRuntime
   annotationProcessor dependenciesList.roomCompiler
 
-  // LOST
-  implementation dependenciesList.lost
+  // Google Play Location
+  implementation dependenciesList.playLocation
 
   // Support libraries
   implementation dependenciesList.supportAnnotation

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.0.0-beta.5',
       mapboxGeocoding    : '3.0.0-beta.4',
       mapboxGeoJson      : '3.0.0-beta.4',
-      lost               : '3.0.4',
+      playLocation       : '11.8.0',
       autoValue          : '1.5.3',
       autoValueParcel    : '0.2.6',
       junit              : '4.12',
@@ -42,8 +42,8 @@ ext {
       mapboxGeoJson          : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxGeoJson}",
       mapboxGeocoding        : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxGeocoding}",
 
-      // Lost
-      lost                   : "com.mapzen.android:lost:${version.lost}",
+      // Google Play Location
+      playLocation           : "com.google.android.gms:play-services-location:${version.playLocation}",
 
       // AutoValue
       autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
@@ -26,6 +26,8 @@ final class LocationLayerConstants {
   static final String BACKGROUND_LAYER = "mapbox-location-stroke-layer";
   static final String ACCURACY_LAYER = "mapbox-location-accuracy-layer";
   static final String BEARING_LAYER = "mapbox-location-bearing-layer";
+  static final String PLACE_TEXT_LAYER = "mapbox-location-place-text-layer";
+  static final String STREET_TEXT_LAYER = "mapbox-location-street-text-layer";
 
   // Icons
   static final String FOREGROUND_ICON = "mapbox-location-icon";

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -239,6 +239,10 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     updateMapWithOptions(options);
   }
 
+  public void setPlaceText(String placeText) {
+    locationLayer.updatePlaceText(placeText);
+  }
+
   /**
    * Sets the distance from the edges of the map view’s frame to the edges of the map
    * view’s logical viewport.


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/5652865/38212004-45fa4584-368a-11e8-91cf-50f037e3e7ee.png" width=360 />

This allows you to place a string text under the location icon. Right now I have the demo querying the map and filtering layer features to only those with names, thus ideally, this will show you the current POI you are at. Still, need to implement navigation version of this that shows current street.

Users can use the `setPlaceText` API to set the string which is displayed.