### PR TITLE
Lower min API to 14 for all plugins

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,10 +71,10 @@ dependencies {
   // Architecture
   implementation dependenciesList.lifecycleExtensions
   implementation dependenciesList.roomRuntime
-  annotationProcessor dependenciesList.roomCompiler
+  kapt dependenciesList.roomCompiler
 
   // LOST
-  implementation dependenciesList.lost
+  implementation dependenciesList.playLocation
 
   // Support libraries
   implementation dependenciesList.supportAnnotation

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext {
 
   androidVersions = [
-      minSdkVersion    : 15,
+      minSdkVersion    : 14,
       targetSdkVersion : 27,
       compileSdkVersion: 27,
       buildToolsVersion: '27.0.2'
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.0.1',
       mapboxGeocoding    : '3.0.1',
       mapboxGeoJson      : '3.0.1',
-      lost               : '3.0.4',
+      playLocation       : '11.8.0',
       autoValue          : '1.5.3',
       autoValueParcel    : '0.2.6',
       junit              : '4.12',
@@ -43,8 +43,8 @@ ext {
       mapboxGeoJson          : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxGeoJson}",
       mapboxGeocoding        : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxGeocoding}",
 
-      // Lost
-      lost                   : "com.mapzen.android:lost:${version.lost}",
+      // Google Play Location
+      playLocation           : "com.google.android.gms:play-services-location:${version.playLocation}",
 
       // AutoValue
       autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",

--- a/plugin-building/CHANGELOG.md
+++ b/plugin-building/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the Mapbox building plugin
 
+### 0.3.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.2.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
 - Adds `isVisible` API [#404](https://github.com/mapbox/mapbox-plugins-android/pull/404)

--- a/plugin-cluster/CHANGELOG.md
+++ b/plugin-cluster/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### 0.3.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.2.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
 

--- a/plugin-geojson/CHANGELOG.md
+++ b/plugin-geojson/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### 0.3.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.2.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
 - Adds consumer ProGuard rules [#373](https://github.com/mapbox/mapbox-plugins-android/pull/373)

--- a/plugin-localization/CHANGELOG.md
+++ b/plugin-localization/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### 0.3.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.2.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
 

--- a/plugin-locationlayer/CHANGELOG.md
+++ b/plugin-locationlayer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### 0.6.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.5.0 - April 19, 2018
 - Maps SDK Bumped to 6.0.1 [#432](https://github.com/mapbox/mapbox-plugins-android/pull/432)
 - Remove invalid Location update check [#431](https://github.com/mapbox/mapbox-plugins-android/pull/431)

--- a/plugin-offline/CHANGELOG.md
+++ b/plugin-offline/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog for the Mapbox offline plugin
 
+### 0.2.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.1.0 - April 18, 2018
 - Initial release as a standalone package.

--- a/plugin-places/CHANGELOG.md
+++ b/plugin-places/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### 0.4.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.3.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
 - Adds consumer ProGuard rules [#373](https://github.com/mapbox/mapbox-plugins-android/pull/373)

--- a/plugin-traffic/CHANGELOG.md
+++ b/plugin-traffic/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the Mapbox traffic plugin
 
+### 0.6.0 - TBD
+- Lowered min SDK to API level 14 to match Map SDK
+
 ### 0.5.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
 


### PR DESCRIPTION
Closes #459 

Went through the test app and didn't notice any issues (other than using LOST still).