### PR TITLE
Fix Proguard issues

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,5 @@
 # Mapbox Plugin testapp ProGuard rules.
 
--keep class com.google.**
--dontwarn com.google.**
+# --- GMS ---
+-keep public class com.google.android.gms.* { public *; }
+-dontwarn com.google.android.gms.**

--- a/plugin-geojson/proguard-consumer.pro
+++ b/plugin-geojson/proguard-consumer.pro
@@ -2,7 +2,7 @@
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.
--dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.**
 
 # --- Retrofit ---
 # Retain generic type information for use by reflection by converters and adapters.

--- a/plugin-locationlayer/proguard-consumer.pro
+++ b/plugin-locationlayer/proguard-consumer.pro
@@ -2,7 +2,7 @@
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.
--dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.**
 
 # --- Retrofit ---
 # Retain generic type information for use by reflection by converters and adapters.

--- a/plugin-offline/proguard-consumer.pro
+++ b/plugin-offline/proguard-consumer.pro
@@ -2,7 +2,7 @@
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.
--dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.**
 
 # --- Retrofit ---
 # Retain generic type information for use by reflection by converters and adapters.

--- a/plugin-places/proguard-consumer.pro
+++ b/plugin-places/proguard-consumer.pro
@@ -2,7 +2,7 @@
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.
--dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.**
 
 # --- Retrofit ---
 # Retain generic type information for use by reflection by converters and adapters.


### PR DESCRIPTION
```
Warning: com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerOptions$Builder: can't find referenced class com.google.auto.value.AutoValue$Builder
Warning: com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerOptions$Builder: can't find referenced class com.google.auto.value.AutoValue$Builder
```

- Fixes AutoValue Proguard rules in `geojson`, `locationlayer`, `offline` and `places` plugins so that builds with Proguard enabled don't fail.

The CI Proguard check ([Build release to test ProGuard rules step](https://github.com/mapbox/mapbox-plugins-android/blob/master/circle.yml#L44)) was ✅ because of https://github.com/mapbox/mapbox-plugins-android/blob/7a676e4496b7459c6b40784779dcf83722ed6186/app/proguard-rules.pro#L3-L4 which include AutoValue classes (note that `com.google.auto.value` is included in `com.google.**`).

We were only taking into account `AutoValue` classes and not `AutoValue$Builder` ones 👇 https://github.com/mapbox/mapbox-plugins-android/blob/7a676e4496b7459c6b40784779dcf83722ed6186/plugin-locationlayer/proguard-consumer.pro#L5

We should remove [Mapbox Plugin testapp ProGuard rules](https://github.com/mapbox/mapbox-plugins-android/blob/048f17ed4a08d65b2604d174f8a826fe4a0ab654/app/proguard-rules.pro) after https://github.com/mapbox/mapbox-events-android/pull/109 lands because Proguard rules will be properly managed upstream.

cc @cammace @LukasPaczos @tobrun 
