### PR TITLE
Allow pre-loaded MapboxMap images / maki icons in LocationLayerOptions

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/MapboxTestingUtils.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/MapboxTestingUtils.kt
@@ -1,5 +1,9 @@
 package com.mapbox.mapboxsdk.plugins.utils
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.os.Handler
 import android.os.Looper
 import com.mapbox.geojson.Feature
@@ -49,4 +53,19 @@ class MapboxTestingUtils {
       }
     }
   }
+}
+
+fun MapboxMap.addImageFromDrawable(string: String, drawable: Drawable) {
+  val bitmapFromDrawable = getBitmapFromDrawable(drawable)
+  this.addImage(string, bitmapFromDrawable)
+}
+
+private fun getBitmapFromDrawable(drawable: Drawable): Bitmap {
+  if (drawable is BitmapDrawable) return drawable.bitmap
+  val bitmap = Bitmap.createBitmap(drawable.intrinsicWidth,
+      drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+  val canvas = Canvas(bitmap)
+  drawable.setBounds(0, 0, canvas.width, canvas.height)
+  drawable.draw(canvas)
+  return bitmap
 }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/MapboxTestingUtils.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/MapboxTestingUtils.kt
@@ -4,15 +4,23 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.location.Location
 import android.os.Handler
 import android.os.Looper
 import com.mapbox.geojson.Feature
+import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.style.layers.Property
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 
 fun MapboxMap.querySourceFeatures(sourceId: String): List<Feature> {
   return this.getSourceAs<GeoJsonSource>(sourceId)?.querySourceFeatures(null) as List<Feature>
+}
+
+fun MapboxMap.queryRenderedFeatures(location: Location, layerId: String): List<Feature> {
+  val latLng = LatLng(location.latitude, location.longitude)
+  val point = this.projection.toScreenLocation(latLng)
+  return this.queryRenderedFeatures(point, layerId)
 }
 
 fun MapboxMap.isLayerVisible(layerId: String): Boolean {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
     <item name="mapbox_foregroundDrawable">@drawable/custom_user_icon</item>
 
     <item name="mapbox_bearingDrawable">@drawable/custom_user_arrow</item>
-    <item name="mapbox_navigationDrawable">@drawable/custom_user_puck_icon</item>
+    <item name="mapbox_gpsDrawable">@drawable/custom_user_puck_icon</item>
 
     <item name="mapbox_accuracyAlpha">0.15</item>
     <item name="mapbox_accuracyColor">#FF82C6</item>

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
@@ -26,6 +26,11 @@ final class LocationLayerConstants {
   static final String PROPERTY_ACCURACY_ALPHA = "mapbox-property-accuracy-alpha";
   static final String PROPERTY_FOREGROUND_ICON_OFFSET = "mapbox-property-foreground-icon-offset";
   static final String PROPERTY_SHADOW_ICON_OFFSET = "mapbox-property-shadow-icon-offset";
+  static final String PROPERTY_FOREGROUND_ICON = "mapbox-property-foreground-icon";
+  static final String PROPERTY_BACKGROUND_ICON = "mapbox-property-background-icon";
+  static final String PROPERTY_FOREGROUND_STALE_ICON = "mapbox-property-foreground-stale-icon";
+  static final String PROPERTY_BACKGROUND_STALE_ICON = "mapbox-property-background-stale-icon";
+  static final String PROPERTY_BEARING_ICON = "mapbox-property-shadow-icon";
 
   // Layers
   static final String SHADOW_LAYER = "mapbox-location-shadow";

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptions.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerOptions.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.plugins.locationlayer;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Bitmap;
 import android.os.Parcelable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.Dimension;
@@ -131,7 +132,7 @@ public abstract class LocationLayerOptions implements Parcelable {
         R.styleable.mapbox_LocationLayer_mapbox_staleStateTimeout, (int) STALE_STATE_DELAY_MS));
     }
     builder.gpsDrawable(typedArray.getResourceId(
-      R.styleable.mapbox_LocationLayer_mapbox_navigationDrawable, -1));
+      R.styleable.mapbox_LocationLayer_mapbox_gpsDrawable, -1));
     float elevation = typedArray.getDimension(
       R.styleable.mapbox_LocationLayer_mapbox_elevation, 0);
     builder.accuracyColor(typedArray.getColor(
@@ -253,6 +254,21 @@ public abstract class LocationLayerOptions implements Parcelable {
   public abstract int backgroundDrawableStale();
 
   /**
+   * String image name, identical to one used in
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * plugin, will used this image in place of the provided or default mapbox_foregroundDrawableStale.
+   * <p>
+   * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+   * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+   * </p>
+   *
+   * @return String icon or maki-icon name
+   * @since 0.6.0
+   */
+  @Nullable
+  public abstract String backgroundStaleName();
+
+  /**
    * Defines the drawable used for the stale foreground icon.
    *
    * @return the drawable resource ID
@@ -263,14 +279,44 @@ public abstract class LocationLayerOptions implements Parcelable {
   public abstract int foregroundDrawableStale();
 
   /**
+   * String image name, identical to one used in
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * plugin, will used this image in place of the provided or default mapbox_foregroundDrawableStale.
+   * <p>
+   * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+   * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+   * </p>
+   *
+   * @return String icon or maki-icon name
+   * @since 0.6.0
+   */
+  @Nullable
+  public abstract String foregroundStaleName();
+
+  /**
    * Defines the drawable used for the navigation state icon.
    *
    * @return the drawable resource ID
-   * @attr ref R.styleable#LocationLayer_navigationDrawable
+   * @attr ref R.styleable#LocationLayer_gpsDrawable
    * @since 0.4.0
    */
   @DrawableRes
   public abstract int gpsDrawable();
+
+  /**
+   * String image name, identical to one used in
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * plugin, will used this image in place of the provided or default mapbox_gpsDrawable.
+   * <p>
+   * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+   * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+   * </p>
+   *
+   * @return String icon or maki-icon name
+   * @since 0.6.0
+   */
+  @Nullable
+  public abstract String gpsName();
 
   /**
    * Supply a Drawable that is to be rendered on top of all of the content in the Location Layer
@@ -284,6 +330,21 @@ public abstract class LocationLayerOptions implements Parcelable {
   public abstract int foregroundDrawable();
 
   /**
+   * String image name, identical to one used in
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * plugin, will used this image in place of the provided or default mapbox_foregroundDrawable.
+   * <p>
+   * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+   * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+   * </p>
+   *
+   * @return String icon or maki-icon name
+   * @since 0.6.0
+   */
+  @Nullable
+  public abstract String foregroundName();
+
+  /**
    * Defines the drawable used for the background state icon.
    *
    * @return the drawable resource ID
@@ -294,6 +355,21 @@ public abstract class LocationLayerOptions implements Parcelable {
   public abstract int backgroundDrawable();
 
   /**
+   * String image name, identical to one used in
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * plugin, will used this image in place of the provided or default mapbox_backgroundDrawable.
+   * <p>
+   * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+   * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+   * </p>
+   *
+   * @return String icon or maki-icon name
+   * @since 0.6.0
+   */
+  @Nullable
+  public abstract String backgroundName();
+
+  /**
    * Defines the drawable used for the bearing icon.
    *
    * @return the drawable resource ID
@@ -302,6 +378,21 @@ public abstract class LocationLayerOptions implements Parcelable {
    */
   @DrawableRes
   public abstract int bearingDrawable();
+
+  /**
+   * String image name, identical to one used in
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * plugin, will used this image in place of the provided or default mapbox_bearingDrawable.
+   * <p>
+   * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+   * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+   * </p>
+   *
+   * @return String icon or maki-icon name
+   * @since 0.6.0
+   */
+  @Nullable
+  public abstract String bearingName();
 
   /**
    * Defines the bearing icon color as an integer.
@@ -498,6 +589,21 @@ public abstract class LocationLayerOptions implements Parcelable {
     public abstract Builder foregroundDrawableStale(@DrawableRes int foregroundDrawableStale);
 
     /**
+     * Given a String image name, identical to one used in
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * plugin, will used this image in place of the provided or default mapbox_foregroundDrawableStale.
+     * <p>
+     * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+     * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+     * </p>
+     *
+     * @param foregroundStaleName String icon or maki-icon name
+     * @return this builder for chaining options together
+     * @since 0.6.0
+     */
+    public abstract Builder foregroundStaleName(@Nullable String foregroundStaleName);
+
+    /**
      * Defines the foreground stale color as an integer.
      *
      * @param foregroundStaleTintColor the color integer resource
@@ -518,6 +624,21 @@ public abstract class LocationLayerOptions implements Parcelable {
     public abstract Builder backgroundDrawableStale(@DrawableRes int backgroundDrawableStale);
 
     /**
+     * Given a String image name, identical to one used in
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * plugin, will used this image in place of the provided or default mapbox_backgroundDrawableStale.
+     * <p>
+     * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+     * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+     * </p>
+     *
+     * @param backgroundStaleName String icon or maki-icon name
+     * @return this builder for chaining options together
+     * @since 0.6.0
+     */
+    public abstract Builder backgroundStaleName(@Nullable String backgroundStaleName);
+
+    /**
      * Defines the background stale color as an integer.
      *
      * @param backgroundStaleTintColor the color integer resource
@@ -532,10 +653,25 @@ public abstract class LocationLayerOptions implements Parcelable {
      *
      * @param gpsDrawable the drawable resource ID
      * @return this builder for chaining options together
-     * @attr ref R.styleable#LocationLayer_navigationDrawable
+     * @attr ref R.styleable#LocationLayer_gpsDrawable
      * @since 0.4.0
      */
     public abstract Builder gpsDrawable(@DrawableRes int gpsDrawable);
+
+    /**
+     * Given a String image name, identical to one used in
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * plugin, will used this image in place of the provided or default mapbox_gpsDrawable.
+     * <p>
+     * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+     * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+     * </p>
+     *
+     * @param gpsName String icon or maki-icon name
+     * @return this builder for chaining options together
+     * @since 0.6.0
+     */
+    public abstract Builder gpsName(@Nullable String gpsName);
 
     /**
      * Supply a Drawable that is to be rendered on top of all of the content in the Location Layer
@@ -549,6 +685,21 @@ public abstract class LocationLayerOptions implements Parcelable {
     public abstract Builder foregroundDrawable(@DrawableRes int foregroundDrawable);
 
     /**
+     * Given a String image name, identical to one used in
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * plugin, will used this image in place of the provided or default mapbox_foregroundDrawable.
+     * <p>
+     * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+     * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+     * </p>
+     *
+     * @param foregroundName String icon or maki-icon name
+     * @return this builder for chaining options together
+     * @since 0.6.0
+     */
+    public abstract Builder foregroundName(@Nullable String foregroundName);
+
+    /**
      * Defines the drawable used for the background state icon.
      *
      * @param backgroundDrawable the drawable resource ID
@@ -559,6 +710,21 @@ public abstract class LocationLayerOptions implements Parcelable {
     public abstract Builder backgroundDrawable(@DrawableRes int backgroundDrawable);
 
     /**
+     * Given a String image name, identical to one used in
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * plugin, will used this image in place of the provided or default mapbox_backgroundDrawable.
+     * <p>
+     * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+     * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+     * </p>
+     *
+     * @param backgroundName String icon or maki-icon name
+     * @return this builder for chaining options together
+     * @since 0.6.0
+     */
+    public abstract Builder backgroundName(@Nullable String backgroundName);
+
+    /**
      * Defines the drawable used for the bearing icon.
      *
      * @param bearingDrawable the drawable resource ID
@@ -567,6 +733,21 @@ public abstract class LocationLayerOptions implements Parcelable {
      * @since 0.4.0
      */
     public abstract Builder bearingDrawable(@DrawableRes int bearingDrawable);
+
+    /**
+     * Given a String image name, identical to one used in
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * plugin, will used this image in place of the provided or default mapbox_bearingDrawable.
+     * <p>
+     * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
+     * with certain styles.  Note, this will fail if the provided icon name is not provided by the loaded map style.
+     * </p>
+     *
+     * @param bearingName String icon or maki-icon name
+     * @return this builder for chaining options together
+     * @since 0.6.0
+     */
+    public abstract Builder bearingName(@Nullable String bearingName);
 
     /**
      * Defines the bearing icon color as an integer.

--- a/plugin-locationlayer/src/main/res/values/attrs.xml
+++ b/plugin-locationlayer/src/main/res/values/attrs.xml
@@ -8,7 +8,7 @@
     <attr name="mapbox_backgroundTintColor" format="color"/>
     <attr name="mapbox_bearingDrawable" format="reference"/>
     <attr name="mapbox_bearingTintColor" format="color"/>
-    <attr name="mapbox_navigationDrawable" format="reference"/>
+    <attr name="mapbox_gpsDrawable" format="reference"/>
 
     <attr name="mapbox_foregroundDrawableStale" format="reference"/>
     <attr name="mapbox_foregroundStaleTintColor" format="color"/>

--- a/plugin-locationlayer/src/main/res/values/styles.xml
+++ b/plugin-locationlayer/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
     <item name="mapbox_foregroundDrawable">@drawable/mapbox_user_icon</item>
     <item name="mapbox_backgroundDrawable">@drawable/mapbox_user_stroke_icon</item>
     <item name="mapbox_bearingDrawable">@drawable/mapbox_user_bearing_icon</item>
-    <item name="mapbox_navigationDrawable">@drawable/mapbox_user_puck_icon</item>
+    <item name="mapbox_gpsDrawable">@drawable/mapbox_user_puck_icon</item>
 
     <item name="mapbox_foregroundDrawableStale">@drawable/mapbox_user_icon_stale</item>
     <item name="mapbox_backgroundDrawableStale">@drawable/mapbox_user_stroke_icon</item>


### PR DESCRIPTION
Closes #486 

This PR introduces options to use `String` names for icons that have already been added to the `MapboxMap` with `MapboxMap#addImage`.  Developers may also provide names for [Maki icons](https://www.mapbox.com/maki-icons/) that are already loaded in their given style. 

![device-2018-07-05-155217](https://user-images.githubusercontent.com/8434572/42347689-a4ff794e-8074-11e8-939c-e698c43c794f.png)
