### PR TITLE
Fix LocationLayerPlugin's leaks when used in a fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,9 @@ configurations.all { config ->
 }
 
 dependencies {
+  // Kotlin
+  implementation dependenciesList.kotlin
+
   // Mapbox
   implementation dependenciesList.mapboxMapSdk
   implementation dependenciesList.mapboxGeocoding
@@ -73,7 +76,7 @@ dependencies {
   implementation dependenciesList.roomRuntime
   kapt dependenciesList.roomCompiler
 
-  // LOST
+  // Google Play Services
   implementation dependenciesList.playLocation
 
   // Support libraries
@@ -120,3 +123,4 @@ dependencies {
 
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/generate-token.gradle"
+apply plugin: 'kotlin-android-extensions'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -169,6 +169,17 @@
         android:name="android.support.PARENT_ACTIVITY"
         android:value=".activity.FeatureOverviewActivity"/>
     </activity>
+    <activity
+        android:name=".activity.location.LocationLayerFragmentActivity"
+        android:description="@string/description_location_fragment"
+        android:label="@string/title_location_fragment">
+        <meta-data
+            android:name="@string/category"
+            android:value="@string/category_location" />
+        <meta-data
+            android:name="android.support.PARENT_ACTIVITY"
+            android:value=".activity.FeatureOverviewActivity" />
+    </activity>
 
     <service
       android:name="com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadService"

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerFragmentActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/location/LocationLayerFragmentActivity.kt
@@ -1,0 +1,155 @@
+package com.mapbox.mapboxsdk.plugins.testapp.activity.location
+
+import android.app.Fragment
+import android.location.Location
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import com.mapbox.android.core.location.LocationEngineListener
+import com.mapbox.android.core.permissions.PermissionsListener
+import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin
+import com.mapbox.mapboxsdk.plugins.testapp.R
+import kotlinx.android.synthetic.main.activity_location_layer_fragment.*
+
+class LocationLayerFragmentActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_location_layer_fragment)
+
+    if (savedInstanceState == null) {
+      fragmentManager
+        .beginTransaction()
+        .replace(R.id.container, LocationLayerFragment.newInstance(), LocationLayerFragment.TAG)
+        .commit()
+    }
+
+    fab.setOnClickListener {
+      val fragment = fragmentManager.findFragmentByTag(EmptyFragment.TAG)
+      if (fragment == null) {
+        fragmentManager
+          .beginTransaction()
+          .replace(R.id.container, EmptyFragment.newInstance(), EmptyFragment.TAG)
+          .addToBackStack("transaction2")
+          .commit()
+      } else {
+        this.onBackPressed()
+      }
+    }
+    supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+    if (!PermissionsManager.areLocationPermissionsGranted(this)) {
+      val permissionsManager = PermissionsManager(object : PermissionsListener {
+        override fun onExplanationNeeded(permissionsToExplain: MutableList<String>?) {
+          // no impl
+        }
+
+        override fun onPermissionResult(granted: Boolean) {
+          if (!granted) {
+            finish()
+          }
+        }
+      })
+      permissionsManager.requestLocationPermissions(this)
+    }
+  }
+
+  class LocationLayerFragment : Fragment(), LocationEngineListener {
+    companion object {
+      const val TAG = "LLFragment"
+      fun newInstance(): LocationLayerFragment {
+        return LocationLayerFragment()
+      }
+    }
+
+    lateinit var mapView: MapView
+    lateinit var mapboxMap: MapboxMap
+    var plugin: LocationLayerPlugin? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+      mapView = MapView(inflater.context)
+      return mapView
+    }
+
+    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+      mapView.onCreate(savedInstanceState)
+      mapView.getMapAsync {
+        mapboxMap = it
+        plugin = LocationLayerPlugin(mapView, mapboxMap)
+        plugin?.locationEngine?.addLocationEngineListener(this)
+      }
+    }
+
+    override fun onLocationChanged(location: Location?) {
+      if (location != null) {
+        mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(LatLng(location), 12.0))
+        plugin?.locationEngine?.removeLocationEngineListener(this)
+      }
+    }
+
+    override fun onConnected() {
+      // no impl
+    }
+
+    override fun onStart() {
+      super.onStart()
+      mapView.onStart()
+      plugin?.onStart()
+    }
+
+    override fun onResume() {
+      super.onResume()
+      mapView.onResume()
+    }
+
+    override fun onPause() {
+      super.onPause()
+      mapView.onPause()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+      super.onSaveInstanceState(outState)
+      mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onStop() {
+      super.onStop()
+      plugin?.onStop()
+      mapView.onStop()
+    }
+
+    override fun onLowMemory() {
+      super.onLowMemory()
+      mapView.onLowMemory()
+    }
+
+    override fun onDestroyView() {
+      super.onDestroyView()
+      mapView.onDestroy()
+      plugin?.locationEngine?.removeLocationEngineListener(this)
+    }
+  }
+
+  class EmptyFragment : Fragment() {
+    companion object {
+      const val TAG = "EmptyFragment"
+      fun newInstance(): EmptyFragment {
+        return EmptyFragment()
+      }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View {
+      val textView = TextView(inflater?.context)
+      textView.text = "This is an empty Fragment"
+      return textView
+    }
+  }
+}

--- a/app/src/main/res/layout/activity_location_layer_fragment.xml
+++ b/app/src/main/res/layout/activity_location_layer_fragment.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        android:tint="@android:color/white"
+        app:backgroundTint="@color/colorAccent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:srcCompat="@drawable/ic_layers" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,3 @@
 <resources>
-  <dimen name="fab_margin">16dp</dimen>
+    <dimen name="fab_margin">16dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
   <string name="title_place_picker">Place picker</string>
   <string name="title_localization">Localization Plugin</string>
   <string name="title_offline_ui_components">Offline Ui Components</string>
+  <string name="title_location_fragment">Location Fragment</string>
 
   <!-- Descriptions -->
   <string name="description_traffic">Add Traffic layers to any Mapbox basemap.</string>
@@ -40,6 +41,7 @@
   <string name="description_place_picker">Launch the place picker activity and receive result</string>
   <string name="description_localization">Automatically localize the map labels into the device\'s set language.</string>
   <string name="description_offline_ui_components">Shows off the UI components included in the offline plugin.</string>
+  <string name="description_location_fragment">Show current location in the Fragment</string>
 
   <!-- Buttons -->
   <string name="button_location_mode_none">None</string>

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -677,19 +677,23 @@ public final class LocationLayerPlugin implements LifecycleObserver {
   }
 
   /**
-   * Required to place inside your activities {@code onStart} method. You'll also most likely want
-   * to check that this Location Layer plugin instance inside your activity is null or not.
+   * You must call this method from the parent's Activity#onStart() or Fragment#onStart()
    *
    * @since 0.1.0
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
   public void onStart() {
+    if (mapView.isDestroyed()) {
+      Timber.e("You are calling plugins #onStart after the map was destroyed. Re-create the plugin before using it.");
+      return;
+    }
+
     isPluginStarted = true;
     onLocationLayerStart();
   }
 
   /**
-   * Required to place inside your activities {@code onStop} method.
+   * You must call this method from the parent's Activity#onStop() or Fragment#onStop().
    *
    * @since 0.1.0
    */


### PR DESCRIPTION
Fixes #635.

This PR fixes the leaks when the plugin is used in a fragment by checking if the map is already destroyed and adds an example of a fragment that's using the plugin.