### PR TITLE
Adds constructor which doesn't take in a locationEngine

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/locationlayer/IsolatedActivityPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/locationlayer/IsolatedActivityPluginTest.kt
@@ -77,6 +77,24 @@ class IsolatedActivityPluginTest {
   }
 
   @Test
+  fun locationLayerPlugin_initializesLocationEngineCorrectlyWhenOnesNotProvided() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocationLayerPlugin> {
+      override fun onGenericPluginAction(plugin: LocationLayerPlugin?, mapboxMap: MapboxMap?,
+                                         uiController: UiController, context: Context) {
+
+        mapView = fragment?.view as MapView?
+        val locationLayerPlugin = LocationLayerPlugin(mapView!!, mapboxMap!!)
+        val locationEngine = locationLayerPlugin.locationEngine
+        assertThat(locationEngine, notNullValue())
+
+        uiController.loopMainThreadForAtLeast(500)
+        assertThat(locationEngine?.isConnected, `is`(equalTo(true)))
+      }
+    }
+    executePluginTest(pluginAction)
+  }
+
+  @Test
   fun settingMapStyleImmediatelyBeforeLoadingPlugin_doesStillLoadLayersProperly() {
     // Using Empty fragment activity to test since Mapbox Style change needs to happen immediately.
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -284,6 +284,13 @@ public final class LocationLayerPlugin implements LifecycleObserver {
    */
   public void setLocationEngine(@Nullable LocationEngine locationEngine) {
     if (this.locationEngine != null) {
+      // If internal location engines being used, extra steps need to be taken to deconstruct the
+      // instance.
+      if (usingInternalLocationEngine) {
+        this.locationEngine.removeLocationUpdates();
+        this.locationEngine.deactivate();
+        usingInternalLocationEngine = false;
+      }
       this.locationEngine.removeLocationEngineListener(locationEngineListener);
       this.locationEngine = null;
     }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/523
Closes #524 

If this constructor's used, we create a location engine and internally use it.