### PR TITLE
Unify bearing and target CameraUpdate

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LayerCameraOnMoveListener.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LayerCameraOnMoveListener.java
@@ -1,0 +1,54 @@
+package com.mapbox.mapboxsdk.plugins.locationlayer;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.android.gestures.MoveGestureDetector;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
+
+class LayerCameraOnMoveListener implements MapboxMap.OnMoveListener {
+
+  private final LocationLayerCamera camera;
+  private MoveGestureDetector moveGestureDetector;
+  private LocationLayerOptions options;
+  private boolean interrupt;
+
+  LayerCameraOnMoveListener(LocationLayerCamera camera, MoveGestureDetector moveGestureDetector,
+                            LocationLayerOptions options) {
+    this.camera = camera;
+    this.moveGestureDetector = moveGestureDetector;
+    this.options = options;
+  }
+
+  void updateOptions(LocationLayerOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public void onMoveBegin(@NonNull MoveGestureDetector detector) {
+    if (detector.getPointersCount() > 1
+      && detector.getMoveThreshold() != options.trackingMultiFingerMoveThreshold()
+      && camera.isLocationTracking()) {
+      detector.setMoveThreshold(options.trackingMultiFingerMoveThreshold());
+      interrupt = true;
+    }
+  }
+
+  @Override
+  public void onMove(@NonNull MoveGestureDetector detector) {
+    if (interrupt) {
+      detector.interrupt();
+      return;
+    }
+
+    camera.setCameraMode(CameraMode.NONE);
+  }
+
+  @Override
+  public void onMoveEnd(@NonNull MoveGestureDetector detector) {
+    if (!interrupt && camera.isLocationTracking()) {
+      moveGestureDetector.setMoveThreshold(options.trackingInitialMoveThreshold());
+    }
+    interrupt = false;
+  }
+}

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LayerCameraOnRotateListener.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LayerCameraOnRotateListener.java
@@ -1,0 +1,38 @@
+package com.mapbox.mapboxsdk.plugins.locationlayer;
+
+import com.mapbox.android.gestures.RotateGestureDetector;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
+
+import static com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode.TRACKING_BEARING;
+
+class LayerCameraOnRotateListener implements MapboxMap.OnRotateListener {
+
+  private final LocationLayerCamera camera;
+
+  LayerCameraOnRotateListener(LocationLayerCamera camera) {
+    this.camera = camera;
+  }
+
+  @Override
+  public void onRotateBegin(RotateGestureDetector detector) {
+    if (isBearingTracking()) {
+      camera.setCameraMode(CameraMode.NONE);
+    }
+  }
+
+  @Override
+  public void onRotate(RotateGestureDetector detector) {
+    // no implementation
+  }
+
+  @Override
+  public void onRotateEnd(RotateGestureDetector detector) {
+    // no implementation
+  }
+
+  private boolean isBearingTracking() {
+    int cameraMode = camera.getCameraMode();
+    return TRACKING_BEARING.contains(cameraMode);
+  }
+}

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
@@ -6,116 +6,67 @@ import android.view.MotionEvent;
 
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveGestureDetector;
-import com.mapbox.android.gestures.RotateGestureDetector;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
 
-import java.util.List;
-import java.util.Set;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode.TRACKING_BEARING;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode.TRACKING_COMPASS_BEARING;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode.TRACKING_GPS_BEARING;
+import static com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode.TRACKING_LOCATION;
 
-final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValuesChangeListener {
+final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValuesChangeListener,
+  RefreshPluginRunnable.RefreshPluginListener {
 
   @CameraMode.Mode
   private int cameraMode;
+  private float bearing;
+  private LatLng target;
 
-  private final MapboxMap mapboxMap;
   private final OnCameraTrackingChangedListener internalCameraTrackingChangedListener;
+  private final OnCameraMoveInvalidateListener onCameraMoveInvalidateListener;
+  private final MoveGestureDetector moveGestureDetector;
+  private final MapboxMap mapboxMap;
+  private final LayerCameraOnMoveListener onMoveListener;
+  private final RefreshPluginRunnable refreshPluginRunnable;
   private LocationLayerOptions options;
   private boolean adjustFocalPoint;
 
-  private final MoveGestureDetector moveGestureDetector;
-  private final OnCameraMoveInvalidateListener onCameraMoveInvalidateListener;
-
-  LocationLayerCamera(
-    Context context,
-    MapboxMap mapboxMap,
-    OnCameraTrackingChangedListener internalCameraTrackingChangedListener,
-    LocationLayerOptions options,
-    OnCameraMoveInvalidateListener onCameraMoveInvalidateListener) {
-    this.mapboxMap = mapboxMap;
-    mapboxMap.setGesturesManager(
-      new PluginsGesturesManager(context), true, true);
-    moveGestureDetector = mapboxMap.getGesturesManager().getMoveGestureDetector();
-    mapboxMap.addOnMoveListener(onMoveListener);
-    mapboxMap.addOnRotateListener(onRotateListener);
-
+  LocationLayerCamera(Context context,
+                      OnCameraTrackingChangedListener internalCameraTrackingChangedListener,
+                      OnCameraMoveInvalidateListener onCameraMoveInvalidateListener,
+                      MapboxMap mapboxMap,
+                      LocationLayerOptions options) {
     this.internalCameraTrackingChangedListener = internalCameraTrackingChangedListener;
     this.onCameraMoveInvalidateListener = onCameraMoveInvalidateListener;
-    initializeOptions(options);
-  }
-
-  void initializeOptions(LocationLayerOptions options) {
+    this.mapboxMap = mapboxMap;
     this.options = options;
-  }
-
-  void setCameraMode(@CameraMode.Mode int cameraMode) {
-    final boolean wasTracking = isLocationTracking();
-    this.cameraMode = cameraMode;
-    mapboxMap.cancelTransitions();
-    adjustGesturesThresholds();
-    notifyCameraTrackingChangeListener(wasTracking);
-  }
-
-  int getCameraMode() {
-    return cameraMode;
-  }
-
-  private void setBearing(float bearing) {
-    mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(bearing));
-    onCameraMoveInvalidateListener.onInvalidateCameraMove();
-  }
-
-  private void setLatLng(LatLng latLng) {
-    mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(latLng));
-    onCameraMoveInvalidateListener.onInvalidateCameraMove();
-  }
-
-  private void setZoom(float zoom) {
-    mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(zoom));
-    onCameraMoveInvalidateListener.onInvalidateCameraMove();
-  }
-
-  private void setTilt(float tilt) {
-    mapboxMap.moveCamera(CameraUpdateFactory.tiltTo(tilt));
-    onCameraMoveInvalidateListener.onInvalidateCameraMove();
+    mapboxMap.setGesturesManager(new PluginsGesturesManager(context), true, true);
+    moveGestureDetector = mapboxMap.getGesturesManager().getMoveGestureDetector();
+    onMoveListener = new LayerCameraOnMoveListener(this, moveGestureDetector, options);
+    mapboxMap.addOnMoveListener(onMoveListener);
+    mapboxMap.addOnRotateListener(new LayerCameraOnRotateListener(this));
+    refreshPluginRunnable = new RefreshPluginRunnable(options.refreshIntervalInMillis());
+    refreshPluginRunnable.setListener(this);
   }
 
   @Override
   public void onNewLatLngValue(LatLng latLng) {
-    if (cameraMode == CameraMode.TRACKING
-      || cameraMode == CameraMode.TRACKING_COMPASS
-      || cameraMode == CameraMode.TRACKING_GPS
-      || cameraMode == CameraMode.TRACKING_GPS_NORTH) {
-      setLatLng(latLng);
-
-      if (adjustFocalPoint) {
-        PointF focalPoint = mapboxMap.getProjection().toScreenLocation(latLng);
-        mapboxMap.getUiSettings().setFocalPoint(focalPoint);
-        adjustFocalPoint = false;
-      }
-    }
+    updateTargetLatLng(latLng);
   }
 
   @Override
   public void onNewGpsBearingValue(float gpsBearing) {
-    boolean trackingNorth = cameraMode == CameraMode.TRACKING_GPS_NORTH
-      && mapboxMap.getCameraPosition().bearing != 0;
-
-    if (cameraMode == CameraMode.TRACKING_GPS
-      || cameraMode == CameraMode.NONE_GPS
-      || trackingNorth) {
-      setBearing(gpsBearing);
-    }
+    boolean trackingNorth = isTrackingNorth();
+    updateGpsBearing(gpsBearing, trackingNorth);
   }
 
   @Override
   public void onNewCompassBearingValue(float compassBearing) {
-    if (cameraMode == CameraMode.TRACKING_COMPASS
-      || cameraMode == CameraMode.NONE_COMPASS) {
-      setBearing(compassBearing);
-    }
+    updateCompassBearing(compassBearing);
   }
 
   @Override
@@ -128,6 +79,123 @@ final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValu
     setTilt(tilt);
   }
 
+  @Override
+  public void onShouldRefresh() {
+    refreshCamera();
+  }
+
+  void updateOptions(LocationLayerOptions options) {
+    this.options = options;
+    double refreshIntervalMillis = options.refreshIntervalInMillis();
+    refreshPluginRunnable.updateRefreshInterval(refreshIntervalMillis);
+    onMoveListener.updateOptions(options);
+  }
+
+  void setCameraMode(@CameraMode.Mode int cameraMode) {
+    refreshWithCurrentCameraPosition();
+    final boolean wasTracking = isLocationTracking();
+    this.cameraMode = cameraMode;
+    mapboxMap.cancelTransitions();
+    updateRefreshRunnableWith(cameraMode);
+    adjustGesturesThresholds();
+    notifyCameraTrackingChangeListener(wasTracking);
+  }
+
+  int getCameraMode() {
+    return cameraMode;
+  }
+
+  boolean isLocationTracking() {
+    return TRACKING_LOCATION.contains(cameraMode);
+  }
+
+  void onStart() {
+    if (cameraMode != CameraMode.NONE) {
+      refreshPluginRunnable.run();
+    }
+  }
+
+  void onStop() {
+    refreshPluginRunnable.cancel();
+  }
+
+  private void setZoom(float zoom) {
+    mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(zoom));
+    onCameraMoveInvalidateListener.onInvalidateCameraMove();
+  }
+
+  private void setTilt(float tilt) {
+    mapboxMap.moveCamera(CameraUpdateFactory.tiltTo(tilt));
+    onCameraMoveInvalidateListener.onInvalidateCameraMove();
+  }
+
+  private void updateTargetLatLng(LatLng latLng) {
+    target = latLng;
+  }
+
+  private boolean isTrackingNorth() {
+    return cameraMode == CameraMode.TRACKING_GPS_NORTH
+      && mapboxMap.getCameraPosition().bearing != 0;
+  }
+
+  private void updateGpsBearing(float gpsBearing, boolean trackingNorth) {
+    if (TRACKING_GPS_BEARING.contains(cameraMode) || trackingNorth) {
+      bearing = gpsBearing;
+    }
+  }
+
+  private void updateCompassBearing(float compassBearing) {
+    if (TRACKING_COMPASS_BEARING.contains(cameraMode)) {
+      bearing = compassBearing;
+    }
+  }
+
+  private void refreshCamera() {
+    CameraUpdate cameraUpdate = buildCameraUpdate();
+    mapboxMap.moveCamera(cameraUpdate);
+    onCameraMoveInvalidateListener.onInvalidateCameraMove();
+
+    if (isLocationTracking()) {
+      adjustFocalPoint(mapboxMap.getCameraPosition().target);
+    }
+  }
+
+  private CameraUpdate buildCameraUpdate() {
+    CameraPosition cameraPosition = mapboxMap.getCameraPosition();
+    CameraPosition.Builder cameraPositionBuilder = new CameraPosition.Builder();
+    addBearing(cameraPosition, cameraPositionBuilder);
+    addTarget(cameraPosition, cameraPositionBuilder);
+    return CameraUpdateFactory.newCameraPosition(cameraPositionBuilder.build());
+  }
+
+  private void addBearing(CameraPosition cameraPosition, CameraPosition.Builder cameraPositionBuilder) {
+    boolean isTrackingBearing = TRACKING_BEARING.contains(cameraMode);
+    boolean isNewBearing = bearing != cameraPosition.bearing;
+    if (isTrackingBearing && isNewBearing) {
+      cameraPositionBuilder.bearing(bearing);
+    }
+  }
+
+  private void addTarget(CameraPosition cameraPosition, CameraPosition.Builder cameraPositionBuilder) {
+    boolean isValidTarget = target != null;
+    if (isValidTarget && isLocationTracking() && !target.equals(cameraPosition.target)) {
+      cameraPositionBuilder.target(target);
+    }
+  }
+
+  private void refreshWithCurrentCameraPosition() {
+    target = mapboxMap.getCameraPosition().target;
+    bearing = (float) mapboxMap.getCameraPosition().bearing;
+  }
+
+  private void updateRefreshRunnableWith(@CameraMode.Mode int cameraMode) {
+    if (cameraMode == CameraMode.NONE) {
+      refreshPluginRunnable.cancel();
+    } else {
+      refreshPluginRunnable.run();
+    }
+  }
+
   private void adjustGesturesThresholds() {
     if (isLocationTracking()) {
       adjustFocalPoint = true;
@@ -137,19 +205,12 @@ final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValu
     }
   }
 
-  private boolean isLocationTracking() {
-    return cameraMode == CameraMode.TRACKING
-      || cameraMode == CameraMode.TRACKING_COMPASS
-      || cameraMode == CameraMode.TRACKING_GPS
-      || cameraMode == CameraMode.TRACKING_GPS_NORTH;
-  }
-
-  private boolean isBearingTracking() {
-    return cameraMode == CameraMode.NONE_COMPASS
-      || cameraMode == CameraMode.TRACKING_COMPASS
-      || cameraMode == CameraMode.NONE_GPS
-      || cameraMode == CameraMode.TRACKING_GPS
-      || cameraMode == CameraMode.TRACKING_GPS_NORTH;
+  private void adjustFocalPoint(LatLng latLng) {
+    if (adjustFocalPoint) {
+      PointF focalPoint = mapboxMap.getProjection().toScreenLocation(latLng);
+      mapboxMap.getUiSettings().setFocalPoint(focalPoint);
+      adjustFocalPoint = false;
+    }
   }
 
   private void notifyCameraTrackingChangeListener(boolean wasTracking) {
@@ -160,74 +221,10 @@ final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValu
     }
   }
 
-  private MapboxMap.OnMoveListener onMoveListener = new MapboxMap.OnMoveListener() {
-    private boolean interrupt;
-
-    @Override
-    public void onMoveBegin(MoveGestureDetector detector) {
-      if (detector.getPointersCount() > 1
-        && detector.getMoveThreshold() != options.trackingMultiFingerMoveThreshold()
-        && isLocationTracking()) {
-        detector.setMoveThreshold(options.trackingMultiFingerMoveThreshold());
-        interrupt = true;
-      }
-    }
-
-    @Override
-    public void onMove(MoveGestureDetector detector) {
-      if (interrupt) {
-        detector.interrupt();
-        return;
-      }
-
-      setCameraMode(CameraMode.NONE);
-    }
-
-    @Override
-    public void onMoveEnd(MoveGestureDetector detector) {
-      if (!interrupt && isLocationTracking()) {
-        moveGestureDetector.setMoveThreshold(options.trackingInitialMoveThreshold());
-      }
-      interrupt = false;
-    }
-  };
-
-  private MapboxMap.OnRotateListener onRotateListener = new MapboxMap.OnRotateListener() {
-    @Override
-    public void onRotateBegin(RotateGestureDetector detector) {
-      if (isBearingTracking()) {
-        setCameraMode(CameraMode.NONE);
-      }
-    }
-
-    @Override
-    public void onRotate(RotateGestureDetector detector) {
-      // no implementation
-    }
-
-    @Override
-    public void onRotateEnd(RotateGestureDetector detector) {
-      // no implementation
-    }
-  };
-
   private class PluginsGesturesManager extends AndroidGesturesManager {
 
-    public PluginsGesturesManager(Context context) {
+    PluginsGesturesManager(Context context) {
       super(context);
-    }
-
-    public PluginsGesturesManager(Context context, boolean applyDefaultThresholds) {
-      super(context, applyDefaultThresholds);
-    }
-
-    public PluginsGesturesManager(Context context, Set<Integer>[] exclusiveGestures) {
-      super(context, exclusiveGestures);
-    }
-
-    public PluginsGesturesManager(Context context, List<Set<Integer>> exclusiveGestures,
-                                  boolean applyDefaultThresholds) {
-      super(context, exclusiveGestures, applyDefaultThresholds);
     }
 
     @Override

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptions.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptions.java
@@ -75,6 +75,11 @@ public abstract class LocationLayerOptions implements Parcelable {
   private static final long STALE_STATE_DELAY_MS = 30000;
 
   /**
+   * By default, the location layer and camera will update at 60/fps
+   */
+  private static final double REFRESH_INTERVAL_IN_MILLIS_DEFAULT = 16.67;
+
+  /**
    * Construct a new Location Layer Options class using the attributes found within a style
    * resource. It's important to note that you only need to define the attributes you plan to
    * change and can safely ignore the other attributes which will be set to their default value.
@@ -220,7 +225,8 @@ public abstract class LocationLayerOptions implements Parcelable {
       .minZoom(MIN_ZOOM_DEFAULT)
       .maxZoomIconScale(MAX_ZOOM_ICON_SCALE_DEFAULT)
       .minZoomIconScale(MIN_ZOOM_ICON_SCALE_DEFAULT)
-      .padding(PADDING_DEFAULT);
+      .padding(PADDING_DEFAULT)
+      .refreshIntervalInMillis(REFRESH_INTERVAL_IN_MILLIS_DEFAULT);
   }
 
   /**
@@ -548,6 +554,15 @@ public abstract class LocationLayerOptions implements Parcelable {
    * @since 0.5.0
    */
   public abstract float trackingMultiFingerMoveThreshold();
+
+  /**
+   * Determines how often the {@link LocationLayer} and {@link LocationLayerCamera}
+   * will update.  By default this is set to 60 frames per second.
+   *
+   * @return refresh interval in milliseconds
+   * @since 0.6.0
+   */
+  public abstract double refreshIntervalInMillis();
 
   /**
    * Builder class for constructing a new instance of {@link LocationLayerOptions}.
@@ -890,6 +905,15 @@ public abstract class LocationLayerOptions implements Parcelable {
      * @since 0.5.0
      */
     public abstract Builder trackingMultiFingerMoveThreshold(float moveThreshold);
+
+    /**
+     * Determines how often the {@link LocationLayer} and {@link LocationLayerCamera}
+     * will update.  By default this is set to 60 frames per second.
+     *
+     * @param refreshIntervalInMillis interval in milliseconds
+     * @since 0.6.0
+     */
+    public abstract Builder refreshIntervalInMillis(double refreshIntervalInMillis);
 
     abstract LocationLayerOptions autoBuild();
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -47,7 +47,7 @@ import static com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerConstants.
  * display a larger icon (customized with {@link LocationLayerOptions#gpsDrawable()}) we call the user puck.
  * <p>
  * This plugin also offers the ability to set a map camera behavior for tracking the user
- * location. These different {@link CameraMode}s will track, stop tracking the location based on the
+ * location. These different {@link CameraMode}s will track or cancel tracking the location based on the
  * mode set with {@link LocationLayerPlugin#setCameraMode(int)}.
  * <p>
  * Lastly, {@link LocationLayerPlugin#setLocationLayerEnabled(boolean)} can be used
@@ -645,6 +645,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
       staleStateManager.onStart();
     }
     compassManager.onStart();
+    locationLayerCamera.onStart();
   }
 
   void onLocationLayerStop() {
@@ -656,6 +657,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     locationLayer.hide();
     staleStateManager.onStop();
     compassManager.onStop();
+    locationLayerCamera.onStop();
     pluginAnimatorCoordinator.cancelAllAnimations();
     if (locationEngine != null) {
       locationEngine.removeLocationEngineListener(locationEngineListener);
@@ -675,8 +677,10 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     mapboxMap.addOnMapLongClickListener(onMapLongClickListener);
 
     locationLayer = new LocationLayer(mapView, mapboxMap, options);
-    locationLayerCamera = new LocationLayerCamera(
-      mapView.getContext(), mapboxMap, cameraTrackingChangedListener, options, onCameraMoveInvalidateListener);
+
+    locationLayerCamera = new LocationLayerCamera(mapView.getContext(),
+      cameraTrackingChangedListener, onCameraMoveInvalidateListener, mapboxMap, options);
+
     pluginAnimatorCoordinator = new PluginAnimatorCoordinator();
     pluginAnimatorCoordinator.addLayerListener(locationLayer);
     pluginAnimatorCoordinator.addCameraListener(locationLayerCamera);
@@ -842,7 +846,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
         onLocationLayerStop();
       } else if (change == MapView.DID_FINISH_LOADING_STYLE) {
         locationLayer.initializeComponents(options);
-        locationLayerCamera.initializeOptions(options);
+        locationLayerCamera.updateOptions(options);
         onLocationLayerStart();
       }
     }

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/RefreshPluginRunnable.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/RefreshPluginRunnable.java
@@ -1,0 +1,36 @@
+package com.mapbox.mapboxsdk.plugins.locationlayer;
+
+import android.os.Handler;
+
+class RefreshPluginRunnable implements Runnable {
+
+  private final Handler handler = new Handler();
+  private RefreshPluginListener listener;
+  private double refreshIntervalMillis;
+
+  RefreshPluginRunnable(double refreshIntervalMillis) {
+    this.refreshIntervalMillis = refreshIntervalMillis;
+  }
+
+  @Override
+  public void run() {
+    listener.onShouldRefresh();
+    handler.postDelayed(this, (long) refreshIntervalMillis);
+  }
+
+  void cancel() {
+    handler.removeCallbacksAndMessages(null);
+  }
+
+  void setListener(RefreshPluginListener listener) {
+    this.listener = listener;
+  }
+
+  void updateRefreshInterval(double refreshIntervalMillis) {
+    this.refreshIntervalMillis = refreshIntervalMillis;
+  }
+
+  interface RefreshPluginListener {
+    void onShouldRefresh();
+  }
+}

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/modes/CameraMode.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/modes/CameraMode.java
@@ -7,6 +7,8 @@ import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Contains the variety of camera modes which determine how the camera will track
@@ -81,4 +83,57 @@ public final class CameraMode {
    * @since 0.5.0
    */
   public static final int TRACKING_GPS_NORTH = 0x00000024;
+
+  /**
+   * Set of camera modes that are tracking user location.
+   *
+   * @since 0.6.0
+   */
+  public static final Set<Integer> TRACKING_LOCATION = new HashSet<Integer>() {
+    {
+      add(CameraMode.TRACKING_COMPASS);
+      add(CameraMode.TRACKING_GPS);
+      add(CameraMode.TRACKING);
+      add(CameraMode.TRACKING_GPS_NORTH);
+    }
+  };
+
+  /**
+   * Set of camera modes that are tracking user bearing.
+   *
+   * @since 0.6.0
+   */
+  public static final Set<Integer> TRACKING_BEARING = new HashSet<Integer>() {
+    {
+      add(CameraMode.NONE_COMPASS);
+      add(CameraMode.TRACKING_COMPASS);
+      add(CameraMode.NONE_GPS);
+      add(CameraMode.TRACKING_GPS);
+      add(CameraMode.TRACKING_GPS_NORTH);
+    }
+  };
+
+  /**
+   * Set of camera modes that are tracking compass bearing.
+   *
+   * @since 0.6.0
+   */
+  public static final Set<Integer> TRACKING_COMPASS_BEARING = new HashSet<Integer>() {
+    {
+      add(CameraMode.TRACKING_COMPASS);
+      add(CameraMode.NONE_COMPASS);
+    }
+  };
+
+  /**
+   * Set of camera modes that are tracking gps bearing.
+   *
+   * @since 0.6.0
+   */
+  public static final Set<Integer> TRACKING_GPS_BEARING = new HashSet<Integer>() {
+    {
+      add(CameraMode.TRACKING_GPS);
+      add(CameraMode.NONE_GPS);
+    }
+  };
 }


### PR DESCRIPTION
Closes #394 

This PR seeks to update the `MapboxMap` camera `float` bearing and `LatLng` target at the same time.  It also introduces a `LocationLayerOption#refreshIntervalInMillis()` to allow customization of how often you'd like the camera to update.  

@LukasPaczos @tobrun if this approach seems okay, I can use the same runnable with the layer, so both the camera and layer updates will reflect the interval provided by the options. 

TODO:
- [x] Updated docs