### PR TITLE
Don't invalidate camera mode if unnecessary for gestures initiated changes

### DIFF
--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCamera.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.plugins.locationlayer;
 
 import android.content.Context;
 import android.graphics.PointF;
+import android.support.annotation.VisibleForTesting;
 import android.view.MotionEvent;
 
 import com.mapbox.android.gestures.AndroidGesturesManager;
@@ -172,7 +173,8 @@ final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValu
     }
   }
 
-  private MapboxMap.OnMoveListener onMoveListener = new MapboxMap.OnMoveListener() {
+  @VisibleForTesting
+  MapboxMap.OnMoveListener onMoveListener = new MapboxMap.OnMoveListener() {
     private boolean interrupt;
 
     @Override
@@ -192,7 +194,10 @@ final class LocationLayerCamera implements PluginAnimator.OnCameraAnimationsValu
         return;
       }
 
-      setCameraMode(CameraMode.NONE);
+      if (isBearingTracking() || isLocationTracking()) {
+        setCameraMode(CameraMode.NONE);
+        detector.interrupt();
+      }
     }
 
     @Override

--- a/plugin-locationlayer/src/test/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCameraTest.java
+++ b/plugin-locationlayer/src/test/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerCameraTest.java
@@ -309,6 +309,63 @@ public class LocationLayerCameraTest {
     verify(mapboxMap).moveCamera(any(CameraUpdate.class));
   }
 
+
+  @Test
+  public void onMove_cancellingTransitionWhileNone() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
+    LocationLayerCamera camera = buildCamera(mapboxMap);
+    camera.initializeOptions(mock(LocationLayerOptions.class));
+
+    camera.setCameraMode(CameraMode.NONE);
+    camera.onMoveListener.onMove(moveGestureDetector);
+    verify(mapboxMap, times(1)).cancelTransitions();
+    verify(moveGestureDetector, times(0)).interrupt();
+
+    // testing subsequent calls
+    camera.onMoveListener.onMove(moveGestureDetector);
+    verify(mapboxMap, times(1)).cancelTransitions();
+    verify(moveGestureDetector, times(0)).interrupt();
+  }
+
+  @Test
+  public void onMove_cancellingTransitionWhileGps() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
+    LocationLayerCamera camera = buildCamera(mapboxMap);
+    camera.initializeOptions(mock(LocationLayerOptions.class));
+
+    camera.setCameraMode(CameraMode.TRACKING);
+    camera.onMoveListener.onMove(moveGestureDetector);
+    verify(mapboxMap, times(2)).cancelTransitions();
+    verify(moveGestureDetector, times(1)).interrupt();
+
+    // testing subsequent calls
+    camera.onMoveListener.onMove(moveGestureDetector);
+    verify(mapboxMap, times(2)).cancelTransitions();
+    verify(moveGestureDetector, times(1)).interrupt();
+  }
+
+  @Test
+  public void onMove_cancellingTransitionWhileBearing() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
+    LocationLayerCamera camera = buildCamera(mapboxMap);
+    camera.initializeOptions(mock(LocationLayerOptions.class));
+
+    camera.setCameraMode(CameraMode.NONE_COMPASS);
+    camera.onMoveListener.onMove(moveGestureDetector);
+    verify(mapboxMap, times(2)).cancelTransitions();
+    verify(moveGestureDetector, times(1)).interrupt();
+
+    // testing subsequent calls
+    camera.onMoveListener.onMove(moveGestureDetector);
+    verify(mapboxMap, times(2)).cancelTransitions();
+    verify(moveGestureDetector, times(1)).interrupt();
+  }
+
   private LocationLayerCamera buildCamera(OnCameraTrackingChangedListener onCameraTrackingChangedListener) {
     MapboxMap mapboxMap = mock(MapboxMap.class);
     when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-plugins-android/issues/693.

Prevents canceling transitions (which happens as a part of `setCameraMode`) when unnecessary. This in general results in dispatching `#onCameraIdle` which prevents from any subsequent `#onCameraMove` being delivered during this gesture motion.