### PR TITLE
Adding READMEs for MarkerView and Annotation plugins

### DIFF
--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -1,0 +1,61 @@
+# Mapbox annotation plugin
+
+![annotations-plugin](https://user-images.githubusercontent.com/2151639/44861322-945d5e00-ac78-11e8-8ccb-883a4a743bcf.gif)
+
+## Getting Started
+
+To use the annotation plugin you include it in your `build.gradle` file.
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation:0.1.0'
+}
+```
+
+The annotation plugin is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation:0.2.0-SNAPSHOT'
+}
+```
+
+## Annotation plugin examples
+
+- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation)
+
+## Help and Usage
+
+This repository includes an app that shows how to use each plugin in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+
+We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues) as we build more plugins and learn how you use them.
+
+## Why Plugins
+
+Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
+
+The Mapbox Android team creates plugins but this plugins repository is an open-source project similar to the various Mapbox SDKs for Android.
+Plugins' lightweight nature makes them much easier for you and anyone else to contribute rather than trying to add the same feature to the more robust Map SDK. The Mapbox team can also more easily accept contributed plugins and keep the plugin list growing.
+
+## Contributing
+
+We welcome contributions to this plugin repository!
+
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/mapbox/mapbox-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-markerview/README.md
+++ b/plugin-markerview/README.md
@@ -1,0 +1,61 @@
+# Mapbox MarkerView plugin
+
+![markerview-plugin](https://user-images.githubusercontent.com/2151639/45137542-69f42f00-b1a9-11e8-854b-3335a5504337.gif)
+
+## Getting Started
+
+To use the MarkerView plugin you include it in your `build.gradle` file.
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview:0.1.0'
+}
+```
+
+The MarkerView plugin is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
+
+```
+// In the root build.gradle file
+repositories {
+    mavenCentral()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+}
+
+...
+
+// In the app build.gradle file
+dependencies {
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview:0.2.0-SNAPSHOT'
+}
+```
+
+## MarkerView plugin examples
+
+- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.java)
+
+## Help and Usage
+
+This repository includes an app that shows how to use each plugin in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+
+We'd love to [hear your feedback](https://github.com/mapbox/mapbox-plugins-android/issues) as we build more plugins and learn how you use them.
+
+## Why Plugins
+
+Splitting specific functionality into plugins makes our Map SDK lighter and nimble for you to use, and it also lets us iterate faster. We can release plugins more often than the SDK, which requires a slower pace due to its larger codebase.
+
+The Mapbox Android team creates plugins but this plugins repository is an open-source project similar to the various Mapbox SDKs for Android.
+Plugins' lightweight nature makes them much easier for you and anyone else to contribute rather than trying to add the same feature to the more robust Map SDK. The Mapbox team can also more easily accept contributed plugins and keep the plugin list growing.
+
+## Contributing
+
+We welcome contributions to this plugin repository!
+
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/mapbox/mapbox-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/668
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/669

Adds basic READMEs for the two new plugins.


cc @tobrun @LukasPaczos 