### PR TITLE
Bumped traffic version to 0.5.0 in README

### DIFF
--- a/plugin-traffic/README.md
+++ b/plugin-traffic/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.4.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.5.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.5.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.6.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
Part of the 0.5.0 Traffic plugin release: https://github.com/mapbox/mapbox-plugins-android/issues/438