### PR TITLE
Enable stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,28 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+exemptProjects: false
+exemptMilestones: false
+
+staleLabel: archived
+
+limitPerRun: 1
+
+# SEMVER-MAJOR - @tobrun
+exemptLabels:
+  - SEMVER-MAJOR
+
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: -1
+  staleComment: false
+  closeComment: >
+    This pull request has been automatically detected as stale because it has not had
+    recent activity and will be archived. Thank you for your contributions.
+
+issues:
+  daysUntilStale: 180
+  daysUntilClose: -1
+  staleComment: false
+  closeComment: >
+    This issue has been automatically detected as stale because it has not had
+    recent activity and will be archived. Thank you for your contributions.


### PR DESCRIPTION
Following on what we've done with https://github.com/mapbox/mapbox-java/pull/906 and https://github.com/mapbox/mapbox-gl-native/pull/13153 I'm now adding the same settings to this repo. I've also created the two labels required by the bot.