### PR TITLE
remove support library and use just livedata dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,8 +28,9 @@ ext {
       spoonRunner        : '1.6.2',
       commonsIO          : '2.5',
       robolectric        : '3.6.1',
-      lifecycleCompiler  : '1.0.0',
-      lifecycleExtensions: '1.0.0',
+      lifecycleCompiler  : '1.1.1',
+      lifecycleExtensions: '1.1.1',
+      lifecycleLiveData  : '1.1.1',
       room               : '1.0.0',
       androidArchCore    : '1.0.0',
       okhttp             : '3.9.1',
@@ -69,6 +70,7 @@ ext {
       // architecture
       lifecycleExtensions    : "android.arch.lifecycle:extensions:${version.lifecycleExtensions}",
       lifecycleCompiler      : "android.arch.lifecycle:compiler:${version.lifecycleCompiler}",
+      lifecycleLiveData      : "android.arch.lifecycle:livedata:${version.lifecycleLiveData}",
       roomRuntime            : "android.arch.persistence.room:runtime:${version.room}",
       roomCompiler           : "android.arch.persistence.room:compiler:${version.room}",
 

--- a/plugin-locationlayer/build.gradle
+++ b/plugin-locationlayer/build.gradle
@@ -39,8 +39,7 @@ android {
 }
 
 dependencies {
-  implementation dependenciesList.supportAppcompatV7
-
+  implementation dependenciesList.lifecycleLiveData
   implementation dependenciesList.mapboxMapSdk
 
   // AutoValues


### PR DESCRIPTION
Closes #417 

In the Location Layer Plugin, we were carrying in all of AppCompat7 which wasn't necessary since it was only being used for lifecycle events. Instead, we just need to use the `livedata` dependency offered. This PR fixes this.

@ivovandongen I briefly remember you mentioning you had issues adding the plugin because you also had to add the architecture sdk, would this fix it? At the very least, you won't have to exclude libraries anymore from this plugin.