### PR TITLE
Initialize in a stale state

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/StaleStateManager.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/StaleStateManager.java
@@ -14,13 +14,14 @@ class StaleStateManager {
 
   private final OnLocationStaleListener innerOnLocationStaleListeners;
   private final Handler handler;
-  private boolean isStale;
+  private boolean isStale = true;
   private long delayTime;
 
   StaleStateManager(OnLocationStaleListener innerListener, long delayTime) {
     innerOnLocationStaleListeners = innerListener;
     this.delayTime = delayTime;
     handler = new Handler();
+    innerOnLocationStaleListeners.onStaleStateChange(true);
   }
 
   private Runnable staleStateRunnable = new Runnable() {


### PR DESCRIPTION
I think it improves UX if we initialize in a stale state and dismiss that with the first location update.