### PR TITLE
Manually set the first location update

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
@@ -53,15 +53,19 @@ final class LocationLayerAnimator {
     cameraListeners.remove(listener);
   }
 
-  void feedNewLocation(@NonNull Location newLocation, @NonNull CameraPosition currentCameraPosition,
-                       boolean isGpsNorth) {
+  /**
+   * Returns whether location has to be updated manually.
+   */
+  boolean feedNewLocation(@NonNull Location newLocation, @NonNull CameraPosition currentCameraPosition,
+                          boolean isGpsNorth) {
     if (previousLocation == null) {
       previousLocation = newLocation;
       locationUpdateTimestamp = SystemClock.elapsedRealtime();
+      return true;
     }
 
     if (invalidUpdateInterval()) {
-      return;
+      return false;
     }
 
     LatLng previousLayerLatLng = getPreviousLayerLatLng();
@@ -80,11 +84,17 @@ final class LocationLayerAnimator {
     playAllLocationAnimators(getAnimationDuration());
 
     previousLocation = newLocation;
+
+    return false;
   }
 
-  void feedNewCompassBearing(float targetCompassBearing, @NonNull CameraPosition currentCameraPosition) {
+  /**
+   * Returns whether compass bearing has to be updated manually.
+   */
+  boolean feedNewCompassBearing(float targetCompassBearing, @NonNull CameraPosition currentCameraPosition) {
     if (previousCompassBearing < 0) {
       previousCompassBearing = targetCompassBearing;
+      return true;
     }
 
     float previousLayerBearing = getPreviousLayerCompassBearing();
@@ -94,6 +104,8 @@ final class LocationLayerAnimator {
     playCompassAnimators(COMPASS_UPDATE_RATE_MS);
 
     previousCompassBearing = targetCompassBearing;
+
+    return false;
   }
 
   private final ValueAnimator.AnimatorUpdateListener layerLatLngUpdateListener =
@@ -251,7 +263,7 @@ final class LocationLayerAnimator {
       animationDuration = 0;
     } else {
       animationDuration = (int) ((locationUpdateTimestamp - previousUpdateTimeStamp) * 1.1f)
-        /*make animation slightly longer*/;
+      /*make animation slightly longer*/;
     }
     return animationDuration;
   }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -505,12 +505,19 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     staleStateManager.updateLatestLocationTime();
     CameraPosition currentCameraPosition = mapboxMap.getCameraPosition();
     boolean isGpsNorth = getCameraMode() == CameraMode.TRACKING_GPS_NORTH;
-    locationLayerAnimator.feedNewLocation(location, currentCameraPosition, isGpsNorth);
+    boolean forceLocationUpdate = locationLayerAnimator.feedNewLocation(location, currentCameraPosition, isGpsNorth);
+    if (forceLocationUpdate) {
+      locationLayer.onNewLatLngValue(new LatLng(location.getLatitude(), location.getLongitude()));
+      locationLayer.onNewGpsBearingValue(location.getBearing());
+    }
     locationLayer.updateAccuracyRadius(location);
   }
 
   private void updateCompassHeading(float heading) {
-    locationLayerAnimator.feedNewCompassBearing(heading, mapboxMap.getCameraPosition());
+    boolean forceCompassUpdate = locationLayerAnimator.feedNewCompassBearing(heading, mapboxMap.getCameraPosition());
+    if (forceCompassUpdate) {
+      locationLayer.onNewCompassBearingValue(heading);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #424.
Animators need two values to start animation and push updates to the `LocationLayer` that's why we need to set the first location sample manually.

/cc @hangduykhiem @danesfeder @langsmith @Guardiola31337