### PR TITLE
Harden state and style changes

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -94,6 +94,8 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
   );
   private GeoJsonSource locationSource;
 
+  private boolean isHidden;
+
   LocationLayer(MapView mapView, MapboxMap mapboxMap, LocationLayerOptions options) {
     this.mapboxMap = mapboxMap;
     this.context = mapView.getContext();
@@ -105,6 +107,12 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
     addLocationSource();
     addLayers();
     applyStyle(options);
+
+    if (isHidden) {
+      hide();
+    } else {
+      show();
+    }
   }
 
   void applyStyle(@NonNull LocationLayerOptions options) {
@@ -165,12 +173,14 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
 
   void show() {
     setRenderMode(renderMode);
+    isHidden = false;
   }
 
   void hide() {
     for (String layerId : layerMap.keySet()) {
       setLayerVisibility(layerId, false);
     }
+    isHidden = true;
   }
 
   private void setLayerVisibility(String layerId, boolean visible) {

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -93,7 +93,6 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
     Point.fromLngLat(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)
   );
   private GeoJsonSource locationSource;
-  private boolean isSourceInitialized;
 
   LocationLayer(MapView mapView, MapboxMap mapboxMap, LocationLayerOptions options) {
     this.mapboxMap = mapboxMap;
@@ -103,7 +102,6 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
   }
 
   void initializeComponents(LocationLayerOptions options) {
-    prepareLocationSource();
     addLocationSource();
     addLayers();
     applyStyle(options);
@@ -299,7 +297,7 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
   // Source actions
   //
 
-  private void prepareLocationSource() {
+  private void addLocationSource() {
     locationFeature.addNumberProperty(PROPERTY_GPS_BEARING, 0f);
     locationFeature.addNumberProperty(PROPERTY_COMPASS_BEARING, 0f);
     locationFeature.addBooleanProperty(PROPERTY_LOCATION_STALE, false);
@@ -309,11 +307,8 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
       locationFeature,
       new GeoJsonOptions().withMaxZoom(16)
     );
-  }
 
-  private void addLocationSource() {
     mapboxMap.addSource(locationSource);
-    isSourceInitialized = true;
   }
 
   private void refreshSource() {
@@ -325,10 +320,6 @@ final class LocationLayer implements LocationLayerAnimator.OnLayerAnimationsValu
     if (properties != null) {
       locationFeature = Feature.fromGeometry(locationPoint, properties);
       locationSource.setGeoJson(locationFeature);
-    }
-
-    if (!isSourceInitialized) {
-      addLocationSource();
     }
   }
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -454,9 +454,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
   public void onStart() {
     onLocationLayerStart();
-    if (isEnabled) {
-      mapView.addOnMapChangedListener(onMapChangedListener);
-    }
+    mapView.addOnMapChangedListener(onMapChangedListener);
   }
 
   /**

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -441,7 +441,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
   public void onStart() {
-    enableLocationLayerPlugin();
+    onLocationLayerStart();
     if (isEnabled) {
       mapView.addOnMapChangedListener(onMapChangedListener);
     }
@@ -454,7 +454,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
   public void onStop() {
-    disableLocationLayerPlugin();
+    onLocationLayerStop();
     mapView.removeOnMapChangedListener(onMapChangedListener);
   }
 
@@ -547,7 +547,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
    * @since 0.1.0
    */
   private void updateLocation(final Location location) {
-    if (location == null || !isEnabled) {
+    if (location == null) {
       return;
     }
     staleStateManager.updateLatestLocationTime();


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/515.

Reverts the regression introduced in https://github.com/mapbox/mapbox-plugins-android/pull/528 which would re-enable location layer plugin even if disabled when the lifecycle is stopped and started again. This PR adds another solution to this issue with https://github.com/mapbox/mapbox-plugins-android/commit/965b6d9ae545001eca78b3c6857e7f656012c449.

Cleans up source addition checks that became obsolete with https://github.com/mapbox/mapbox-plugins-android/pull/516.

Fixes crash that would occur when the plugin is disabled, the lifecycle is stopped then started and the style is changed, which would result in layers and sources not being initialized leading to a native `null pointer dereference` exception.