### PR TITLE
Localization Plugin test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.kt
@@ -1,0 +1,190 @@
+package com.mapbox.mapboxsdk.plugins.localization
+
+import android.content.Context
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.IdlingRegistry
+import android.support.test.espresso.UiController
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.filters.LargeTest
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.plugins.testapp.activity.LocalizationActivity
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.utils.GenericPluginAction
+import com.mapbox.mapboxsdk.utils.OnMapReadyIdlingResource
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.After
+import org.junit.Assert.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import timber.log.Timber
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LocalizationPluginTest {
+
+  @Rule
+  @JvmField
+  val rule = ActivityTestRule(LocalizationActivity::class.java)
+
+  private var idlingResource: OnMapReadyIdlingResource? = null
+  private var localizationPlugin: LocalizationPlugin? = null
+  private var mapboxMap: MapboxMap? = null
+
+  @Before
+  fun beforeTest() {
+    Timber.e("@Before: register idle resource")
+    // If idlingResource is null, throw Kotlin exception
+    idlingResource = OnMapReadyIdlingResource(rule.activity)
+    IdlingRegistry.getInstance().register(idlingResource!!)
+    onView(withId(android.R.id.content)).check(matches(isDisplayed()))
+    mapboxMap = idlingResource!!.mapboxMap
+    localizationPlugin = rule.activity.localizationPlugin
+  }
+
+  //
+  // Country Labels
+  //
+
+  @Test
+  fun languageChanged_changesCountryLabelLgLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("country-label-lg")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesCountryLabelMdLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("country-label-md")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesCountryLabelSmLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("country-label-sm")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  //
+  // State Labels
+  //
+
+  @Test
+  fun languageChanged_changesStateLabelLgLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("state-label-lg")!!
+        var language = layer.textField.expression!!.toArray()[5].toString()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.expression!!.toArray()[5].toString()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesStateLabelMdLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("state-label-md")!!
+        var language = layer.textField.expression!!.toArray()[5].toString()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.expression!!.toArray()[5].toString()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesStateLabelSmLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("state-label-sm")!!
+        var language = layer.textField.expression!!.toArray()[5].toString()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.expression!!.toArray()[5].toString()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  //
+  // Marine Labels
+  //
+
+  @Test
+  fun languageChanged_changesMarineLabelLgPtLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-lg-pt")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @After
+  fun afterTest() {
+    Timber.e("@After: unregister idle resource")
+    IdlingRegistry.getInstance().unregister(idlingResource!!)
+  }
+
+  private fun executePluginTest(listener: GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin>) {
+    onView(withId(android.R.id.content)).perform(GenericPluginAction(mapboxMap, localizationPlugin, listener))
+  }
+}

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.kt
@@ -10,6 +10,7 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.filters.LargeTest
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.constants.Style
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.plugins.testapp.activity.LocalizationActivity
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
@@ -45,6 +46,29 @@ class LocalizationPluginTest {
     onView(withId(android.R.id.content)).check(matches(isDisplayed()))
     mapboxMap = idlingResource!!.mapboxMap
     localizationPlugin = rule.activity.localizationPlugin
+  }
+
+  //
+  // Style Changes
+  //
+  
+  @Test
+  fun styleChanged_theCurrentLanguageRemainsTheSame() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("country-label-lg")!!
+
+        // Change the language
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        var language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+        mapboxMap.setStyleUrl(Style.DARK)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
   }
 
   //
@@ -167,6 +191,180 @@ class LocalizationPluginTest {
       override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
                                          uiController: UiController, context: Context) {
         val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-lg-pt")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesMarineLabelLgLnLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-lg-ln")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesMarineLabelMdPtLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-md-pt")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesMarineLabelMdLnLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-md-ln")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesMarineLabelSmPtLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-sm-pt")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesMarineLabelSmLnLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("marine-label-sm-ln")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  //
+  // City Labels
+  //
+
+  @Test
+  fun languageChanged_changesPlaceCityLgnLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("place-city-lg-n")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesPlaceCityLgsLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("place-city-lg-s")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesPlaceCityMdnLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("place-city-md-n")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesPlaceCityMdsLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("place-city-md-s")!!
+        var language = layer.textField.getValue()
+
+        assertThat(language, equalTo("{name_en}"))
+        plugin?.setMapLanguage(MapLocale.RUSSIAN)
+        language = layer.textField.getValue()
+        assertThat(language, equalTo("{name_ru}"))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
+  fun languageChanged_changesPlaceCitySmLanguage() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocalizationPlugin> {
+      override fun onGenericPluginAction(plugin: LocalizationPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+        val layer: SymbolLayer = mapboxMap?.getLayerAs("place-city-sm")!!
         var language = layer.textField.getValue()
 
         assertThat(language, equalTo("{name_en}"))

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/utils/GenericPluginAction.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/utils/GenericPluginAction.kt
@@ -1,0 +1,30 @@
+package com.mapbox.mapboxsdk.utils
+
+import android.content.Context
+import android.support.test.espresso.UiController
+import android.support.test.espresso.ViewAction
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.view.View
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import org.hamcrest.Matcher
+
+class GenericPluginAction<T>(private val mapboxMap: MapboxMap?, private val plugin: T?,
+                             private val onPerformGenericPluginAction: OnPerformGenericPluginAction<T>?) : ViewAction {
+
+  override fun getConstraints(): Matcher<View> {
+    return isDisplayed()
+  }
+
+  override fun getDescription(): String {
+    return javaClass.simpleName
+  }
+
+  override fun perform(uiController: UiController, view: View) {
+    onPerformGenericPluginAction?.onGenericPluginAction(plugin, mapboxMap, uiController,
+        view.context)
+  }
+
+  interface OnPerformGenericPluginAction<T> {
+    fun onGenericPluginAction(plugin: T?, mapboxMap: MapboxMap?, uiController: UiController, context: Context)
+  }
+}

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/LocalizationActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/LocalizationActivity.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity;
 
 import android.os.Bundle;
+import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -14,14 +15,11 @@ import com.mapbox.mapboxsdk.plugins.localization.MapLocale;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 public class LocalizationActivity extends AppCompatActivity implements OnMapReadyCallback {
 
-  @BindView(R.id.mapView)
-  MapView mapView;
+  private MapView mapView;
 
   private LocalizationPlugin localizationPlugin;
   private MapboxMap mapboxMap;
@@ -45,9 +43,10 @@ public class LocalizationActivity extends AppCompatActivity implements OnMapRead
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_localization);
-    ButterKnife.bind(this);
+
     mapIsLocalized = true;
     Toast.makeText(this, R.string.change_language_instruction, Toast.LENGTH_LONG).show();
+    mapView = findViewById(R.id.map_view);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
   }
@@ -177,6 +176,11 @@ public class LocalizationActivity extends AppCompatActivity implements OnMapRead
       index = 0;
     }
     return LOCALES[index];
+  }
+
+  @VisibleForTesting
+  public LocalizationPlugin getLocalizationPlugin() {
+    return localizationPlugin;
   }
 }
 

--- a/app/src/main/res/layout/activity_localization.xml
+++ b/app/src/main/res/layout/activity_localization.xml
@@ -2,19 +2,17 @@
 <android.support.constraint.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
 
   <com.mapbox.mapboxsdk.maps.MapView
-    android:id="@+id/mapView"
+    android:id="@+id/map_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:mapbox_cameraTargetLat="51.505300"
-    app:mapbox_cameraTargetLng="-0.075073"
-    app:mapbox_cameraTilt="20"
-    app:mapbox_cameraZoom="2.5"
+    app:mapbox_cameraTargetLat="31.559"
+    app:mapbox_cameraTargetLng="-99.517"
+    app:mapbox_cameraZoom="5"
     app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets">
 
   </com.mapbox.mapboxsdk.maps.MapView>
@@ -26,11 +24,11 @@
     android:layout_marginBottom="16dp"
     android:layout_marginEnd="16dp"
     android:layout_marginRight="16dp"
-    android:src="@drawable/ic_translate_white_24dp"
     app:backgroundTint="@color/colorPrimary"
     app:fabSize="normal"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"/>
+    app:layout_constraintEnd_toEndOf="parent"
+    app:srcCompat="@drawable/ic_translate_white_24dp"/>
 
   <android.support.design.widget.FloatingActionButton
     android:id="@+id/change_map_style"
@@ -39,13 +37,13 @@
     android:layout_marginBottom="8dp"
     android:layout_marginEnd="16dp"
     android:layout_marginRight="16dp"
-    android:src="@drawable/ic_layers"
     android:tint="@android:color/white"
     app:backgroundTint="@color/colorAccent"
     app:fabSize="normal"
     app:layout_constraintBottom_toTopOf="@+id/camera_localization"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintRight_toRightOf="parent"/>
+    app:layout_constraintRight_toRightOf="parent"
+    app:srcCompat="@drawable/ic_layers"/>
 
   <android.support.design.widget.FloatingActionButton
     android:id="@+id/camera_localization"
@@ -54,12 +52,12 @@
     android:layout_marginBottom="8dp"
     android:layout_marginEnd="16dp"
     android:layout_marginRight="16dp"
-    android:src="@drawable/ic_camera"
     android:tint="@android:color/white"
     app:backgroundTint="@color/colorAccent"
     app:fabSize="normal"
     app:layout_constraintBottom_toTopOf="@+id/localize_fab"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintRight_toRightOf="parent"/>
+    app:layout_constraintRight_toRightOf="parent"
+    app:srcCompat="@drawable/ic_camera"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     classpath pluginDependencies.gradle
     classpath pluginDependencies.sonarqube
     classpath pluginDependencies.errorprone
+    classpath pluginDependencies.kotlin
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -115,13 +115,15 @@ ext {
       jacoco    : '0.8.0',
       errorprone: '0.0.13',
       sonarqube : '2.6.2',
-      gradle    : '3.0.1'
+      gradle    : '3.0.1',
+      kotlin    : '1.2.40'
   ]
 
   pluginDependencies = [
       gradle    : "com.android.tools.build:gradle:${pluginVersion.gradle}",
       checkstyle: "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
       sonarqube : "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${pluginVersion.sonarqube}",
-      errorprone: "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}"
+      errorprone: "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
+      kotlin    : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}"
   ]
 }


### PR DESCRIPTION
PR does the following:

- Adds Kotlin to the testapp
- Adds a few test to reproduce issue pointed out in #374 
- Creates a generic plugin action class which we can use for all plugin instrument test rather than having an action class for each plugin.

What's left to do:
- [ ] Test the rest of the Street style labels
- [ ] fix expressions not changing languages

cc: @tobrun @langsmith 