### PR TITLE
Update localization plugin to support expressions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.4.0',
+      mapboxMapSdk       : '6.5.0',
       mapboxJava         : '3.2.0',
       playLocation       : '15.0.1',
       autoValue          : '1.5.4',


### PR DESCRIPTION
This PR updates our localization plugin to support expressions  (also backwards compatible with our old token syntax setup). Atm it requires a beta.1 build of the Mapbox Maps SDK for Android, as it requires https://github.com/mapbox/mapbox-gl-native/pull/12769 and https://github.com/mapbox/mapbox-gl-native/pull/12768 to be fixed upstream. We will have to hold off merging and releasing this plugin until 6.5.0 final has been released, eta 1 week. 

One issue I had with migration is that some step expression returned from core contain an invalid representation. On [this](https://github.com/mapbox/mapbox-plugins-android/compare/tvn-upgrade-local-to-expressions?expand=1#diff-1bf159640ccc4e006c457ee997362bf9R153) line I'm fixing this up by introducing an additional 0 stop output based on the current locale. This fix will not break if the issue is fixed upstream though would love to remove it at some point. 