### PR TITLE
Move camera and puck immediately when starting to track and displacement is big

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPluginTest.kt
@@ -1064,6 +1064,30 @@ class LocationLayerPluginTest {
   }
 
   @Test
+  fun cameraPositionSnappedToTargetIfExceedsThreshold() {
+    val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocationLayerPlugin> {
+      override fun onGenericPluginAction(plugin: LocationLayerPlugin, mapboxMap: MapboxMap,
+                                         uiController: UiController, context: Context) {
+        val target = LatLng(51.0, 17.0)
+        assertTrue(target.distanceTo(LatLng(location)) > LocationLayerConstants.INSTANT_LOCATION_TRANSITION_THRESHOLD)
+
+        plugin.cameraMode = CameraMode.NONE
+        plugin.forceLocationUpdate(location)
+        plugin.isLocationLayerEnabled = true
+        mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(target))
+        mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(90.0))
+        plugin.cameraMode = CameraMode.TRACKING_GPS
+
+        assertEquals(location.bearing.toDouble(), mapboxMap.cameraPosition.bearing, 0.1)
+        assertEquals(location.latitude, mapboxMap.cameraPosition.target.latitude, 0.1)
+        assertEquals(location.longitude, mapboxMap.cameraPosition.target.longitude, 0.1)
+      }
+    }
+
+    executePluginTest(pluginAction, PluginGenerationUtil.getLocationLayerPluginProvider(activityRule.activity))
+  }
+
+  @Test
   fun onPluginInitialized_defaultCompassEngineIsProvided() {
     val pluginAction = object : GenericPluginAction.OnPerformGenericPluginAction<LocationLayerPlugin> {
       override fun onGenericPluginAction(plugin: LocationLayerPlugin, mapboxMap: MapboxMap,

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerConstants.java
@@ -25,6 +25,9 @@ final class LocationLayerConstants {
   // Default animation duration for tilting while tracking.
   static final long DEFAULT_TRACKING_TILT_ANIMATION_DURATION = 1250;
 
+  // Threshold value to perform immediate camera/layer position update.
+  static final double INSTANT_LOCATION_TRANSITION_THRESHOLD = 500_000;
+
   // Sources
   static final String LOCATION_SOURCE = "mapbox-location-source";
   static final String PROPERTY_GPS_BEARING = "mapbox-property-gps-bearing";

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java
@@ -269,8 +269,8 @@ public final class LocationLayerPlugin implements LifecycleObserver {
    */
   public void setCameraMode(@CameraMode.Mode int cameraMode) {
     boolean isGpsNorth = cameraMode == CameraMode.TRACKING_GPS_NORTH;
-    pluginAnimatorCoordinator.resetAllCameraAnimations(mapboxMap.getCameraPosition(), isGpsNorth);
     locationLayerCamera.setCameraMode(cameraMode);
+    pluginAnimatorCoordinator.resetAllCameraAnimations(mapboxMap.getCameraPosition(), isGpsNorth);
   }
 
   /**

--- a/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
+++ b/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/Utils.java
@@ -85,8 +85,7 @@ public final class Utils {
     if (location == null) {
       return 0;
     }
-    double metersPerPixel = mapboxMap.getProjection().getMetersPerPixelAtLatitude(
-      location.getLatitude());
+    double metersPerPixel = mapboxMap.getProjection().getMetersPerPixelAtLatitude(location.getLatitude());
     return (float) (location.getAccuracy() * (1 / metersPerPixel));
   }
 


### PR DESCRIPTION
When the camera's/puck's current position is far away from the target one, instead of slowly animating, we are now moving it immediately. 

![ezgif com-video-to-gif 6](https://user-images.githubusercontent.com/16925074/46357697-b7a76e80-c665-11e8-87be-78098f45ad3b.gif)
