### PR TITLE
Only adds location source once the first location update occurs

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -99,7 +99,6 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
 
   void initializeComponents(LocationLayerOptions options) {
     prepareLocationSource();
-    addLocationSource();
     addLayers();
     applyStyle(options);
   }


### PR DESCRIPTION
Closes #460 

removes the `addLocationSource` call inside `initializeComponents` which causes the location icon to show before the first location update occurs.