### PR TITLE
Initialize with default modes and fix style reloading issue

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerModesActivity.java
@@ -20,6 +20,7 @@ import com.mapbox.android.core.location.LocationEngineListener;
 import com.mapbox.android.core.location.LocationEnginePriority;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -141,13 +142,17 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
       return super.onOptionsItemSelected(item);
     }
 
-    if (item.getItemId() == R.id.action_style_change) {
+    int id = item.getItemId();
+    if (id == R.id.action_style_change) {
       toggleStyle();
       return true;
-    } else if (item.getItemId() == R.id.action_plugin_disable) {
+    } else if (id == R.id.action_map_style_change) {
+      toggleMapStyle();
+      return true;
+    } else if (id == R.id.action_plugin_disable) {
       locationLayerPlugin.setLocationLayerEnabled(false);
       return true;
-    } else if (item.getItemId() == R.id.action_plugin_enabled) {
+    } else if (id == R.id.action_plugin_enabled) {
       locationLayerPlugin.setLocationLayerEnabled(true);
       return true;
     }
@@ -160,6 +165,12 @@ public class LocationLayerModesActivity extends AppCompatActivity implements OnM
     customStyle = !customStyle;
     locationLayerPlugin.applyStyle(customStyle ? R.style.CustomLocationLayer
       : R.style.mapbox_LocationLayer);
+  }
+
+  @VisibleForTesting
+  public void toggleMapStyle() {
+    String styleUrl = mapboxMap.getStyleUrl().contentEquals(Style.DARK) ? Style.LIGHT : Style.DARK;
+    mapboxMap.setStyle(styleUrl);
   }
 
   @VisibleForTesting

--- a/app/src/main/res/menu/menu_location.xml
+++ b/app/src/main/res/menu/menu_location.xml
@@ -2,7 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/action_style_change"
-          android:title="Toggle custom style"
+          android:title="Toggle custom LocationLayer style"
+          app:showAsAction="never"/>
+
+    <item android:id="@+id/action_map_style_change"
+          android:title="Toggle custom Map style"
           app:showAsAction="never"/>
 
     <item android:id="@+id/action_plugin_disable"

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -99,6 +99,7 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
 
   void initializeComponents(LocationLayerOptions options) {
     prepareLocationSource();
+    addLocationSource();
     addLayers();
     applyStyle(options);
   }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -471,6 +471,8 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     updateMapWithOptions(options);
 
     enableLocationLayerPlugin();
+    setRenderMode(RenderMode.NORMAL);
+    setCameraMode(CameraMode.NONE);
   }
 
   @SuppressLint("MissingPermission")
@@ -604,6 +606,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
         locationLayer.initializeComponents(options);
         locationLayerCamera.initializeOptions(options);
         setRenderMode(locationLayer.getRenderMode());
+        setCameraMode(locationLayerCamera.getCameraMode());
         onStart();
       }
     }


### PR DESCRIPTION
Closes #457, Closes #456 

Adds default render / camera mode when the plugin is initialized.

Fixes issue where we weren't re-adding the sources when a new style was loaded (adds test functionality to test app as well from options menu)