### PR TITLE
[LLP] prevent from showing the location layer on every location update

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayer.java
@@ -168,6 +168,10 @@ final class LocationLayer implements PluginAnimator.OnLayerAnimationsValuesChang
     }
   }
 
+  boolean isHidden() {
+    return isHidden;
+  }
+
   void updateForegroundOffset(double tilt) {
     JsonArray foregroundJsonArray = new JsonArray();
     foregroundJsonArray.add(0f);

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -830,9 +830,7 @@ public final class LocationLayerPlugin implements LifecycleObserver {
       return;
     }
 
-    if (isEnabled && isPluginStarted) {
-      locationLayer.show();
-    }
+    showLocationLayerIfHidden();
 
     if (!fromLastLocation) {
       staleStateManager.updateLatestLocationTime();
@@ -842,6 +840,13 @@ public final class LocationLayerPlugin implements LifecycleObserver {
     pluginAnimatorCoordinator.feedNewLocation(location, currentCameraPosition, isGpsNorth);
     updateAccuracyRadius(location, false);
     lastLocation = location;
+  }
+
+  private void showLocationLayerIfHidden() {
+    boolean isLocationLayerHidden = locationLayer.isHidden();
+    if (isEnabled && isPluginStarted && isLocationLayerHidden) {
+      locationLayer.show();
+    }
   }
 
   private void updateCompassHeading(float heading) {


### PR DESCRIPTION
- Prevents from showing the location layer on every location update 

Aims to fix the performance 📉 shown in https://github.com/mapbox/mapbox-navigation-android/pull/1252

I was able to reproduce in `master` 👀 

![llp_jumpy](https://user-images.githubusercontent.com/1668582/44997458-c17a7b00-afae-11e8-8769-ef017d1c3bbe.gif)

The idea is to call `locationLayer.show()` method only once (when the first valid fix is received).

Apparently, calling `show` > `setRenderMode` > `LocationLayer#styleForeground` > `generateBitmap` multiple times - especially when the `RenderMode` is `GPS` in which `generateBitmap` is called 4 times - is quite heavy and has a noticeable impact on low-end devices. This was tested on a Nexus 5 running Android 6.0

cc @danesfeder 