### PR TITLE
Fix for disappearing places picker marker

### DIFF
--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/PlacePickerActivity.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/PlacePickerActivity.java
@@ -143,7 +143,7 @@ public class PlacePickerActivity extends AppCompatActivity implements OnMapReady
   @Override
   public void onCameraIdle() {
     Timber.v("Map camera is now idling.");
-    markerImage.animate().translationY(Math.abs(mapView.getY() / 2))
+    markerImage.animate().translationY(0)
       .setInterpolator(new OvershootInterpolator()).setDuration(250).start();
     bottomSheet.setPlaceDetails(null);
     makeReverseGeocodingSearch();


### PR DESCRIPTION
@tobrun @LukasPaczos 

Resolves #529 by fixing the floating marker in the place picker functionality of the places plugin.  In my opinion, this bug renders the picker essentially unusable.

If you share my slight concern that`mapView.getY() / 2` isn't the most performant fix, given that it happens every time that `onCameraIdle()` fires, I'm happy to hear other ideas for fixing.


![ezgif com-optimize](https://user-images.githubusercontent.com/4394910/42852569-1cc2295c-89e6-11e8-981c-6de0b828ad28.gif)


