### PR TITLE
bumped maps sdk to 5.5.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '5.5.0',
+      mapboxMapSdk       : '5.5.2',
       mapboxGeocoding    : '3.0.0-beta.3',
       mapboxGeoJson      : '3.0.0-beta.3',
       mapboxServices     : '2.2.9',


### PR DESCRIPTION
Part of the 5.5.2 release of the Mapbox Maps SDK for Android: https://github.com/mapbox/mapbox-gl-native/issues/11645