### PR TITLE
Exclude Kotlin from javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
   apply plugin: 'jacoco'
 
   repositories {
-    jcenter()
     google()
+    jcenter()
     maven {   url "https://maven.google.com"   }
   }
 
@@ -16,8 +16,8 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
     google()
+    jcenter()
 //    SNAPSHOT repository
 //    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
   }

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -14,6 +14,6 @@ android.libraryVariants.all { variant ->
     options.bottom("&copy; 2015&ndash;2018 Mapbox. All rights reserved.")
     options.links("http://docs.oracle.com/javase/7/docs/api/")
     options.linksOffline("http://d.android.com/reference/", "$System.env.ANDROID_HOME/docs/reference")
-    exclude '**/R.java', '**/BuildConfig.java'
+    exclude '**/R.java', '**/BuildConfig.java', '**/*.kt'
   }
 }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-plugins-android/issues/730.
This PR also changes the order of remote repositories.