### PR TITLE
Adding /android-docs links to the plugin READMEs

### DIFF
--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -4,6 +4,8 @@
 
 ## Getting Started
 
+[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/annotation/)
+
 To use the annotation plugin you include it in your `build.gradle` file.
 
 ```

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -4,6 +4,8 @@
 
 ## Getting Started
 
+[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/building/)
+
 To use the building plugin you include it in your `build.gradle` file.
 
 ```

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -5,6 +5,8 @@
 
 ## Getting Started
 
+[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/localization/)
+
 To use the localization plugin, you include it in your `build.gradle` file.
 
 ```gradle

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -4,6 +4,8 @@ The offline plugin automatically does the downloading and managment of map tiles
 
 ## Getting Started
 
+[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/offline)
+
 To use the offline plugin you include it in your `build.gradle` file.
 
 ```

--- a/plugin-places/README.md
+++ b/plugin-places/README.md
@@ -6,6 +6,8 @@ The places plugin is the easiest and most powerful way to take advantage of [Map
 
 ## Getting Started
 
+[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/places/)
+
 To use the places plugin, you include it in your `build.gradle` file.
 
 ```

--- a/plugin-traffic/README.md
+++ b/plugin-traffic/README.md
@@ -6,6 +6,8 @@ The traffic plugin adds a real-time traffic layer to any Mapbox basemap.
 
 ## Getting Started
 
+[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/traffic/)
+
 To use the traffic plugin, you include it in your `build.gradle` file.
 
 ```


### PR DESCRIPTION
Adds respective https://www.mapbox.com/android-docs/plugins links to each plugin's README file. Without these links, the READMEs are much less helpful 😖 