### PR TITLE
Initialize LocationEngine for all constructors if null

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -95,7 +95,6 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     this.mapboxMap = mapboxMap;
     this.mapView = mapView;
     options = LocationLayerOptions.createFromAttributes(mapView.getContext(), R.style.mapbox_LocationLayer);
-    initializeLocationEngine();
     initialize();
   }
 
@@ -488,6 +487,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
   }
 
   private void initialize() {
+    initializeLocationEngine();
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
     mapboxMap.addOnMapClickListener(onMapClickListener);
@@ -512,11 +512,13 @@ public final class LocationLayerPlugin implements LifecycleObserver {
   }
 
   private void initializeLocationEngine() {
-    usingInternalLocationEngine = true;
-    locationEngine = new LocationEngineProvider(mapView.getContext()).obtainBestLocationEngineAvailable();
-    locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
-    locationEngine.setFastestInterval(1000);
-    locationEngine.activate();
+    if (locationEngine == null) {
+      usingInternalLocationEngine = true;
+      locationEngine = new LocationEngineProvider(mapView.getContext()).obtainBestLocationEngineAvailable();
+      locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+      locationEngine.setFastestInterval(1000);
+      locationEngine.activate();
+    }
   }
 
   private void enableLocationLayerPlugin() {


### PR DESCRIPTION
Re: https://github.com/mapbox/mapbox-plugins-android/issues/510#issuecomment-391717083

If we only want the constructor added in #527 to initialize a default `LocationEngine`, then we should mark the other constructor `LocationEngine` params as `@NonNull` currently marked as nullable. 

Happy to change the annotations or use the code I submitted originally 