### PR TITLE
Add offline UI options

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.java
@@ -6,10 +6,13 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
-import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.offline.OfflineRegionSelector;
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
+import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
+import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 
 import java.util.Locale;
@@ -30,7 +33,15 @@ public class OfflineUiComponentsActivity extends AppCompatActivity {
 
   @OnClick(R.id.launch_offline_region_selector_button)
   public void onOfflineRegionSelectorButtonClicked() {
+
+    // Create the offline region selector options
+    RegionSelectionOptions options = RegionSelectionOptions.builder()
+      .statingCameraPosition(
+        new CameraPosition.Builder().target(new LatLng(32.7852, -96.8154)).zoom(12).build()
+      ).build();
+
     Intent intent = new OfflineRegionSelector.IntentBuilder()
+      .regionSelectionOptions(options)
       .build(this);
     startActivityForResult(intent, REQUEST_CODE);
   }

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePluginConstants.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePluginConstants.java
@@ -1,0 +1,10 @@
+package com.mapbox.mapboxsdk.plugins.offline;
+
+public class OfflinePluginConstants {
+
+  private OfflinePluginConstants() {
+    // No Instances
+  }
+
+  public static final String REGION_SELECTION_OPTIONS = "com.mapbox.mapboxsdk.plugins.offline:region_selection_options";
+}

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineRegionSelector.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineRegionSelector.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
+import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
 import com.mapbox.mapboxsdk.plugins.offline.ui.OfflineActivity;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_DEFINITION;
@@ -162,6 +163,11 @@ public class OfflineRegionSelector {
      */
     public IntentBuilder() {
       intent = new Intent();
+    }
+
+    public IntentBuilder regionSelectionOptions(RegionSelectionOptions regionSelectionOptions) {
+      intent.putExtra(OfflinePluginConstants.REGION_SELECTION_OPTIONS, regionSelectionOptions);
+      return this;
     }
 
     /**

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/OfflineDownloadOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/OfflineDownloadOptions.java
@@ -89,6 +89,7 @@ public abstract class OfflineDownloadOptions implements Parcelable {
    * Used to build a new instance of this class.
    *
    * @return this classes builder class
+   * @since 0.1.0
    */
   public static Builder builder() {
     return new AutoValue_OfflineDownloadOptions.Builder()
@@ -187,9 +188,7 @@ public abstract class OfflineDownloadOptions implements Parcelable {
 
     /**
      * Build a new {@link OfflineDownloadOptions} instance using the information and values provided
-     * inside this builder class.
-    public abstract Builder regionId(long regionId);
-
+     * inside this builder class
      *
      * @return a new instance of the {@link OfflineDownloadOptions} which is using the values you
      * provided in this builder

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/RegionSelectionOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/RegionSelectionOptions.java
@@ -1,0 +1,97 @@
+package com.mapbox.mapboxsdk.plugins.offline.model;
+
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.plugins.offline.ui.OfflineActivity;
+
+/**
+ * Options specific to the Region Selection UI component.
+ *
+ * @since 0.2.0
+ */
+@AutoValue
+public abstract class RegionSelectionOptions implements Parcelable {
+
+  /**
+   * Define the map's starting camera position by providing a bounding box
+   *
+   * @return the bounding box which is where the {@link OfflineActivity} initial map's camera
+   * position will be placed
+   * @since 0.2.0
+   */
+  @Nullable
+  public abstract LatLngBounds startingBounds();
+
+  /**
+   * Define the map's starting camera position by providing a camera position.
+   *
+   * @return the camera position which is where the {@link OfflineActivity} initial map's camera
+   * position will be placed
+   * @since 0.2.0
+   */
+  @Nullable
+  public abstract CameraPosition statingCameraPosition();
+
+  /**
+   * A convenient way to build a new instance of this class using all of the same values this current
+   * instance has. Use this when you wish to modify a single entry.
+   *
+   * @return a new {@link Builder} instance with all the same values this classes instance contains
+   * @since 0.2.0
+   */
+  public abstract Builder toBuilder();
+
+  /**
+   * Used to build a new instance of this class.
+   *
+   * @return this classes builder class
+   * @since 0.2.0
+   */
+  public static Builder builder() {
+    return new AutoValue_RegionSelectionOptions.Builder();
+  }
+
+  /**
+   * The Builder class in charge of constructing this class and setting the values accordingly.
+   *
+   * @since 0.2.0
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    /**
+     * Define the map's starting camera position by providing a bounding box
+     *
+     * @param bounds the bounding box which is where the {@link OfflineActivity} initial map's camera
+     *               position will be placed
+     * @return this builder for chaining options together
+     * @since 0.2.0
+     */
+    public abstract Builder startingBounds(@NonNull LatLngBounds bounds);
+
+    /**
+     * Define the map's starting camera position by providing a camera position.
+     *
+     * @param cameraPosition the camera position which is where the {@link OfflineActivity} initial
+     *                       map's camera position will be placed
+     * @return this builder for chaining options together
+     * @since 0.2.0
+     */
+    public abstract Builder statingCameraPosition(@NonNull CameraPosition cameraPosition);
+
+    /**
+     * Build a new {@link RegionSelectionOptions} instance using the information and values provided
+     * inside this builder class
+     *
+     * @return a new instance of the {@link RegionSelectionOptions} which is using the values you
+     * provided in this builder
+     * @since 0.2.0
+     */
+    public abstract RegionSelectionOptions build();
+  }
+}

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/OfflineActivity.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/OfflineActivity.java
@@ -8,7 +8,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.Window;
 
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
+import com.mapbox.mapboxsdk.plugins.offline.OfflinePluginConstants;
 import com.mapbox.mapboxsdk.plugins.offline.R;
+import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
 import com.mapbox.mapboxsdk.plugins.offline.utils.ColorUtils;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_DEFINITION;
@@ -35,7 +37,13 @@ public class OfflineActivity extends AppCompatActivity implements RegionSelected
 
       RegionSelectionFragment fragment;
 
-      fragment = RegionSelectionFragment.newInstance();
+      RegionSelectionOptions regionSelectionOptions
+        = getIntent().getParcelableExtra(OfflinePluginConstants.REGION_SELECTION_OPTIONS);
+      if (regionSelectionOptions != null) {
+        fragment = RegionSelectionFragment.newInstance(regionSelectionOptions);
+      } else {
+        fragment = RegionSelectionFragment.newInstance();
+      }
 
       getSupportFragmentManager().beginTransaction()
         .add(R.id.fragment_container, fragment, RegionSelectionFragment.TAG).commit();


### PR DESCRIPTION
Adds a RegionSelectorOptions class which can be used to set the initial camera position for the offline region selector UI component.