### PR TITLE
use default download icon for notification

### DIFF
--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/NotificationOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/NotificationOptions.java
@@ -30,6 +30,7 @@ public abstract class NotificationOptions implements Parcelable {
 
   public static Builder builder(Context context) {
     return new AutoValue_NotificationOptions.Builder()
+      .smallIconRes(android.R.drawable.stat_sys_download)
       .contentTitle(context.getString(R.string.mapbox_offline_notification_default_content_title))
       .contentText(context.getString(R.string.mapbox_offline_notification_default_content_text));
   }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/283

This uses the default android download icon for the notification icon but still leaves the ability to change the icon to whatever the dev wants if desired.