### PR TITLE
Maps sdk bump to 6.1.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.1.1',
+      mapboxMapSdk       : '6.1.2',
       mapboxGeocoding    : '3.0.1',
       mapboxGeoJson      : '3.0.1',
       playLocation       : '11.8.0',


### PR DESCRIPTION
Part of the 6.1.2 release of the Maps SDK for Android

