### PR TITLE
Fix LocationLayerAnimator ignored updates for first second

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
@@ -35,7 +35,7 @@ final class LocationLayerAnimator {
 
   private Location previousLocation;
   private float previousCompassBearing = -1;
-  private long locationUpdateTimestamp;
+  private long locationUpdateTimestamp = -1;
 
   void addLayerListener(OnLayerAnimationsValuesChangeListener listener) {
     layerListeners.add(listener);
@@ -186,7 +186,8 @@ final class LocationLayerAnimator {
   }
 
   private boolean invalidUpdateInterval() {
-    return (SystemClock.elapsedRealtime() - locationUpdateTimestamp) < ONE_SECOND;
+    return locationUpdateTimestamp > 0
+      && (SystemClock.elapsedRealtime() - locationUpdateTimestamp) < ONE_SECOND;
   }
 
   private LatLng getPreviousLayerLatLng() {


### PR DESCRIPTION
We are seeing delays of the LLP drawing the user icon in the Navigation SDK. 

The `LocationLayerAnimator` was ignoring updates for the first second because the `locationUpdateTimeStamp` wasn't being set.  This PR checks for invalid updates only after the first timestamp has been set. 

Regression from #393 

cc @tobrun 