### PR TITLE
Max animation duration when tracking

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.COMPASS_UPDATE_RATE_MS;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.MAX_ANIMATION_DURATION_MS;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.TRANSITION_ANIMATION_DURATION_MS;
 
 final class LocationLayerAnimator {
 
@@ -175,7 +177,7 @@ final class LocationLayerAnimator {
   void resetAllCameraAnimations(CameraPosition currentCameraPosition, boolean isGpsNorth) {
     resetCameraCompassAnimation(currentCameraPosition);
     resetCameraLocationAnimations(currentCameraPosition, isGpsNorth);
-    playCameraAnimators();
+    playCameraAnimators(TRANSITION_ANIMATION_DURATION_MS);
   }
 
   void cancelAllAnimations() {
@@ -223,9 +225,9 @@ final class LocationLayerAnimator {
   private void updateLayerAnimators(LatLng previousLatLng, LatLng targetLatLng,
                                     float previousBearing, float targetBearing) {
     cancelLayerLocationAnimations();
-    layerLatLngAnimator = new LatLngAnimator(previousLatLng, targetLatLng, 1000);
+    layerLatLngAnimator = new LatLngAnimator(previousLatLng, targetLatLng);
     float normalizedLayerBearing = Utils.shortestRotation(targetBearing, previousBearing);
-    layerGpsBearingAnimator = new BearingAnimator(previousBearing, normalizedLayerBearing, 1000);
+    layerGpsBearingAnimator = new BearingAnimator(previousBearing, normalizedLayerBearing);
 
     layerLatLngAnimator.addUpdateListener(layerLatLngUpdateListener);
     layerGpsBearingAnimator.addUpdateListener(layerGpsBearingUpdateListener);
@@ -234,25 +236,28 @@ final class LocationLayerAnimator {
   private void updateCameraAnimators(LatLng previousCameraLatLng, float previousCameraBearing,
                                      LatLng targetLatLng, float targetBearing) {
     cancelCameraLocationAnimations();
-    cameraLatLngAnimator = new LatLngAnimator(previousCameraLatLng, targetLatLng, 1000);
+    cameraLatLngAnimator = new LatLngAnimator(previousCameraLatLng, targetLatLng);
     cameraLatLngAnimator.addUpdateListener(cameraLatLngUpdateListener);
 
     float normalizedCameraBearing = Utils.shortestRotation(targetBearing, previousCameraBearing);
-    cameraGpsBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing, 1000);
+    cameraGpsBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing);
     cameraGpsBearingAnimator.addUpdateListener(cameraGpsBearingUpdateListener);
   }
 
   private long getAnimationDuration() {
-    float previousUpdateTimeStamp = locationUpdateTimestamp;
+    long previousUpdateTimeStamp = locationUpdateTimestamp;
     locationUpdateTimestamp = SystemClock.elapsedRealtime();
 
-    int animationDuration;
+    long animationDuration;
     if (previousUpdateTimeStamp == 0) {
       animationDuration = 0;
     } else {
-      animationDuration = (int) ((locationUpdateTimestamp - previousUpdateTimeStamp) * 1.1f)
-        /*make animation slightly longer*/;
+      animationDuration = (long) ((locationUpdateTimestamp - previousUpdateTimeStamp) * 1.1f)
+      /*make animation slightly longer*/;
     }
+
+    animationDuration = Math.min(animationDuration, MAX_ANIMATION_DURATION_MS);
+
     return animationDuration;
   }
 
@@ -276,13 +281,14 @@ final class LocationLayerAnimator {
     locationAnimatorSet.start();
   }
 
-  private void playCameraAnimators() {
+  private void playCameraAnimators(long duration) {
     List<Animator> locationAnimators = new ArrayList<>();
     locationAnimators.add(cameraLatLngAnimator);
     locationAnimators.add(cameraGpsBearingAnimator);
     AnimatorSet locationAnimatorSet = new AnimatorSet();
     locationAnimatorSet.playTogether(locationAnimators);
     locationAnimatorSet.setInterpolator(new LinearInterpolator());
+    locationAnimatorSet.setDuration(duration);
     locationAnimatorSet.start();
   }
 
@@ -290,12 +296,12 @@ final class LocationLayerAnimator {
                                       float previousCameraBearing) {
     cancelLayerCompassAnimations();
     float normalizedLayerBearing = Utils.shortestRotation(targetCompassBearing, previousLayerBearing);
-    layerCompassBearingAnimator = new BearingAnimator(previousLayerBearing, normalizedLayerBearing, 1000);
+    layerCompassBearingAnimator = new BearingAnimator(previousLayerBearing, normalizedLayerBearing);
     layerCompassBearingAnimator.addUpdateListener(layerCompassBearingUpdateListener);
 
     cancelCameraCompassAnimations();
     float normalizedCameraBearing = Utils.shortestRotation(targetCompassBearing, previousCameraBearing);
-    cameraCompassBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing, 1000);
+    cameraCompassBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing);
     cameraCompassBearingAnimator.addUpdateListener(cameraCompassBearingUpdateListener);
   }
 
@@ -356,11 +362,10 @@ final class LocationLayerAnimator {
     if (cameraLatLngAnimator == null) {
       return;
     }
-    long duration = cameraLatLngAnimator.getDuration();
     cancelCameraLatLngAnimations();
     LatLng currentTarget = cameraLatLngAnimator.getTarget();
     LatLng previousCameraTarget = currentCameraPosition.target;
-    cameraLatLngAnimator = new LatLngAnimator(previousCameraTarget, currentTarget, duration);
+    cameraLatLngAnimator = new LatLngAnimator(previousCameraTarget, currentTarget);
     cameraLatLngAnimator.addUpdateListener(cameraLatLngUpdateListener);
   }
 
@@ -375,13 +380,12 @@ final class LocationLayerAnimator {
     if (cameraGpsBearingAnimator == null) {
       return;
     }
-    long duration = cameraLatLngAnimator.getDuration();
     cancelCameraGpsBearingAnimations();
     float currentTargetBearing = cameraGpsBearingAnimator.getTargetBearing();
     currentTargetBearing = checkGpsNorth(isGpsNorth, currentTargetBearing);
     float previousCameraBearing = (float) currentCameraPosition.bearing;
     float normalizedCameraBearing = Utils.shortestRotation(currentTargetBearing, previousCameraBearing);
-    cameraGpsBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing, duration);
+    cameraGpsBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing);
     cameraGpsBearingAnimator.addUpdateListener(cameraGpsBearingUpdateListener);
   }
 
@@ -396,12 +400,11 @@ final class LocationLayerAnimator {
     if (cameraCompassBearingAnimator == null || cameraLatLngAnimator == null) {
       return;
     }
-    long duration = cameraLatLngAnimator.getDuration();
     cancelCameraCompassAnimations();
     float currentTargetBearing = cameraCompassBearingAnimator.getTargetBearing();
     float previousCameraBearing = (float) currentCameraPosition.bearing;
     float normalizedCameraBearing = Utils.shortestRotation(currentTargetBearing, previousCameraBearing);
-    cameraCompassBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing, duration);
+    cameraCompassBearingAnimator = new BearingAnimator(previousCameraBearing, normalizedCameraBearing);
     cameraCompassBearingAnimator.addUpdateListener(cameraCompassBearingUpdateListener);
   }
 }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
@@ -10,12 +10,11 @@ final class LocationLayerConstants {
   // Controls the compass update rate in milliseconds
   static final int COMPASS_UPDATE_RATE_MS = 500;
 
-  // Sets the animation time when moving the user location icon from the previous location to the
-  // updated. If LinearAnimator's enabled, this values ignored.
-  static final int LOCATION_UPDATE_DELAY_MS = 500;
+  // Sets the transition animation duration when switching camera modes.
+  static final long TRANSITION_ANIMATION_DURATION_MS = 750;
 
-  // Sets the max allowed time for the location icon animation from one latlng to another.
-  static final long MIN_ANIMATION_DURATION_MS = 1500;
+  // Sets the max allowed time for the location icon animation from one LatLng to another.
+  static final long MAX_ANIMATION_DURATION_MS = 2000;
 
   // Sources
   static final String LOCATION_SOURCE = "mapbox-location-source";

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/camera/BearingAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/camera/BearingAnimator.java
@@ -7,8 +7,7 @@ public class BearingAnimator extends ValueAnimator {
 
   private float targetBearing;
 
-  public BearingAnimator(float previous, float target, long duration) {
-    setDuration(duration);
+  public BearingAnimator(float previous, float target) {
     setEvaluator(new FloatEvaluator());
     setFloatValues(previous, target);
     this.targetBearing = target;

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/camera/LatLngAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/camera/LatLngAnimator.java
@@ -10,8 +10,7 @@ public class LatLngAnimator extends ValueAnimator {
 
   private LatLng target;
 
-  public LatLngAnimator(@NonNull LatLng previous, @NonNull LatLng target, long duration) {
-    setDuration(duration);
+  public LatLngAnimator(@NonNull LatLng previous, @NonNull LatLng target) {
     setObjectValues(previous, target);
     setEvaluator(new LatLngEvaluator());
     this.target = target;


### PR DESCRIPTION
Added checks for maximum animation duration time between location samples (2 seconds) as well as fixed animation duration when switching between camera modes (750 ms).

/cc @tobrun @cammace 