### PR TITLE
[annotation] - add geojson compatible api

### DIFF
--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -88,6 +88,46 @@ public class <%- camelize(type) %> extends Annotation {
     geometry = Polygon.fromLngLats(points);
   }
 <% } -%>
+<% if (type === "circle" || type === "symbol") { -%>
+
+  /**
+   * Set the Geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+   * <p>
+   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the <%- type %>
+   */
+  public void setGeometry(Point geometry) {
+    this.geometry = geometry;
+  }
+<% } else if (type === "line") { -%>
+
+  /**
+   * Set the Geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+   * <p>
+   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the <%- type %>
+   */
+  public void setGeometry(LineString geometry) {
+    this.geometry = geometry;
+  }
+<% } else { -%>
+
+  /**
+   * Set the Geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+   * <p>
+   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the <%- type %>
+   */
+  public void setGeometry(Polygon geometry) {
+    this.geometry = geometry;
+  }
+<% } -%>
 <% if (type === "symbol") { -%>
 
   ///**

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -66,6 +66,17 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
     geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
     return this;
   }
+
+  /**
+   * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+   *
+   * @param geometry the location of the <%- type %>
+   * @return this
+   */
+  public <%- camelize(type) %>Options withGeometry(Point geometry) {
+    this.geometry = geometry;
+    return this;
+  }
 <% } else if (type === "line") { -%>
 
   /**
@@ -80,6 +91,17 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
       points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
     }
     geometry = LineString.fromLngLats(points);
+    return this;
+  }
+
+  /**
+   * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+   *
+   * @param geometry the location of the <%- type %>
+   * @return this
+   */
+  public <%- camelize(type) %>Options withGeometry(LineString geometry) {
+    this.geometry = geometry;
     return this;
   }
 <% } else { -%>
@@ -100,6 +122,17 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
       points.add(innerList);
     }
     geometry = Polygon.fromLngLats(points);
+    return this;
+  }
+
+  /**
+   * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+   *
+   * @param geometry the location of the <%- type %>
+   * @return this
+   */
+  public <%- camelize(type) %>Options withGeometry(Polygon geometry) {
+    this.geometry = geometry;
     return this;
   }
 <% } -%>

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
@@ -38,6 +38,18 @@ public class Circle extends Annotation {
     geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
   }
 
+  /**
+   * Set the Geometry of the circle, which represents the location of the circle on the map
+   * <p>
+   * To update the circle on the map use {@link CircleManager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the circle
+   */
+  public void setGeometry(Point geometry) {
+    this.geometry = geometry;
+  }
+
   // Property accessors
   /**
    * Get the CircleRadius property

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
@@ -179,6 +179,17 @@ public class CircleOptions extends Options<Circle> {
     return this;
   }
 
+  /**
+   * Set the geometry of the circle, which represents the location of the circle on the map
+   *
+   * @param geometry the location of the circle
+   * @return this
+   */
+  public CircleOptions withGeometry(Point geometry) {
+    this.geometry = geometry;
+    return this;
+  }
+
   @Override
   Circle build(long id) {
     if (geometry == null) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
@@ -46,6 +46,18 @@ public class Fill extends Annotation {
     geometry = Polygon.fromLngLats(points);
   }
 
+  /**
+   * Set the Geometry of the fill, which represents the location of the fill on the map
+   * <p>
+   * To update the fill on the map use {@link FillManager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the fill
+   */
+  public void setGeometry(Polygon geometry) {
+    this.geometry = geometry;
+  }
+
   // Property accessors
   /**
    * Get the FillOpacity property

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
@@ -124,6 +124,17 @@ public class FillOptions extends Options<Fill> {
     return this;
   }
 
+  /**
+   * Set the geometry of the fill, which represents the location of the fill on the map
+   *
+   * @param geometry the location of the fill
+   * @return this
+   */
+  public FillOptions withGeometry(Polygon geometry) {
+    this.geometry = geometry;
+    return this;
+  }
+
   @Override
   Fill build(long id) {
     if (geometry == null) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
@@ -42,6 +42,18 @@ public class Line extends Annotation {
     geometry = LineString.fromLngLats(points);
   }
 
+  /**
+   * Set the Geometry of the line, which represents the location of the line on the map
+   * <p>
+   * To update the line on the map use {@link LineManager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the line
+   */
+  public void setGeometry(LineString geometry) {
+    this.geometry = geometry;
+  }
+
   // Property accessors
   /**
    * Get the LineJoin property

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
@@ -204,6 +204,17 @@ public class LineOptions extends Options<Line> {
     return this;
   }
 
+  /**
+   * Set the geometry of the line, which represents the location of the line on the map
+   *
+   * @param geometry the location of the line
+   * @return this
+   */
+  public LineOptions withGeometry(LineString geometry) {
+    this.geometry = geometry;
+    return this;
+  }
+
   @Override
   Line build(long id) {
     if (geometry == null) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -40,6 +40,18 @@ public class Symbol extends Annotation {
     geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
   }
 
+  /**
+   * Set the Geometry of the symbol, which represents the location of the symbol on the map
+   * <p>
+   * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
+   * <p>
+   *
+   * @param geometry the geometry of the symbol
+   */
+  public void setGeometry(Point geometry) {
+    this.geometry = geometry;
+  }
+
   ///**
   // * Set the z-index of a symbol.
   // * <p>

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -557,6 +557,17 @@ public class SymbolOptions extends Options<Symbol> {
     return this;
   }
 
+  /**
+   * Set the geometry of the symbol, which represents the location of the symbol on the map
+   *
+   * @param geometry the location of the symbol
+   * @return this
+   */
+  public SymbolOptions withGeometry(Point geometry) {
+    this.geometry = geometry;
+    return this;
+  }
+
   @Override
   Symbol build(long id) {
     if (geometry == null) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/683,
Instead of an exposing LatLng equivalent API, This PR allows to use the geojson equivalent instead:
 - Point (circle/symbol)
 - Polygon (Fill)
 - MultiLineString (Line)

