### PR TITLE
Adding japanese and korean support to localization plugin

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/LocalizationActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/LocalizationActivity.java
@@ -164,6 +164,12 @@ public class LocalizationActivity extends AppCompatActivity implements OnMapRead
       case R.id.arabic:
         localizationPlugin.setMapLanguage(MapLocale.ARABIC);
         return true;
+      case R.id.japanese:
+        localizationPlugin.setMapLanguage(MapLocale.JAPANESE);
+        return true;
+      case R.id.korean:
+        localizationPlugin.setMapLanguage(MapLocale.KOREAN);
+        return true;
       case android.R.id.home:
         finish();
         return true;

--- a/app/src/main/res/menu/menu_languages.xml
+++ b/app/src/main/res/menu/menu_languages.xml
@@ -48,5 +48,14 @@
         android:title="Arabic"
         app:showAsAction="never"/>
 
+    <item
+        android:id="@+id/japanese"
+        android:title="Japanese"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/korean"
+        android:title="Korean"
+        app:showAsAction="never"/>
 
 </menu>

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -121,36 +121,42 @@ public final class MapLocale {
    * UK Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds UK_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(59.360249, -8.623555))
     .include(new LatLng(49.906193, 1.759)).build();
 
   /**
    * Canada Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds CANADA_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(83.110626, -141.0))
     .include(new LatLng(41.67598, -52.636291)).build();
 
   /**
    * China Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds CHINA_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(53.56086, 73.557693))
     .include(new LatLng(15.775416, 134.773911)).build();
 
   /**
    * Germany Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds GERMANY_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(55.055637, 5.865639))
     .include(new LatLng(47.275776, 15.039889)).build();
 
   /**
    * Korea Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds KOREA_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(38.612446, 125.887108))
     .include(new LatLng(33.190945, 129.584671)).build();
 
   /**
    * Japan Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds JAPAN_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(45.52314, 122.93853))
     .include(new LatLng(24.249472, 145.820892)).build();
 
   /**
@@ -163,12 +169,14 @@ public final class MapLocale {
    * Italy Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds ITALY_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(47.095196, 6.614889))
     .include(new LatLng(36.652779, 18.513445)).build();
 
   /**
    * Peoples Republic of China Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds PRC_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(53.56086, 73.557693))
     .include(new LatLng(15.775416, 134.773911)).build();
 
   /*

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -90,9 +90,19 @@ public final class MapLocale {
    */
   public static final String SIMPLIFIED_CHINESE = "name_zh-Hans";
 
+  /**
+   * Japanese (if available, otherwise same as name)
+   */
+  public static final String JAPANESE = "name_ja";
+
+  /**
+   * Korean (if available, otherwise same as name)
+   */
+  public static final String KOREAN = "name_ko";
+
   @Retention(SOURCE)
-  @StringDef( {LOCAL_NAME, ENGLISH, FRENCH, SIMPLIFIED_CHINESE, ARABIC, SPANISH, GERMAN, PORTUGUESE,
-    RUSSIAN, CHINESE})
+  @StringDef({LOCAL_NAME, ENGLISH, FRENCH, SIMPLIFIED_CHINESE, ARABIC, SPANISH, GERMAN, PORTUGUESE,
+      RUSSIAN, CHINESE, JAPANESE, KOREAN})
   public @interface Languages {
   }
 
@@ -111,63 +121,54 @@ public final class MapLocale {
    * UK Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds UK_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(59.360249, -8.623555))
     .include(new LatLng(49.906193, 1.759)).build();
 
   /**
    * Canada Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds CANADA_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(83.110626, -141.0))
     .include(new LatLng(41.67598, -52.636291)).build();
 
   /**
    * China Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds CHINA_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(53.56086, 73.557693))
     .include(new LatLng(15.775416, 134.773911)).build();
 
   /**
    * Germany Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds GERMANY_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(55.055637, 5.865639))
     .include(new LatLng(47.275776, 15.039889)).build();
 
   /**
    * Korea Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds KOREA_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(38.612446, 125.887108))
     .include(new LatLng(33.190945, 129.584671)).build();
 
   /**
    * Japan Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds JAPAN_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(45.52314, 122.93853))
     .include(new LatLng(24.249472, 145.820892)).build();
 
   /**
    * France Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds FRANCE_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(51.092804, -5.142222))
     .include(new LatLng(41.371582, 9.561556)).build();
 
   /**
    * Italy Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds ITALY_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(47.095196, 6.614889))
     .include(new LatLng(36.652779, 18.513445)).build();
 
   /**
    * Peoples Republic of China Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds PRC_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(53.56086, 73.557693))
     .include(new LatLng(15.775416, 134.773911)).build();
 
   /*

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -163,6 +163,7 @@ public final class MapLocale {
    * France Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds FRANCE_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(51.092804, -5.142222))
     .include(new LatLng(41.371582, 9.561556)).build();
 
   /**


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/566 by adding support for Korean and Japanese

Related /ref mapbox/vector-tiles#54 mapbox/mapbox-gl-language#21 mapbox/mapbox-gl-native#12283


@1ec5 , not sure when the next release of this plugin will be. These changes will at least be exposed through SNAPSHOT when this pr is merged. cc @zugaldia for fyi.

![ezgif com-optimize](https://user-images.githubusercontent.com/4394910/42354066-1855d1be-8079-11e8-9ec9-d5c4c3c3bc0b.gif)


