### PR TITLE
Add getter and setter for CompassEngine interface

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPluginTest.kt
@@ -40,6 +40,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import org.hamcrest.CoreMatchers.*
 import org.junit.*
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.rules.TestName
 import org.junit.runner.RunWith
 import timber.log.Timber
@@ -1056,6 +1057,18 @@ class LocationLayerPluginTest {
         assertEquals(location.bearing.toDouble(), mapboxMap.cameraPosition.bearing, 0.1)
         assertEquals(location.latitude, mapboxMap.cameraPosition.target.latitude, 0.1)
         assertEquals(location.longitude, mapboxMap.cameraPosition.target.longitude, 0.1)
+      }
+    }
+
+    executePluginTest(pluginAction, PluginGenerationUtil.getLocationLayerPluginProvider(activityRule.activity))
+  }
+
+  @Test
+  fun onPluginInitialized_defaultCompassEngineIsProvided() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocationLayerPlugin> {
+      override fun onGenericPluginAction(plugin: LocationLayerPlugin, mapboxMap: MapboxMap,
+                                         uiController: UiController, context: Context) {
+        assertTrue(plugin.compassEngine is LocationLayerCompassEngine)
       }
     }
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/CompassEngine.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/CompassEngine.java
@@ -1,0 +1,62 @@
+package com.mapbox.mapboxsdk.plugins.locationlayer;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Interface defining the source of compass heading data that is
+ * consumed by the {@link LocationLayerPlugin} when in compass related
+ * {@link com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode} or
+ * {@link com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode}s.
+ */
+public interface CompassEngine {
+
+  /**
+   * Adds a {@link CompassListener} that can be used to
+   * receive heading and state changes.
+   *
+   * @param compassListener to be added
+   */
+  void addCompassListener(@NonNull CompassListener compassListener);
+
+  /**
+   * Removes a {@link CompassListener} that can be used to
+   * receive heading and state changes.
+   *
+   * @param compassListener to be removed
+   */
+  void removeCompassListener(@NonNull CompassListener compassListener);
+
+  /**
+   * Returns the last heading value produced and pushed via
+   * a compass listener.
+   *
+   * @return last heading value
+   */
+  float getLastHeading();
+
+  /**
+   * Provides the last know accuracy status from the sensor manager.
+   * <p>
+   * An integer value which is identical to the {@code SensorManager} class constants:
+   * <ul>
+   * <li>{@link android.hardware.SensorManager#SENSOR_STATUS_NO_CONTACT}</li>
+   * <li>{@link android.hardware.SensorManager#SENSOR_STATUS_UNRELIABLE}</li>
+   * <li>{@link android.hardware.SensorManager#SENSOR_STATUS_ACCURACY_LOW}</li>
+   * <li>{@link android.hardware.SensorManager#SENSOR_STATUS_ACCURACY_MEDIUM}</li>
+   * <li>{@link android.hardware.SensorManager#SENSOR_STATUS_ACCURACY_HIGH}</li>
+   * </ul>
+   *
+   * @return last accuracy status
+   */
+  int getLastAccuracySensorStatus();
+
+  /**
+   * Lifecycle method that can be used for adding or releasing resources.
+   */
+  void onStart();
+
+  /**
+   * Lifecycle method that can be used for adding or releasing resources.
+   */
+  void onStop();
+}

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCompassEngine.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCompassEngine.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
  *
  * @since 0.1.0
  */
-class CompassManager implements SensorEventListener {
+class LocationLayerCompassEngine implements CompassEngine, SensorEventListener {
 
   // The rate sensor events will be delivered at. As the Android documentation states, this is only
   // a hint to the system and the events might actually be received faster or slower then this
@@ -58,7 +58,7 @@ class CompassManager implements SensorEventListener {
    * Construct a new instance of the this class. A internal compass listeners needed to separate it
    * from the cleared list of public listeners.
    */
-  CompassManager(WindowManager windowManager, SensorManager sensorManager) {
+  LocationLayerCompassEngine(WindowManager windowManager, SensorManager sensorManager) {
     this.windowManager = windowManager;
     this.sensorManager = sensorManager;
     compassSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR);
@@ -74,33 +74,39 @@ class CompassManager implements SensorEventListener {
     }
   }
 
-  void addCompassListener(@NonNull CompassListener compassListener) {
+  @Override
+  public void addCompassListener(@NonNull CompassListener compassListener) {
     if (compassListeners.isEmpty()) {
       onStart();
     }
     compassListeners.add(compassListener);
   }
 
-  void removeCompassListener(@NonNull CompassListener compassListener) {
+  @Override
+  public void removeCompassListener(@NonNull CompassListener compassListener) {
     compassListeners.remove(compassListener);
     if (compassListeners.isEmpty()) {
       onStop();
     }
   }
 
-  int getLastAccuracySensorStatus() {
+  @Override
+  public int getLastAccuracySensorStatus() {
     return lastAccuracySensorStatus;
   }
 
-  float getLastHeading() {
+  @Override
+  public float getLastHeading() {
     return lastHeading;
   }
 
-  void onStart() {
+  @Override
+  public void onStart() {
     registerSensorListeners();
   }
 
-  void onStop() {
+  @Override
+  public void onStop() {
     unregisterSensorListeners();
   }
 

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/modes/RenderMode.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/modes/RenderMode.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.plugins.locationlayer.modes;
 
 import android.support.annotation.IntDef;
 
+import com.mapbox.mapboxsdk.plugins.locationlayer.CompassEngine;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
 
 import java.lang.annotation.Retention;
@@ -39,7 +40,7 @@ public final class RenderMode {
 
   /**
    * Tracking the user location with bearing considered
-   * from a {@link com.mapbox.mapboxsdk.plugins.locationlayer.CompassManager}.
+   * from a {@link CompassEngine}.
    *
    * @since 0.1.0
    */

--- a/plugin-locationlayer/src/test/java/com/mapbox/mapboxsdk/plugins/locationlayer/CompassEngineTest.java
+++ b/plugin-locationlayer/src/test/java/com/mapbox/mapboxsdk/plugins/locationlayer/CompassEngineTest.java
@@ -17,9 +17,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CompassManagerTest {
+public class CompassEngineTest {
 
-    private CompassManager compassManager;
+    private LocationLayerCompassEngine compassEngine;
 
     @Mock
     private WindowManager windowManager;
@@ -29,26 +29,26 @@ public class CompassManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        compassManager = new CompassManager(windowManager, sensorManager);
+        compassEngine = new LocationLayerCompassEngine(windowManager, sensorManager);
     }
 
     @Test
-    public void lastKnownCompassAccuracyStatusDefault() {
-        assertEquals("Last accuracy should match", compassManager.getLastAccuracySensorStatus(), 0);
+    public void lastKnownCompassBearingAccuracyDefault() {
+        assertEquals("Last accuracy should match", compassEngine.getLastAccuracySensorStatus(), 0);
     }
 
     @Test
     public void lastKnownCompassAccuracyStatusValue() {
         Sensor sensor = mock(Sensor.class);
-        compassManager.onAccuracyChanged(sensor, 2);
-        assertEquals("Last accuracy should match", compassManager.getLastAccuracySensorStatus(), 2);
+        compassEngine.onAccuracyChanged(sensor, 2);
+        assertEquals("Last accuracy should match", compassEngine.getLastAccuracySensorStatus(), 2);
     }
 
     @Test
     public void whenGyroscopeIsNull_fallbackToGravity() {
         SensorManager sensorManager = mock(SensorManager.class);
         when(sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)).thenReturn(null);
-        new CompassManager(windowManager, sensorManager);
+        new LocationLayerCompassEngine(windowManager, sensorManager);
 
         verify(sensorManager, times(1)).getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
     }
@@ -57,7 +57,7 @@ public class CompassManagerTest {
     public void whenGyroscopeIsNull_fallbackToMagneticField() {
         SensorManager sensorManager = mock(SensorManager.class);
         when(sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)).thenReturn(null);
-        new CompassManager(windowManager, sensorManager);
+        new LocationLayerCompassEngine(windowManager, sensorManager);
 
         verify(sensorManager, times(1)).getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
     }


### PR DESCRIPTION
Closes #617 

Allows custom `CompassEngine` for generating bearing values provided to the `LocationLayerPlugin`
