### PR TITLE
Maps SDK bump to 6.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.4.0',
+      mapboxMapSdk       : '6.5.0',
       mapboxJava         : '3.2.0',
       playLocation       : '15.0.1',
       autoValue          : '1.5.4',


### PR DESCRIPTION
Part of the eventual stable 6.5.0 release of the Maps SDK for Android 