### PR TITLE
Add expression for dds supported properties on managers

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 
@@ -37,6 +39,45 @@ public class CircleManagerTest extends BaseActivityTest {
   }
 
   @Test
+  public void testCircleRadiusAsExpression() {
+    validateTestSetup();
+    setupCircleManager();
+    Timber.i("circle-radius");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(circleManager);
+
+      circleManager.setCircleRadiusExpression(get("hello"));
+      assertEquals(circleManager.getCircleRadiusExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testCircleBlurAsExpression() {
+    validateTestSetup();
+    setupCircleManager();
+    Timber.i("circle-blur");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(circleManager);
+
+      circleManager.setCircleBlurExpression(get("hello"));
+      assertEquals(circleManager.getCircleBlurExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testCircleOpacityAsExpression() {
+    validateTestSetup();
+    setupCircleManager();
+    Timber.i("circle-opacity");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(circleManager);
+
+      circleManager.setCircleOpacityExpression(get("hello"));
+      assertEquals(circleManager.getCircleOpacityExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
   public void testCircleTranslateAsConstant() {
     validateTestSetup();
     setupCircleManager();
@@ -45,7 +86,7 @@ public class CircleManagerTest extends BaseActivityTest {
       assertNotNull(circleManager);
 
       circleManager.setCircleTranslate(new Float[] {0f, 0f});
-      assertEquals((Float[]) circleManager.getCircleTranslate(), (Float[]) new Float[] {0f, 0f});
+      assertEquals(circleManager.getCircleTranslate(), (Float[]) new Float[] {0f, 0f});
     });
   }
 
@@ -58,7 +99,7 @@ public class CircleManagerTest extends BaseActivityTest {
       assertNotNull(circleManager);
 
       circleManager.setCircleTranslateAnchor(CIRCLE_TRANSLATE_ANCHOR_MAP);
-      assertEquals((String) circleManager.getCircleTranslateAnchor(), (String) CIRCLE_TRANSLATE_ANCHOR_MAP);
+      assertEquals(circleManager.getCircleTranslateAnchor(), (String) CIRCLE_TRANSLATE_ANCHOR_MAP);
     });
   }
 
@@ -71,7 +112,7 @@ public class CircleManagerTest extends BaseActivityTest {
       assertNotNull(circleManager);
 
       circleManager.setCirclePitchScale(CIRCLE_PITCH_SCALE_MAP);
-      assertEquals((String) circleManager.getCirclePitchScale(), (String) CIRCLE_PITCH_SCALE_MAP);
+      assertEquals(circleManager.getCirclePitchScale(), (String) CIRCLE_PITCH_SCALE_MAP);
     });
   }
 
@@ -84,7 +125,33 @@ public class CircleManagerTest extends BaseActivityTest {
       assertNotNull(circleManager);
 
       circleManager.setCirclePitchAlignment(CIRCLE_PITCH_ALIGNMENT_MAP);
-      assertEquals((String) circleManager.getCirclePitchAlignment(), (String) CIRCLE_PITCH_ALIGNMENT_MAP);
+      assertEquals(circleManager.getCirclePitchAlignment(), (String) CIRCLE_PITCH_ALIGNMENT_MAP);
+    });
+  }
+
+  @Test
+  public void testCircleStrokeWidthAsExpression() {
+    validateTestSetup();
+    setupCircleManager();
+    Timber.i("circle-stroke-width");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(circleManager);
+
+      circleManager.setCircleStrokeWidthExpression(get("hello"));
+      assertEquals(circleManager.getCircleStrokeWidthExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testCircleStrokeOpacityAsExpression() {
+    validateTestSetup();
+    setupCircleManager();
+    Timber.i("circle-stroke-opacity");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(circleManager);
+
+      circleManager.setCircleStrokeOpacityExpression(get("hello"));
+      assertEquals(circleManager.getCircleStrokeOpacityExpression(), number(get("hello")));
     });
   }
 }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 
@@ -45,7 +47,20 @@ public class FillManagerTest extends BaseActivityTest {
       assertNotNull(fillManager);
 
       fillManager.setFillAntialias(true);
-      assertEquals((Boolean) fillManager.getFillAntialias(), (Boolean) true);
+      assertEquals(fillManager.getFillAntialias(), (Boolean) true);
+    });
+  }
+
+  @Test
+  public void testFillOpacityAsExpression() {
+    validateTestSetup();
+    setupFillManager();
+    Timber.i("fill-opacity");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(fillManager);
+
+      fillManager.setFillOpacityExpression(get("hello"));
+      assertEquals(fillManager.getFillOpacityExpression(), number(get("hello")));
     });
   }
 
@@ -58,7 +73,7 @@ public class FillManagerTest extends BaseActivityTest {
       assertNotNull(fillManager);
 
       fillManager.setFillTranslate(new Float[] {0f, 0f});
-      assertEquals((Float[]) fillManager.getFillTranslate(), (Float[]) new Float[] {0f, 0f});
+      assertEquals(fillManager.getFillTranslate(), (Float[]) new Float[] {0f, 0f});
     });
   }
 
@@ -71,7 +86,20 @@ public class FillManagerTest extends BaseActivityTest {
       assertNotNull(fillManager);
 
       fillManager.setFillTranslateAnchor(FILL_TRANSLATE_ANCHOR_MAP);
-      assertEquals((String) fillManager.getFillTranslateAnchor(), (String) FILL_TRANSLATE_ANCHOR_MAP);
+      assertEquals(fillManager.getFillTranslateAnchor(), (String) FILL_TRANSLATE_ANCHOR_MAP);
+    });
+  }
+
+  @Test
+  public void testFillPatternAsExpression() {
+    validateTestSetup();
+    setupFillManager();
+    Timber.i("fill-pattern");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(fillManager);
+
+      fillManager.setFillPatternExpression(get("hello"));
+      assertEquals(fillManager.getFillPatternExpression(), Expression.toString(get("hello")));
     });
   }
 }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 
@@ -45,7 +47,7 @@ public class LineManagerTest extends BaseActivityTest {
       assertNotNull(lineManager);
 
       lineManager.setLineCap(LINE_CAP_BUTT);
-      assertEquals((String) lineManager.getLineCap(), (String) LINE_CAP_BUTT);
+      assertEquals(lineManager.getLineCap(), (String) LINE_CAP_BUTT);
     });
   }
 
@@ -58,7 +60,7 @@ public class LineManagerTest extends BaseActivityTest {
       assertNotNull(lineManager);
 
       lineManager.setLineMiterLimit(0.3f);
-      assertEquals((Float) lineManager.getLineMiterLimit(), (Float) 0.3f);
+      assertEquals(lineManager.getLineMiterLimit(), (Float) 0.3f);
     });
   }
 
@@ -71,7 +73,20 @@ public class LineManagerTest extends BaseActivityTest {
       assertNotNull(lineManager);
 
       lineManager.setLineRoundLimit(0.3f);
-      assertEquals((Float) lineManager.getLineRoundLimit(), (Float) 0.3f);
+      assertEquals(lineManager.getLineRoundLimit(), (Float) 0.3f);
+    });
+  }
+
+  @Test
+  public void testLineOpacityAsExpression() {
+    validateTestSetup();
+    setupLineManager();
+    Timber.i("line-opacity");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(lineManager);
+
+      lineManager.setLineOpacityExpression(get("hello"));
+      assertEquals(lineManager.getLineOpacityExpression(), number(get("hello")));
     });
   }
 
@@ -84,7 +99,7 @@ public class LineManagerTest extends BaseActivityTest {
       assertNotNull(lineManager);
 
       lineManager.setLineTranslate(new Float[] {0f, 0f});
-      assertEquals((Float[]) lineManager.getLineTranslate(), (Float[]) new Float[] {0f, 0f});
+      assertEquals(lineManager.getLineTranslate(), (Float[]) new Float[] {0f, 0f});
     });
   }
 
@@ -97,7 +112,59 @@ public class LineManagerTest extends BaseActivityTest {
       assertNotNull(lineManager);
 
       lineManager.setLineTranslateAnchor(LINE_TRANSLATE_ANCHOR_MAP);
-      assertEquals((String) lineManager.getLineTranslateAnchor(), (String) LINE_TRANSLATE_ANCHOR_MAP);
+      assertEquals(lineManager.getLineTranslateAnchor(), (String) LINE_TRANSLATE_ANCHOR_MAP);
+    });
+  }
+
+  @Test
+  public void testLineWidthAsExpression() {
+    validateTestSetup();
+    setupLineManager();
+    Timber.i("line-width");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(lineManager);
+
+      lineManager.setLineWidthExpression(get("hello"));
+      assertEquals(lineManager.getLineWidthExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testLineGapWidthAsExpression() {
+    validateTestSetup();
+    setupLineManager();
+    Timber.i("line-gap-width");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(lineManager);
+
+      lineManager.setLineGapWidthExpression(get("hello"));
+      assertEquals(lineManager.getLineGapWidthExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testLineOffsetAsExpression() {
+    validateTestSetup();
+    setupLineManager();
+    Timber.i("line-offset");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(lineManager);
+
+      lineManager.setLineOffsetExpression(get("hello"));
+      assertEquals(lineManager.getLineOffsetExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testLineBlurAsExpression() {
+    validateTestSetup();
+    setupLineManager();
+    Timber.i("line-blur");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(lineManager);
+
+      lineManager.setLineBlurExpression(get("hello"));
+      assertEquals(lineManager.getLineBlurExpression(), number(get("hello")));
     });
   }
 
@@ -110,7 +177,20 @@ public class LineManagerTest extends BaseActivityTest {
       assertNotNull(lineManager);
 
       lineManager.setLineDasharray(new Float[] {});
-      assertEquals((Float[]) lineManager.getLineDasharray(), (Float[]) new Float[] {});
+      assertEquals(lineManager.getLineDasharray(), (Float[]) new Float[] {});
+    });
+  }
+
+  @Test
+  public void testLinePatternAsExpression() {
+    validateTestSetup();
+    setupLineManager();
+    Timber.i("line-pattern");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(lineManager);
+
+      lineManager.setLinePatternExpression(get("hello"));
+      assertEquals(lineManager.getLinePatternExpression(), Expression.toString(get("hello")));
     });
   }
 }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 
@@ -45,7 +47,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setSymbolPlacement(SYMBOL_PLACEMENT_POINT);
-      assertEquals((String) symbolManager.getSymbolPlacement(), (String) SYMBOL_PLACEMENT_POINT);
+      assertEquals(symbolManager.getSymbolPlacement(), (String) SYMBOL_PLACEMENT_POINT);
     });
   }
 
@@ -58,7 +60,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setSymbolSpacing(0.3f);
-      assertEquals((Float) symbolManager.getSymbolSpacing(), (Float) 0.3f);
+      assertEquals(symbolManager.getSymbolSpacing(), (Float) 0.3f);
     });
   }
 
@@ -71,7 +73,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setSymbolAvoidEdges(true);
-      assertEquals((Boolean) symbolManager.getSymbolAvoidEdges(), (Boolean) true);
+      assertEquals(symbolManager.getSymbolAvoidEdges(), (Boolean) true);
     });
   }
 
@@ -84,7 +86,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconAllowOverlap(true);
-      assertEquals((Boolean) symbolManager.getIconAllowOverlap(), (Boolean) true);
+      assertEquals(symbolManager.getIconAllowOverlap(), (Boolean) true);
     });
   }
 
@@ -97,7 +99,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconIgnorePlacement(true);
-      assertEquals((Boolean) symbolManager.getIconIgnorePlacement(), (Boolean) true);
+      assertEquals(symbolManager.getIconIgnorePlacement(), (Boolean) true);
     });
   }
 
@@ -110,7 +112,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconOptional(true);
-      assertEquals((Boolean) symbolManager.getIconOptional(), (Boolean) true);
+      assertEquals(symbolManager.getIconOptional(), (Boolean) true);
     });
   }
 
@@ -123,7 +125,20 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP);
-      assertEquals((String) symbolManager.getIconRotationAlignment(), (String) ICON_ROTATION_ALIGNMENT_MAP);
+      assertEquals(symbolManager.getIconRotationAlignment(), (String) ICON_ROTATION_ALIGNMENT_MAP);
+    });
+  }
+
+  @Test
+  public void testIconSizeAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("icon-size");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setIconSizeExpression(get("hello"));
+      assertEquals(symbolManager.getIconSizeExpression(), number(get("hello")));
     });
   }
 
@@ -136,7 +151,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconTextFit(ICON_TEXT_FIT_NONE);
-      assertEquals((String) symbolManager.getIconTextFit(), (String) ICON_TEXT_FIT_NONE);
+      assertEquals(symbolManager.getIconTextFit(), (String) ICON_TEXT_FIT_NONE);
     });
   }
 
@@ -149,7 +164,33 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconTextFitPadding(new Float[] {0f, 0f, 0f, 0f});
-      assertEquals((Float[]) symbolManager.getIconTextFitPadding(), (Float[]) new Float[] {0f, 0f, 0f, 0f});
+      assertEquals(symbolManager.getIconTextFitPadding(), (Float[]) new Float[] {0f, 0f, 0f, 0f});
+    });
+  }
+
+  @Test
+  public void testIconImageAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("icon-image");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setIconImageExpression(get("hello"));
+      assertEquals(symbolManager.getIconImageExpression(), Expression.toString(get("hello")));
+    });
+  }
+
+  @Test
+  public void testIconRotateAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("icon-rotate");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setIconRotateExpression(get("hello"));
+      assertEquals(symbolManager.getIconRotateExpression(), number(get("hello")));
     });
   }
 
@@ -162,7 +203,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconPadding(0.3f);
-      assertEquals((Float) symbolManager.getIconPadding(), (Float) 0.3f);
+      assertEquals(symbolManager.getIconPadding(), (Float) 0.3f);
     });
   }
 
@@ -175,7 +216,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconKeepUpright(true);
-      assertEquals((Boolean) symbolManager.getIconKeepUpright(), (Boolean) true);
+      assertEquals(symbolManager.getIconKeepUpright(), (Boolean) true);
     });
   }
 
@@ -188,7 +229,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconPitchAlignment(ICON_PITCH_ALIGNMENT_MAP);
-      assertEquals((String) symbolManager.getIconPitchAlignment(), (String) ICON_PITCH_ALIGNMENT_MAP);
+      assertEquals(symbolManager.getIconPitchAlignment(), (String) ICON_PITCH_ALIGNMENT_MAP);
     });
   }
 
@@ -201,7 +242,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextPitchAlignment(TEXT_PITCH_ALIGNMENT_MAP);
-      assertEquals((String) symbolManager.getTextPitchAlignment(), (String) TEXT_PITCH_ALIGNMENT_MAP);
+      assertEquals(symbolManager.getTextPitchAlignment(), (String) TEXT_PITCH_ALIGNMENT_MAP);
     });
   }
 
@@ -214,7 +255,33 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextRotationAlignment(TEXT_ROTATION_ALIGNMENT_MAP);
-      assertEquals((String) symbolManager.getTextRotationAlignment(), (String) TEXT_ROTATION_ALIGNMENT_MAP);
+      assertEquals(symbolManager.getTextRotationAlignment(), (String) TEXT_ROTATION_ALIGNMENT_MAP);
+    });
+  }
+
+  @Test
+  public void testTextSizeAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-size");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextSizeExpression(get("hello"));
+      assertEquals(symbolManager.getTextSizeExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testTextMaxWidthAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-max-width");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextMaxWidthExpression(get("hello"));
+      assertEquals(symbolManager.getTextMaxWidthExpression(), number(get("hello")));
     });
   }
 
@@ -227,7 +294,20 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextLineHeight(0.3f);
-      assertEquals((Float) symbolManager.getTextLineHeight(), (Float) 0.3f);
+      assertEquals(symbolManager.getTextLineHeight(), (Float) 0.3f);
+    });
+  }
+
+  @Test
+  public void testTextLetterSpacingAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-letter-spacing");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextLetterSpacingExpression(get("hello"));
+      assertEquals(symbolManager.getTextLetterSpacingExpression(), number(get("hello")));
     });
   }
 
@@ -240,7 +320,20 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextMaxAngle(0.3f);
-      assertEquals((Float) symbolManager.getTextMaxAngle(), (Float) 0.3f);
+      assertEquals(symbolManager.getTextMaxAngle(), (Float) 0.3f);
+    });
+  }
+
+  @Test
+  public void testTextRotateAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-rotate");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextRotateExpression(get("hello"));
+      assertEquals(symbolManager.getTextRotateExpression(), number(get("hello")));
     });
   }
 
@@ -253,7 +346,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextPadding(0.3f);
-      assertEquals((Float) symbolManager.getTextPadding(), (Float) 0.3f);
+      assertEquals(symbolManager.getTextPadding(), (Float) 0.3f);
     });
   }
 
@@ -266,7 +359,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextKeepUpright(true);
-      assertEquals((Boolean) symbolManager.getTextKeepUpright(), (Boolean) true);
+      assertEquals(symbolManager.getTextKeepUpright(), (Boolean) true);
     });
   }
 
@@ -279,7 +372,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextAllowOverlap(true);
-      assertEquals((Boolean) symbolManager.getTextAllowOverlap(), (Boolean) true);
+      assertEquals(symbolManager.getTextAllowOverlap(), (Boolean) true);
     });
   }
 
@@ -292,7 +385,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextIgnorePlacement(true);
-      assertEquals((Boolean) symbolManager.getTextIgnorePlacement(), (Boolean) true);
+      assertEquals(symbolManager.getTextIgnorePlacement(), (Boolean) true);
     });
   }
 
@@ -305,7 +398,46 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextOptional(true);
-      assertEquals((Boolean) symbolManager.getTextOptional(), (Boolean) true);
+      assertEquals(symbolManager.getTextOptional(), (Boolean) true);
+    });
+  }
+
+  @Test
+  public void testIconOpacityAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("icon-opacity");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setIconOpacityExpression(get("hello"));
+      assertEquals(symbolManager.getIconOpacityExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testIconHaloWidthAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("icon-halo-width");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setIconHaloWidthExpression(get("hello"));
+      assertEquals(symbolManager.getIconHaloWidthExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testIconHaloBlurAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("icon-halo-blur");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setIconHaloBlurExpression(get("hello"));
+      assertEquals(symbolManager.getIconHaloBlurExpression(), number(get("hello")));
     });
   }
 
@@ -318,7 +450,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconTranslate(new Float[] {0f, 0f});
-      assertEquals((Float[]) symbolManager.getIconTranslate(), (Float[]) new Float[] {0f, 0f});
+      assertEquals(symbolManager.getIconTranslate(), (Float[]) new Float[] {0f, 0f});
     });
   }
 
@@ -331,7 +463,46 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setIconTranslateAnchor(ICON_TRANSLATE_ANCHOR_MAP);
-      assertEquals((String) symbolManager.getIconTranslateAnchor(), (String) ICON_TRANSLATE_ANCHOR_MAP);
+      assertEquals(symbolManager.getIconTranslateAnchor(), (String) ICON_TRANSLATE_ANCHOR_MAP);
+    });
+  }
+
+  @Test
+  public void testTextOpacityAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-opacity");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextOpacityExpression(get("hello"));
+      assertEquals(symbolManager.getTextOpacityExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testTextHaloWidthAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-halo-width");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextHaloWidthExpression(get("hello"));
+      assertEquals(symbolManager.getTextHaloWidthExpression(), number(get("hello")));
+    });
+  }
+
+  @Test
+  public void testTextHaloBlurAsExpression() {
+    validateTestSetup();
+    setupSymbolManager();
+    Timber.i("text-halo-blur");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(symbolManager);
+
+      symbolManager.setTextHaloBlurExpression(get("hello"));
+      assertEquals(symbolManager.getTextHaloBlurExpression(), number(get("hello")));
     });
   }
 
@@ -344,7 +515,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextTranslate(new Float[] {0f, 0f});
-      assertEquals((Float[]) symbolManager.getTextTranslate(), (Float[]) new Float[] {0f, 0f});
+      assertEquals(symbolManager.getTextTranslate(), (Float[]) new Float[] {0f, 0f});
     });
   }
 
@@ -357,7 +528,7 @@ public class SymbolManagerTest extends BaseActivityTest {
       assertNotNull(symbolManager);
 
       symbolManager.setTextTranslateAnchor(TEXT_TRANSLATE_ANCHOR_MAP);
-      assertEquals((String) symbolManager.getTextTranslateAnchor(), (String) TEXT_TRANSLATE_ANCHOR_MAP);
+      assertEquals(symbolManager.getTextTranslateAnchor(), (String) TEXT_TRANSLATE_ANCHOR_MAP);
     });
   }
 }

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -11,6 +11,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -137,6 +138,30 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), "") %> <%- propertyType(property) %> value) {
     layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(value));
+  }
+
+<% } else {-%>
+  /**
+   * Get the <%- camelize(property.name) %> expression
+   *
+   * @return property wrapper value around <%- propertyType(property) %>
+   */
+  @Nullable
+  public Expression get<%- camelize(property.name) %>Expression() {
+    return layer.get<%- camelize(property.name) %>().getExpression();
+  }
+
+  /**
+   * Set the <%- camelize(property.name) %> expression.
+   * <p>
+   * this expression is applied to all <%- type %>s used by this manager and overrides
+   * behaviour defined on a <%- type %> itself.
+   * </p>
+   *
+   * @param expression value for <%- propertyType(property) %>
+   */
+  public void set<%- camelize(property.name) %>Expression(@NonNull Expression expression) {
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(expression));
   }
 
 <% } -%>

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -11,12 +11,14 @@ import android.support.test.runner.AndroidJUnit4;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 
@@ -51,7 +53,21 @@ public class <%- camelize(type) %>ManagerTest extends BaseActivityTest {
       assertNotNull(<%- type %>Manager);
 
       <%- type %>Manager.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
-      assertEquals((<%- propertyType(property) %>) <%- type %>Manager.get<%- camelize(property.name) %>(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
+      assertEquals(<%- type %>Manager.get<%- camelize(property.name) %>(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
+    });
+  }
+<% } else if(property.type !== "color" && property.type !== "enum" && property.type !== "array" && property.type !== "formatted"){ -%>
+
+  @Test
+  public void test<%- camelize(property.name) %>AsExpression() {
+    validateTestSetup();
+    setup<%- camelize(type) %>Manager();
+    Timber.i("<%- property.name %>");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(<%- type %>Manager);
+
+      <%- type %>Manager.set<%- camelize(property.name) %>Expression(get("hello"));
+      assertEquals(<%- type %>Manager.get<%- camelize(property.name) %>Expression(), <%- propertyJavaExpressionType(property) %>(get("hello")));
     });
   }
 <% } -%>

--- a/plugin-annotation/scripts/code-gen.js
+++ b/plugin-annotation/scripts/code-gen.js
@@ -139,6 +139,21 @@ global.propertyJavaType = function propertyType(property) {
    }
  }
 
+global.propertyJavaExpressionType = function propertyType(property) {
+   switch (property.type) {
+       case 'boolean':
+         return 'boolean';
+       case 'number':
+         return 'number';
+       case 'formatted':
+         return 'format'
+       case 'string':
+         return 'Expression.toString';
+       default:
+         throw new Error(`unknown type for ${property.name}`);
+   }
+ }
+
 global.propertyJNIType = function propertyJNIType(property) {
   switch (property.type) {
       case 'boolean':

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -119,6 +120,98 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
 
   // Property accessors
   /**
+   * Get the CircleRadius expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getCircleRadiusExpression() {
+    return layer.getCircleRadius().getExpression();
+  }
+
+  /**
+   * Set the CircleRadius expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setCircleRadiusExpression(@NonNull Expression expression) {
+    layer.setProperties(circleRadius(expression));
+  }
+
+  /**
+   * Get the CircleColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getCircleColorExpression() {
+    return layer.getCircleColor().getExpression();
+  }
+
+  /**
+   * Set the CircleColor expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setCircleColorExpression(@NonNull Expression expression) {
+    layer.setProperties(circleColor(expression));
+  }
+
+  /**
+   * Get the CircleBlur expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getCircleBlurExpression() {
+    return layer.getCircleBlur().getExpression();
+  }
+
+  /**
+   * Set the CircleBlur expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setCircleBlurExpression(@NonNull Expression expression) {
+    layer.setProperties(circleBlur(expression));
+  }
+
+  /**
+   * Get the CircleOpacity expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getCircleOpacityExpression() {
+    return layer.getCircleOpacity().getExpression();
+  }
+
+  /**
+   * Set the CircleOpacity expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setCircleOpacityExpression(@NonNull Expression expression) {
+    layer.setProperties(circleOpacity(expression));
+  }
+
+  /**
    * Get the CircleTranslate property
    *
    * @return property wrapper value around Float[]
@@ -188,6 +281,75 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    */
   public void setCirclePitchAlignment(@Property.CIRCLE_PITCH_ALIGNMENT String value) {
     layer.setProperties(circlePitchAlignment(value));
+  }
+
+  /**
+   * Get the CircleStrokeWidth expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getCircleStrokeWidthExpression() {
+    return layer.getCircleStrokeWidth().getExpression();
+  }
+
+  /**
+   * Set the CircleStrokeWidth expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setCircleStrokeWidthExpression(@NonNull Expression expression) {
+    layer.setProperties(circleStrokeWidth(expression));
+  }
+
+  /**
+   * Get the CircleStrokeColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getCircleStrokeColorExpression() {
+    return layer.getCircleStrokeColor().getExpression();
+  }
+
+  /**
+   * Set the CircleStrokeColor expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setCircleStrokeColorExpression(@NonNull Expression expression) {
+    layer.setProperties(circleStrokeColor(expression));
+  }
+
+  /**
+   * Get the CircleStrokeOpacity expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getCircleStrokeOpacityExpression() {
+    return layer.getCircleStrokeOpacity().getExpression();
+  }
+
+  /**
+   * Set the CircleStrokeOpacity expression.
+   * <p>
+   * this expression is applied to all circles used by this manager and overrides
+   * behaviour defined on a circle itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setCircleStrokeOpacityExpression(@NonNull Expression expression) {
+    layer.setProperties(circleStrokeOpacity(expression));
   }
 
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -125,6 +126,75 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
   }
 
   /**
+   * Get the FillOpacity expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getFillOpacityExpression() {
+    return layer.getFillOpacity().getExpression();
+  }
+
+  /**
+   * Set the FillOpacity expression.
+   * <p>
+   * this expression is applied to all fills used by this manager and overrides
+   * behaviour defined on a fill itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setFillOpacityExpression(@NonNull Expression expression) {
+    layer.setProperties(fillOpacity(expression));
+  }
+
+  /**
+   * Get the FillColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getFillColorExpression() {
+    return layer.getFillColor().getExpression();
+  }
+
+  /**
+   * Set the FillColor expression.
+   * <p>
+   * this expression is applied to all fills used by this manager and overrides
+   * behaviour defined on a fill itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setFillColorExpression(@NonNull Expression expression) {
+    layer.setProperties(fillColor(expression));
+  }
+
+  /**
+   * Get the FillOutlineColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getFillOutlineColorExpression() {
+    return layer.getFillOutlineColor().getExpression();
+  }
+
+  /**
+   * Set the FillOutlineColor expression.
+   * <p>
+   * this expression is applied to all fills used by this manager and overrides
+   * behaviour defined on a fill itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setFillOutlineColorExpression(@NonNull Expression expression) {
+    layer.setProperties(fillOutlineColor(expression));
+  }
+
+  /**
    * Get the FillTranslate property
    *
    * @return property wrapper value around Float[]
@@ -158,6 +228,29 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    */
   public void setFillTranslateAnchor(@Property.FILL_TRANSLATE_ANCHOR String value) {
     layer.setProperties(fillTranslateAnchor(value));
+  }
+
+  /**
+   * Get the FillPattern expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getFillPatternExpression() {
+    return layer.getFillPattern().getExpression();
+  }
+
+  /**
+   * Set the FillPattern expression.
+   * <p>
+   * this expression is applied to all fills used by this manager and overrides
+   * behaviour defined on a fill itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setFillPatternExpression(@NonNull Expression expression) {
+    layer.setProperties(fillPattern(expression));
   }
 
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -141,6 +142,29 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
   }
 
   /**
+   * Get the LineJoin expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getLineJoinExpression() {
+    return layer.getLineJoin().getExpression();
+  }
+
+  /**
+   * Set the LineJoin expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setLineJoinExpression(@NonNull Expression expression) {
+    layer.setProperties(lineJoin(expression));
+  }
+
+  /**
    * Get the LineMiterLimit property
    *
    * @return property wrapper value around Float
@@ -174,6 +198,52 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   public void setLineRoundLimit( Float value) {
     layer.setProperties(lineRoundLimit(value));
+  }
+
+  /**
+   * Get the LineOpacity expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getLineOpacityExpression() {
+    return layer.getLineOpacity().getExpression();
+  }
+
+  /**
+   * Set the LineOpacity expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setLineOpacityExpression(@NonNull Expression expression) {
+    layer.setProperties(lineOpacity(expression));
+  }
+
+  /**
+   * Get the LineColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getLineColorExpression() {
+    return layer.getLineColor().getExpression();
+  }
+
+  /**
+   * Set the LineColor expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setLineColorExpression(@NonNull Expression expression) {
+    layer.setProperties(lineColor(expression));
   }
 
   /**
@@ -213,6 +283,98 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
   }
 
   /**
+   * Get the LineWidth expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getLineWidthExpression() {
+    return layer.getLineWidth().getExpression();
+  }
+
+  /**
+   * Set the LineWidth expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setLineWidthExpression(@NonNull Expression expression) {
+    layer.setProperties(lineWidth(expression));
+  }
+
+  /**
+   * Get the LineGapWidth expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getLineGapWidthExpression() {
+    return layer.getLineGapWidth().getExpression();
+  }
+
+  /**
+   * Set the LineGapWidth expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setLineGapWidthExpression(@NonNull Expression expression) {
+    layer.setProperties(lineGapWidth(expression));
+  }
+
+  /**
+   * Get the LineOffset expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getLineOffsetExpression() {
+    return layer.getLineOffset().getExpression();
+  }
+
+  /**
+   * Set the LineOffset expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setLineOffsetExpression(@NonNull Expression expression) {
+    layer.setProperties(lineOffset(expression));
+  }
+
+  /**
+   * Get the LineBlur expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getLineBlurExpression() {
+    return layer.getLineBlur().getExpression();
+  }
+
+  /**
+   * Set the LineBlur expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setLineBlurExpression(@NonNull Expression expression) {
+    layer.setProperties(lineBlur(expression));
+  }
+
+  /**
    * Get the LineDasharray property
    *
    * @return property wrapper value around Float[]
@@ -228,6 +390,52 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   public void setLineDasharray( Float[] value) {
     layer.setProperties(lineDasharray(value));
+  }
+
+  /**
+   * Get the LinePattern expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getLinePatternExpression() {
+    return layer.getLinePattern().getExpression();
+  }
+
+  /**
+   * Set the LinePattern expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setLinePatternExpression(@NonNull Expression expression) {
+    layer.setProperties(linePattern(expression));
+  }
+
+  /**
+   * Get the LineGradient expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getLineGradientExpression() {
+    return layer.getLineGradient().getExpression();
+  }
+
+  /**
+   * Set the LineGradient expression.
+   * <p>
+   * this expression is applied to all lines used by this manager and overrides
+   * behaviour defined on a line itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setLineGradientExpression(@NonNull Expression expression) {
+    layer.setProperties(lineGradient(expression));
   }
 
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -249,6 +250,29 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Get the SymbolZOrder expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getSymbolZOrderExpression() {
+    return layer.getSymbolZOrder().getExpression();
+  }
+
+  /**
+   * Set the SymbolZOrder expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setSymbolZOrderExpression(@NonNull Expression expression) {
+    layer.setProperties(symbolZOrder(expression));
+  }
+
+  /**
    * Get the IconAllowOverlap property
    *
    * @return property wrapper value around Boolean
@@ -321,6 +345,29 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Get the IconSize expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getIconSizeExpression() {
+    return layer.getIconSize().getExpression();
+  }
+
+  /**
+   * Set the IconSize expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setIconSizeExpression(@NonNull Expression expression) {
+    layer.setProperties(iconSize(expression));
+  }
+
+  /**
    * Get the IconTextFit property
    *
    * @return property wrapper value around String
@@ -357,6 +404,52 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Get the IconImage expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getIconImageExpression() {
+    return layer.getIconImage().getExpression();
+  }
+
+  /**
+   * Set the IconImage expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setIconImageExpression(@NonNull Expression expression) {
+    layer.setProperties(iconImage(expression));
+  }
+
+  /**
+   * Get the IconRotate expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getIconRotateExpression() {
+    return layer.getIconRotate().getExpression();
+  }
+
+  /**
+   * Set the IconRotate expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setIconRotateExpression(@NonNull Expression expression) {
+    layer.setProperties(iconRotate(expression));
+  }
+
+  /**
    * Get the IconPadding property
    *
    * @return property wrapper value around Float
@@ -390,6 +483,52 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   public void setIconKeepUpright( Boolean value) {
     layer.setProperties(iconKeepUpright(value));
+  }
+
+  /**
+   * Get the IconOffset expression
+   *
+   * @return property wrapper value around Float[]
+   */
+  @Nullable
+  public Expression getIconOffsetExpression() {
+    return layer.getIconOffset().getExpression();
+  }
+
+  /**
+   * Set the IconOffset expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float[]
+   */
+  public void setIconOffsetExpression(@NonNull Expression expression) {
+    layer.setProperties(iconOffset(expression));
+  }
+
+  /**
+   * Get the IconAnchor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getIconAnchorExpression() {
+    return layer.getIconAnchor().getExpression();
+  }
+
+  /**
+   * Set the IconAnchor expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setIconAnchorExpression(@NonNull Expression expression) {
+    layer.setProperties(iconAnchor(expression));
   }
 
   /**
@@ -447,6 +586,98 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Get the TextField expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getTextFieldExpression() {
+    return layer.getTextField().getExpression();
+  }
+
+  /**
+   * Set the TextField expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setTextFieldExpression(@NonNull Expression expression) {
+    layer.setProperties(textField(expression));
+  }
+
+  /**
+   * Get the TextFont expression
+   *
+   * @return property wrapper value around String[]
+   */
+  @Nullable
+  public Expression getTextFontExpression() {
+    return layer.getTextFont().getExpression();
+  }
+
+  /**
+   * Set the TextFont expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String[]
+   */
+  public void setTextFontExpression(@NonNull Expression expression) {
+    layer.setProperties(textFont(expression));
+  }
+
+  /**
+   * Get the TextSize expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextSizeExpression() {
+    return layer.getTextSize().getExpression();
+  }
+
+  /**
+   * Set the TextSize expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextSizeExpression(@NonNull Expression expression) {
+    layer.setProperties(textSize(expression));
+  }
+
+  /**
+   * Get the TextMaxWidth expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextMaxWidthExpression() {
+    return layer.getTextMaxWidth().getExpression();
+  }
+
+  /**
+   * Set the TextMaxWidth expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextMaxWidthExpression(@NonNull Expression expression) {
+    layer.setProperties(textMaxWidth(expression));
+  }
+
+  /**
    * Get the TextLineHeight property
    *
    * @return property wrapper value around Float
@@ -465,6 +696,75 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Get the TextLetterSpacing expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextLetterSpacingExpression() {
+    return layer.getTextLetterSpacing().getExpression();
+  }
+
+  /**
+   * Set the TextLetterSpacing expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextLetterSpacingExpression(@NonNull Expression expression) {
+    layer.setProperties(textLetterSpacing(expression));
+  }
+
+  /**
+   * Get the TextJustify expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getTextJustifyExpression() {
+    return layer.getTextJustify().getExpression();
+  }
+
+  /**
+   * Set the TextJustify expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setTextJustifyExpression(@NonNull Expression expression) {
+    layer.setProperties(textJustify(expression));
+  }
+
+  /**
+   * Get the TextAnchor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getTextAnchorExpression() {
+    return layer.getTextAnchor().getExpression();
+  }
+
+  /**
+   * Set the TextAnchor expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setTextAnchorExpression(@NonNull Expression expression) {
+    layer.setProperties(textAnchor(expression));
+  }
+
+  /**
    * Get the TextMaxAngle property
    *
    * @return property wrapper value around Float
@@ -480,6 +780,29 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   public void setTextMaxAngle( Float value) {
     layer.setProperties(textMaxAngle(value));
+  }
+
+  /**
+   * Get the TextRotate expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextRotateExpression() {
+    return layer.getTextRotate().getExpression();
+  }
+
+  /**
+   * Set the TextRotate expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextRotateExpression(@NonNull Expression expression) {
+    layer.setProperties(textRotate(expression));
   }
 
   /**
@@ -516,6 +839,52 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   public void setTextKeepUpright( Boolean value) {
     layer.setProperties(textKeepUpright(value));
+  }
+
+  /**
+   * Get the TextTransform expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getTextTransformExpression() {
+    return layer.getTextTransform().getExpression();
+  }
+
+  /**
+   * Set the TextTransform expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setTextTransformExpression(@NonNull Expression expression) {
+    layer.setProperties(textTransform(expression));
+  }
+
+  /**
+   * Get the TextOffset expression
+   *
+   * @return property wrapper value around Float[]
+   */
+  @Nullable
+  public Expression getTextOffsetExpression() {
+    return layer.getTextOffset().getExpression();
+  }
+
+  /**
+   * Set the TextOffset expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float[]
+   */
+  public void setTextOffsetExpression(@NonNull Expression expression) {
+    layer.setProperties(textOffset(expression));
   }
 
   /**
@@ -573,6 +942,121 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Get the IconOpacity expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getIconOpacityExpression() {
+    return layer.getIconOpacity().getExpression();
+  }
+
+  /**
+   * Set the IconOpacity expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setIconOpacityExpression(@NonNull Expression expression) {
+    layer.setProperties(iconOpacity(expression));
+  }
+
+  /**
+   * Get the IconColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getIconColorExpression() {
+    return layer.getIconColor().getExpression();
+  }
+
+  /**
+   * Set the IconColor expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setIconColorExpression(@NonNull Expression expression) {
+    layer.setProperties(iconColor(expression));
+  }
+
+  /**
+   * Get the IconHaloColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getIconHaloColorExpression() {
+    return layer.getIconHaloColor().getExpression();
+  }
+
+  /**
+   * Set the IconHaloColor expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setIconHaloColorExpression(@NonNull Expression expression) {
+    layer.setProperties(iconHaloColor(expression));
+  }
+
+  /**
+   * Get the IconHaloWidth expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getIconHaloWidthExpression() {
+    return layer.getIconHaloWidth().getExpression();
+  }
+
+  /**
+   * Set the IconHaloWidth expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setIconHaloWidthExpression(@NonNull Expression expression) {
+    layer.setProperties(iconHaloWidth(expression));
+  }
+
+  /**
+   * Get the IconHaloBlur expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getIconHaloBlurExpression() {
+    return layer.getIconHaloBlur().getExpression();
+  }
+
+  /**
+   * Set the IconHaloBlur expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setIconHaloBlurExpression(@NonNull Expression expression) {
+    layer.setProperties(iconHaloBlur(expression));
+  }
+
+  /**
    * Get the IconTranslate property
    *
    * @return property wrapper value around Float[]
@@ -606,6 +1090,121 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   public void setIconTranslateAnchor(@Property.ICON_TRANSLATE_ANCHOR String value) {
     layer.setProperties(iconTranslateAnchor(value));
+  }
+
+  /**
+   * Get the TextOpacity expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextOpacityExpression() {
+    return layer.getTextOpacity().getExpression();
+  }
+
+  /**
+   * Set the TextOpacity expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextOpacityExpression(@NonNull Expression expression) {
+    layer.setProperties(textOpacity(expression));
+  }
+
+  /**
+   * Get the TextColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getTextColorExpression() {
+    return layer.getTextColor().getExpression();
+  }
+
+  /**
+   * Set the TextColor expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setTextColorExpression(@NonNull Expression expression) {
+    layer.setProperties(textColor(expression));
+  }
+
+  /**
+   * Get the TextHaloColor expression
+   *
+   * @return property wrapper value around String
+   */
+  @Nullable
+  public Expression getTextHaloColorExpression() {
+    return layer.getTextHaloColor().getExpression();
+  }
+
+  /**
+   * Set the TextHaloColor expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for String
+   */
+  public void setTextHaloColorExpression(@NonNull Expression expression) {
+    layer.setProperties(textHaloColor(expression));
+  }
+
+  /**
+   * Get the TextHaloWidth expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextHaloWidthExpression() {
+    return layer.getTextHaloWidth().getExpression();
+  }
+
+  /**
+   * Set the TextHaloWidth expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextHaloWidthExpression(@NonNull Expression expression) {
+    layer.setProperties(textHaloWidth(expression));
+  }
+
+  /**
+   * Get the TextHaloBlur expression
+   *
+   * @return property wrapper value around Float
+   */
+  @Nullable
+  public Expression getTextHaloBlurExpression() {
+    return layer.getTextHaloBlur().getExpression();
+  }
+
+  /**
+   * Set the TextHaloBlur expression.
+   * <p>
+   * this expression is applied to all symbols used by this manager and overrides
+   * behaviour defined on a symbol itself.
+   * </p>
+   *
+   * @param expression value for Float
+   */
+  public void setTextHaloBlurExpression(@NonNull Expression expression) {
+    layer.setProperties(textHaloBlur(expression));
   }
 
   /**


### PR DESCRIPTION
Closes #736. PR exposes basic setters and getters for expression on the manager level. They override behaviour defined in the underlying annotation. This enables users to combine per annotation syntax with using expressions on the manager class. Basic testing for boolean, number and string expression values were added. Leaving out format, array,.. out for now. 

