### PR TITLE
Add additional maven resource to fix ongoing release ci issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
   repositories {
     jcenter()
     google()
+    maven {   url "https://maven.google.com"   }
   }
 
   dependencies {


### PR DESCRIPTION
Plausible fix for our ci release workflow issues that we are experiencing taken from [here](https://stackoverflow.com/questions/49510176/android-studio-gradle-sync-failed-could-not-head-received-status-code-5/49510333#49510333).