### PR TITLE
Revert release configuration from #536

### DIFF
--- a/plugin-building/gradle.properties
+++ b/plugin-building/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.4.0
+VERSION_NAME=0.5.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-building
 POM_NAME=Mapbox Android Building Plugin
 POM_DESCRIPTION=Mapbox Android Building Plugin

--- a/plugin-localization/gradle.properties
+++ b/plugin-localization/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.4.0
+VERSION_NAME=0.5.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-localization
 POM_NAME=Mapbox Android Localization Plugin
 POM_DESCRIPTION=Mapbox Android Localization Plugin

--- a/plugin-locationlayer/gradle.properties
+++ b/plugin-locationlayer/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.5.3
+VERSION_NAME=0.6.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-locationlayer
 POM_NAME=Mapbox Android Location Layer Plugin
 POM_DESCRIPTION=Mapbox Android Location Layer Plugin

--- a/plugin-offline/gradle.properties
+++ b/plugin-offline/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.3.0
+VERSION_NAME=0.4.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-offline
 POM_NAME=Mapbox Android Offline Plugin
 POM_DESCRIPTION=Mapbox Android Offline Plugin

--- a/plugin-places/gradle.properties
+++ b/plugin-places/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-places
 POM_NAME=Mapbox Android Places Plugin
 POM_DESCRIPTION=Mapbox Android Places Plugin

--- a/plugin-traffic/gradle.properties
+++ b/plugin-traffic/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.7.0
+VERSION_NAME=0.8.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-traffic
 POM_NAME=Mapbox Android Traffic Plugin
 POM_DESCRIPTION=Mapbox Android Traffic Plugin


### PR DESCRIPTION
This reverts release configuration from #536 and brings back snapshots builds for `master` .