### PR TITLE
Remove invalid Location update check

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
@@ -20,8 +20,6 @@ import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.
 
 final class LocationLayerAnimator {
 
-  private static final int ONE_SECOND = 1000;
-
   private final List<OnLayerAnimationsValuesChangeListener> layerListeners = new ArrayList<>();
   private final List<OnCameraAnimationsValuesChangeListener> cameraListeners = new ArrayList<>();
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerAnimator.java
@@ -60,10 +60,6 @@ final class LocationLayerAnimator {
       locationUpdateTimestamp = SystemClock.elapsedRealtime();
     }
 
-    if (invalidUpdateInterval()) {
-      return;
-    }
-
     LatLng previousLayerLatLng = getPreviousLayerLatLng();
     float previousLayerBearing = getPreviousLayerGpsBearing();
     LatLng previousCameraLatLng = currentCameraPosition.target;
@@ -183,11 +179,6 @@ final class LocationLayerAnimator {
     cancelLayerCompassAnimations();
     cancelCameraLocationAnimations();
     cancelCameraCompassAnimations();
-  }
-
-  private boolean invalidUpdateInterval() {
-    return locationUpdateTimestamp > 0
-      && (SystemClock.elapsedRealtime() - locationUpdateTimestamp) < ONE_SECOND;
   }
 
   private LatLng getPreviousLayerLatLng() {


### PR DESCRIPTION
We found that the invalid update check was causing the initial delay when showing the user's location with the `LocationLayerPlugin`.  

After further testing, it doesn't seem the check is necessary as `Location` APIs should not be sending the same update in less that a seconds time.  