### PR TITLE
adjusted max line amount for test app examples' description

### DIFF
--- a/app/src/main/res/layout/item_feature.xml
+++ b/app/src/main/res/layout/item_feature.xml
@@ -29,7 +29,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
         android:alpha="0.56"
-        android:maxLines="1"
+        android:maxLines="3"
         android:textColor="@android:color/black"
         android:textSize="14sp"/>
 


### PR DESCRIPTION
The description area for each plugin test app example was at `android:maxLines="1"`, which meant that some descriptions would get cut off. Not sure if this was done on purpose or not. If not, this pr adjusts the max line to 3. For example, look at the descriptions for `Compass Listener` in the two screenshots below


**`master`**:

![before](https://user-images.githubusercontent.com/4394910/45108491-95b3de00-b0f1-11e8-8b18-c27a3831c1cc.png)

**This pr**:

![after](https://user-images.githubusercontent.com/4394910/45108490-951b4780-b0f1-11e8-8f89-7efd40470ced.png)

