### PR TITLE
Style spec update, z ordering symbols

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -13,6 +13,7 @@ import com.mapbox.mapboxsdk.plugins.annotation.*;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +27,7 @@ public class SymbolActivity extends AppCompatActivity {
   private static final String MAKI_ICON_AIRPORT = "airport-15";
   private static final String MAKI_ICON_CAR = "car-15";
   private static final String MAKI_ICON_CAFE = "cafe-15";
+  private static final String MAKI_ICON_CIRCLE = "circle-15";
 
   private final Random random = new Random();
 
@@ -63,8 +65,18 @@ public class SymbolActivity extends AppCompatActivity {
       SymbolOptions symbolOptions = new SymbolOptions()
         .withLatLng(new LatLng(6.687337, 0.381457))
         .withIconImage(MAKI_ICON_AIRPORT)
-        .withIconSize(1.3f);
+        .withIconSize(1.3f)
+        .withZIndex(10);
       symbol = symbolManager.create(symbolOptions);
+
+      // create nearby symbols
+      SymbolOptions nearbyOptions = new SymbolOptions()
+        .withLatLng(new LatLng(6.626384, 0.367099))
+        .withIconImage(MAKI_ICON_CIRCLE)
+        .withIconColor(PropertyFactory.colorToRgbaString(Color.YELLOW))
+        .withIconSize(2.5f)
+        .withZIndex(5);
+      symbolManager.create(nearbyOptions);
 
       // random add symbols across the globe
       List<SymbolOptions> symbolOptionsList = new ArrayList<>();
@@ -106,6 +118,8 @@ public class SymbolActivity extends AppCompatActivity {
       symbol.setTextColor(PropertyFactory.colorToRgbaString(Color.WHITE));
     } else if (item.getItemId() == R.id.menu_action_text_size) {
       symbol.setTextSize(22f);
+    }else if(item.getItemId() == R.id.menu_action_z_index){
+      symbol.setZIndex(0);
     } else {
       return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/res/menu/menu_marker.xml
+++ b/app/src/main/res/menu/menu_marker.xml
@@ -37,4 +37,8 @@
             android:id="@+id/menu_action_text_anchor"
             android:title="Set text anchor top"
             app:showAsAction="never"/>
+    <item
+            android:id="@+id/menu_action_z_index"
+            android:title="Change Z index"
+            app:showAsAction="never"/>
 </menu>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.5.0',
+      mapboxMapSdk       : '6.6.0',
       mapboxJava         : '3.2.0',
       playLocation       : '15.0.1',
       autoValue          : '1.5.4',

--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -19,10 +19,11 @@ import java.util.List;
 
 @UiThread
 public class <%- camelize(type) %> extends Annotation {
-
 <% if (type === "symbol") { -%>
-  //public static final String Z_INDEX = "z-index";
+
+  public static final String Z_INDEX = "z-index";
 <% } -%>
+
   /**
    * Create a <%- type %>.
    *
@@ -32,9 +33,6 @@ public class <%- camelize(type) %> extends Annotation {
    */
   <%- camelize(type) %>(long id, JsonObject jsonObject, Geometry geometry) {
     super(id, jsonObject, geometry);
-<% if (type === "symbol") { -%>
-    //this.jsonObject.addProperty(Z_INDEX, 0);
-<% } -%>
   }
 <% if (type === "circle" || type === "symbol") { -%>
 
@@ -130,30 +128,29 @@ public class <%- camelize(type) %> extends Annotation {
 <% } -%>
 <% if (type === "symbol") { -%>
 
-  ///**
-  // * Set the z-index of a symbol.
-  // * <p>
-  // * If a symbol z-index is higher as another symbol it will be rendered above it.
-  // * </p>
-  // * <p>
-  // * Default value is 0.
-  // * </p>
-  // *
-  // * @param index the z-index value
-  // */
-  //public void setZIndex(int index) {
-  //  jsonObject.addProperty(Z_INDEX, index);
-  //  symbolManager.updateSource();
-  //}
+  /**
+   * Set the z-index of a symbol.
+   * <p>
+   * If a symbol z-index is higher as another symbol it will be rendered above it.
+   * </p>
+   * <p>
+   * Default value is 0.
+   * </p>
+   *
+   * @param index the z-index value
+   */
+  public void setZIndex(int index) {
+    jsonObject.addProperty(Z_INDEX, index);
+  }
 
-  ///**
-  // * Get the z-index of a symbol.
-  // *
-  // * @return the z-index value, 0 if not set
-  // */
-  //public int getZIndex() {
-  //  return jsonObject.get(Z_INDEX).getAsInt();
-  //}
+  /**
+   * Get the z-index of a symbol.
+   *
+   * @return the z-index value, 0 if not set
+   */
+  public int getZIndex() {
+    return jsonObject.get(Z_INDEX).getAsInt();
+  }
 <% } -%>
 
   // Property accessors

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -29,7 +29,6 @@ import java.util.List;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
-//import static com.mapbox.mapboxsdk.annotations.symbol.Symbol.Z_INDEX;
 
 /**
  * The <%- type %> manager allows to add <%- type %>s to a map.
@@ -40,9 +39,6 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
   public static final String ID_GEOJSON_LAYER = "mapbox-android-<%- type %>-layer";
 
   private <%- camelize(type) %>Layer layer;
-<% if (type === "symbol") { -%>
-  //private final SymbolComparator symbolComparator = new SymbolComparator();
-<% } -%>
 
   /**
    * Create a <%- type %> manager, used to manage <%- type %>s.
@@ -77,7 +73,11 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   @VisibleForTesting
   public <%- camelize(type) %>Manager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull <%- camelize(type) %>Layer layer, @Nullable String belowLayerId) {
+<% if (type === "symbol") { -%>
+    super(mapboxMap, geoJsonSource, new SymbolComparator());
+<% } else { -%>
     super(mapboxMap, geoJsonSource);
+<% } -%>
     initLayer(layer, belowLayerId);
   }
 
@@ -123,7 +123,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
       <%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")),
 <% } -%><% } -%>
 <% if (type === "symbol") { -%>
-      //symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE)
+      symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE)
 <% } -%>
     };
   }
@@ -150,15 +150,5 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
   }
 
 <% } -%>
-<% } -%>
-
-<% if (type === "symbol") { -%>
-
-  //private class SymbolComparator implements Comparator<Feature> {
-  //  @Override
-  //  public int compare(Feature left, Feature right) {
-  //    return right.getProperty(Z_INDEX).getAsInt() - left.getProperty(Z_INDEX).getAsInt();
-  //  }
-  //}
 <% } -%>
 }

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -40,7 +40,7 @@ public class <%- camelize(type) %>ManagerTest extends BaseActivityTest {
     });
   }
 <% for (const property of properties) { -%>
-<% if (!supportsPropertyFunction(property) && property.name !== "line-gradient") { -%>
+<% if (!supportsPropertyFunction(property) && property.name !== "line-gradient" && property.name !== "symbol-z-order") { -%>
 
   @Test
   public void test<%- camelize(property.name) %>AsConstant() {

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -30,6 +30,9 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
   private <%- propertyType(property) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 <% } -%>
 <% } -%>
+<% if (type === "symbol") { -%>
+  private int zIndex;
+<% } -%>
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 
@@ -136,6 +139,31 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
     return this;
   }
 <% } -%>
+<% if (type === "symbol") { -%>
+
+  /**
+   * Set the zIndex of the symbol, which represents the place of the symbol on the map inside a layer.
+   * <p>
+   * A higher value brings the symbol to the front.
+   * </p>
+   *
+   * @param zIndex the z index
+   * @return this
+   */
+  public SymbolOptions withZIndex(int zIndex) {
+    this.zIndex = zIndex;
+    return this;
+  }
+
+  /**
+   * Get the zIndex of the symbol, which represents the place of the symbol on the map inside a layer.
+   *
+   * @return the z index
+   */
+  public int getZIndex() {
+    return zIndex;
+  }
+<% } -%>
 
   @Override
   <%- camelize(type) %> build(long id) {
@@ -151,6 +179,9 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
     jsonObject.addProperty("<%- property.name %>", <%- camelizeWithLeadingLowercase(property.name) %>);
 <% } -%>
 <% } -%>
+<% } -%>
+<% if (type === "symbol") { -%>
+    jsonObject.addProperty(Symbol.Z_INDEX, zIndex);
 <% } -%>
     return new <%- camelize(type) %>(id, jsonObject, geometry);
   }

--- a/plugin-annotation/scripts/v8.json
+++ b/plugin-annotation/scripts/v8.json
@@ -70,12 +70,12 @@
     },
     "sprite": {
       "type": "string",
-      "doc": "A base URL for retrieving the sprite image and metadata. The extensions `.png`, `.json` and scale factor `@2x.png` will be automatically appended. This property is required if any layer uses the `background-pattern`, `fill-pattern`, `line-pattern`, `fill-extrusion-pattern`, or `icon-image` properties.",
+      "doc": "A base URL for retrieving the sprite image and metadata. The extensions `.png`, `.json` and scale factor `@2x.png` will be automatically appended. This property is required if any layer uses the `background-pattern`, `fill-pattern`, `line-pattern`, `fill-extrusion-pattern`, or `icon-image` properties. The URL must be absolute, containing the [scheme, authority and path components](https://en.wikipedia.org/wiki/URL#Syntax).",
       "example": "mapbox://sprites/mapbox/bright-v8"
     },
     "glyphs": {
       "type": "string",
-      "doc": "A URL template for loading signed-distance-field glyph sets in PBF format. The URL must include `{fontstack}` and `{range}` tokens. This property is required if any layer uses the `text-field` layout property.",
+      "doc": "A URL template for loading signed-distance-field glyph sets in PBF format. The URL must include `{fontstack}` and `{range}` tokens. This property is required if any layer uses the `text-field` layout property. The URL must be absolute, containing the [scheme, authority and path components](https://en.wikipedia.org/wiki/URL#Syntax).",
       "example": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf"
     },
     "transition": {
@@ -581,7 +581,7 @@
     },
     "filter": {
       "type": "filter",
-      "doc": "A expression specifying conditions on source features. Only features that match the filter are displayed. The `feature-state` expression is not supported in filter expressions."
+      "doc": "A expression specifying conditions on source features. Only features that match the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom levels. The `feature-state` expression is not supported in filter expressions."
     },
     "layout": {
       "type": "layout",
@@ -894,7 +894,10 @@
           "macos": "0.1.0"
         },
         "`line-center` value": {
-          "js": "0.47.0"
+          "js": "0.47.0",
+          "android": "6.4.0",
+          "ios": "4.3.0",
+          "macos": "0.10.0"
         },
         "data-driven styling": {}
       },
@@ -944,6 +947,32 @@
           "android": "2.0.1",
           "ios": "2.0.0",
           "macos": "0.1.0"
+        },
+        "data-driven styling": {}
+      },
+      "expression": {
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "property-type": "data-constant"
+    },
+    "symbol-z-order": {
+      "type": "enum",
+      "values": {
+        "viewport-y": {
+          "doc": "Symbols will be sorted by their y-position relative to the viewport."
+        },
+        "source": {
+          "doc": "Symbols will be rendered in the same order as the source data with no sorting applied."
+        }
+      },
+      "default": "viewport-y",
+      "doc": "Controls the order in which overlapping symbols in the same layer are rendered",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.49.0"
         },
         "data-driven styling": {}
       },
@@ -2525,6 +2554,7 @@
         "sdk-support": {
           "basic functionality": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3008,6 +3038,7 @@
           },
           "collator": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3025,6 +3056,7 @@
           },
           "collator": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3042,6 +3074,7 @@
           },
           "collator": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3059,6 +3092,7 @@
           },
           "collator": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3076,6 +3110,7 @@
           },
           "collator": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3093,6 +3128,7 @@
           },
           "collator": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3163,7 +3199,7 @@
         }
       },
       "concat": {
-        "doc": "Returns a `string` consisting of the concatenation of the inputs. If any inputs are `formatted`, returns a `formatted` with default formatting options for all unformatted inputs.",
+        "doc": "Returns a `string` consisting of the concatenation of the inputs. Each input is converted to a string as if by `to-string`.",
         "group": "String",
         "sdk-support": {
           "basic functionality": {
@@ -3180,6 +3216,7 @@
         "sdk-support": {
           "basic functionality": {
             "js": "0.45.0",
+            "android": "6.5.0",
             "ios": "4.2.0",
             "macos": "0.9.0"
           }
@@ -3501,7 +3538,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.46.0"
+          "js": "0.49.0",
+          "android": "6.5.0",
+          "macos": "0.11.0",
+          "ios": "4.4.0"
         }
       },
       "expression": {
@@ -3643,7 +3683,12 @@
           "ios": "3.6.0",
           "macos": "0.5.0"
         },
-        "data-driven styling": {}
+        "data-driven styling": {
+          "js": "0.49.0",
+          "android": "6.5.0",
+          "macos": "0.11.0",
+          "ios": "4.4.0"
+        }
       },
       "expression": {
         "interpolated": false,
@@ -3718,6 +3763,22 @@
         ]
       },
       "property-type": "data-driven"
+    },
+    "fill-extrusion-vertical-gradient": {
+      "type": "boolean",
+      "default": true,
+      "doc": "Whether to apply a vertical gradient to the sides of a fill-extrusion layer. If true, sides will be shaded slightly darker farther down.",
+      "transition": false,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "0.50.0"
+        }
+      },
+      "expression": {
+        "interpolated": false,
+        "parameters": ["zoom"]
+      },
+      "property-type": "data-constant"
     }
   },
   "paint_line": {
@@ -4010,7 +4071,10 @@
           "macos": "0.1.0"
         },
         "data-driven styling": {
-          "js": "0.46.0"
+          "js": "0.49.0",
+          "android": "6.5.0",
+          "macos": "0.11.0",
+          "ios": "4.4.0"
         }
       },
       "expression": {
@@ -4042,7 +4106,10 @@
       ],
       "sdk-support": {
         "basic functionality": {
-          "js": "0.45.0"
+          "js": "0.45.0",
+          "android": "6.5.0",
+          "ios": "4.4.0",
+          "macos": "0.11.0"
         },
         "data-driven styling": {}
       },

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -12,6 +12,8 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -38,11 +40,18 @@ public abstract class AnnotationManager<
 
   private final GeoJsonSource geoJsonSource;
   private final MapClickResolver mapClickResolver;
+  private final Comparator<Feature> comparator;
 
   @UiThread
   protected AnnotationManager(MapboxMap mapboxMap, GeoJsonSource geoJsonSource) {
+    this(mapboxMap, geoJsonSource, null);
+  }
+
+  @UiThread
+  protected AnnotationManager(MapboxMap mapboxMap, GeoJsonSource geoJsonSource, Comparator<Feature> comparator) {
     this.mapboxMap = mapboxMap;
     this.geoJsonSource = geoJsonSource;
+    this.comparator = comparator;
     mapboxMap.addSource(geoJsonSource);
     mapboxMap.addOnMapClickListener(mapClickResolver = new MapClickResolver(mapboxMap));
     mapboxMap.addOnMapLongClickListener(mapClickResolver);
@@ -152,7 +161,10 @@ public abstract class AnnotationManager<
       t = annotations.valueAt(i);
       features.add(Feature.fromGeometry(t.getGeometry(), t.getFeature()));
     }
-    //Collections.sort(features, symbolComparator);
+
+    if(comparator != null) {
+      Collections.sort(features, comparator);
+    }
     geoJsonSource.setGeoJson(FeatureCollection.fromFeatures(features));
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
-//import static com.mapbox.mapboxsdk.annotations.symbol.Symbol.Z_INDEX;
 
 /**
  * The circle manager allows to add circles to a map.
@@ -192,6 +191,5 @@ public class CircleManager extends AnnotationManager<Circle, CircleOptions, OnCi
   public void setCirclePitchAlignment(@Property.CIRCLE_PITCH_ALIGNMENT String value) {
     layer.setProperties(circlePitchAlignment(value));
   }
-
 
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
-//import static com.mapbox.mapboxsdk.annotations.symbol.Symbol.Z_INDEX;
 
 /**
  * The fill manager allows to add fills to a map.
@@ -170,6 +169,5 @@ public class FillManager extends AnnotationManager<Fill, FillOptions, OnFillClic
   public void setFillTranslateAnchor(@Property.FILL_TRANSLATE_ANCHOR String value) {
     layer.setProperties(fillTranslateAnchor(value));
   }
-
 
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
-//import static com.mapbox.mapboxsdk.annotations.symbol.Symbol.Z_INDEX;
 
 /**
  * The line manager allows to add lines to a map.
@@ -228,6 +227,5 @@ public class LineManager extends AnnotationManager<Line, LineOptions, OnLineClic
   public void setLineDasharray( Float[] value) {
     layer.setProperties(lineDasharray(value));
   }
-
 
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -15,7 +15,8 @@ import java.util.List;
 @UiThread
 public class Symbol extends Annotation {
 
-  //public static final String Z_INDEX = "z-index";
+  public static final String Z_INDEX = "z-index";
+
   /**
    * Create a symbol.
    *
@@ -25,7 +26,6 @@ public class Symbol extends Annotation {
    */
   Symbol(long id, JsonObject jsonObject, Geometry geometry) {
     super(id, jsonObject, geometry);
-    //this.jsonObject.addProperty(Z_INDEX, 0);
   }
 
   /**
@@ -52,30 +52,29 @@ public class Symbol extends Annotation {
     this.geometry = geometry;
   }
 
-  ///**
-  // * Set the z-index of a symbol.
-  // * <p>
-  // * If a symbol z-index is higher as another symbol it will be rendered above it.
-  // * </p>
-  // * <p>
-  // * Default value is 0.
-  // * </p>
-  // *
-  // * @param index the z-index value
-  // */
-  //public void setZIndex(int index) {
-  //  jsonObject.addProperty(Z_INDEX, index);
-  //  symbolManager.updateSource();
-  //}
+  /**
+   * Set the z-index of a symbol.
+   * <p>
+   * If a symbol z-index is higher as another symbol it will be rendered above it.
+   * </p>
+   * <p>
+   * Default value is 0.
+   * </p>
+   *
+   * @param index the z-index value
+   */
+  public void setZIndex(int index) {
+    jsonObject.addProperty(Z_INDEX, index);
+  }
 
-  ///**
-  // * Get the z-index of a symbol.
-  // *
-  // * @return the z-index value, 0 if not set
-  // */
-  //public int getZIndex() {
-  //  return jsonObject.get(Z_INDEX).getAsInt();
-  //}
+  /**
+   * Get the z-index of a symbol.
+   *
+   * @return the z-index value, 0 if not set
+   */
+  public int getZIndex() {
+    return jsonObject.get(Z_INDEX).getAsInt();
+  }
 
   // Property accessors
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolComparator.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolComparator.java
@@ -1,0 +1,14 @@
+package com.mapbox.mapboxsdk.plugins.annotation;
+
+import com.mapbox.geojson.Feature;
+
+import java.util.Comparator;
+
+import static com.mapbox.mapboxsdk.plugins.annotation.Symbol.Z_INDEX;
+
+public class SymbolComparator implements Comparator<Feature> {
+  @Override
+  public int compare(Feature left, Feature right) {
+    return left.getProperty(Z_INDEX).getAsInt() - right.getProperty(Z_INDEX).getAsInt();
+  }
+}

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
-//import static com.mapbox.mapboxsdk.annotations.symbol.Symbol.Z_INDEX;
 
 /**
  * The symbol manager allows to add symbols to a map.
@@ -35,7 +34,6 @@ public class SymbolManager extends AnnotationManager<Symbol, SymbolOptions, OnSy
   public static final String ID_GEOJSON_LAYER = "mapbox-android-symbol-layer";
 
   private SymbolLayer layer;
-  //private final SymbolComparator symbolComparator = new SymbolComparator();
 
   /**
    * Create a symbol manager, used to manage symbols.
@@ -70,7 +68,7 @@ public class SymbolManager extends AnnotationManager<Symbol, SymbolOptions, OnSy
    */
   @VisibleForTesting
   public SymbolManager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull SymbolLayer layer, @Nullable String belowLayerId) {
-    super(mapboxMap, geoJsonSource);
+    super(mapboxMap, geoJsonSource, new SymbolComparator());
     initLayer(layer, belowLayerId);
   }
 
@@ -136,7 +134,7 @@ public class SymbolManager extends AnnotationManager<Symbol, SymbolOptions, OnSy
       textHaloColor(get("text-halo-color")),
       textHaloWidth(get("text-halo-width")),
       textHaloBlur(get("text-halo-blur")),
-      //symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE)
+      symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE)
     };
   }
 
@@ -591,12 +589,4 @@ public class SymbolManager extends AnnotationManager<Symbol, SymbolOptions, OnSy
     layer.setProperties(textTranslateAnchor(value));
   }
 
-
-
-  //private class SymbolComparator implements Comparator<Feature> {
-  //  @Override
-  //  public int compare(Feature left, Feature right) {
-  //    return right.getProperty(Z_INDEX).getAsInt() - left.getProperty(Z_INDEX).getAsInt();
-  //  }
-  //}
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -45,6 +45,7 @@ public class SymbolOptions extends Options<Symbol> {
   private String textHaloColor;
   private Float textHaloWidth;
   private Float textHaloBlur;
+  private int zIndex;
 
   /**
    * Set icon-size to initialise the symbol with.
@@ -568,6 +569,29 @@ public class SymbolOptions extends Options<Symbol> {
     return this;
   }
 
+  /**
+   * Set the zIndex of the symbol, which represents the place of the symbol on the map inside a layer.
+   * <p>
+   * A higher value brings the symbol to the front.
+   * </p>
+   *
+   * @param zIndex the z index
+   * @return this
+   */
+  public SymbolOptions withZIndex(int zIndex) {
+    this.zIndex = zIndex;
+    return this;
+  }
+
+  /**
+   * Get the zIndex of the symbol, which represents the place of the symbol on the map inside a layer.
+   *
+   * @return the z index
+   */
+  public int getZIndex() {
+    return zIndex;
+  }
+
   @Override
   Symbol build(long id) {
     if (geometry == null) {
@@ -599,6 +623,7 @@ public class SymbolOptions extends Options<Symbol> {
     jsonObject.addProperty("text-halo-color", textHaloColor);
     jsonObject.addProperty("text-halo-width", textHaloWidth);
     jsonObject.addProperty("text-halo-blur", textHaloBlur);
+    jsonObject.addProperty(Symbol.Z_INDEX, zIndex);
     return new Symbol(id, jsonObject, geometry);
   }
 }


### PR DESCRIPTION
With release of upstream maps sdk release of v6.6.0, we can reintegrate symbol z ordering.

![ezgif com-video-to-gifasd](https://user-images.githubusercontent.com/2151639/46811362-e5319d80-cd72-11e8-8022-2854420d57bc.gif)


