### PR TITLE
Support for streets v8 sources

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
@@ -5,14 +5,12 @@ import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
-
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.plugins.localization.LocalizationPlugin
 import com.mapbox.mapboxsdk.plugins.localization.MapLocale
 import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.Utils
-
 import kotlinx.android.synthetic.main.activity_localization.*
 
 class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -44,11 +42,11 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
         fabCamera.setOnClickListener{
             val locale = nextMapLocale
             localizationPlugin?.setMapLanguage(locale)
-            localizationPlugin?.setCameraToLocaleCountry(locale)
+            localizationPlugin?.setCameraToLocaleCountry(locale, 25)
         }
 
         fabStyles.setOnClickListener{
-            mapboxMap?.setStyleUrl(Utils.nextStyle);
+            mapboxMap?.setStyleUrl(Utils.nextStyle)
         }
     }
 
@@ -144,6 +142,10 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
                 localizationPlugin?.setMapLanguage(MapLocale.KOREAN)
                 return true
             }
+            R.id.local -> {
+                localizationPlugin?.setMapLanguage(MapLocale.LOCAL_NAME)
+                return true
+            }
             android.R.id.home -> {
                 finish()
                 return true
@@ -154,7 +156,7 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
 
     companion object {
 
-        private val LOCALES = arrayOf(MapLocale.CANADA, MapLocale.GERMANY, MapLocale.CHINA, MapLocale.US, MapLocale.CANADA_FRENCH, MapLocale.ITALY, MapLocale.JAPAN, MapLocale.KOREA, MapLocale.FRANCE)
+        private val LOCALES = arrayOf(MapLocale.CANADA, MapLocale.GERMANY, MapLocale.CHINA, MapLocale.US, MapLocale.CANADA_FRENCH, MapLocale.JAPAN, MapLocale.KOREA, MapLocale.FRANCE, MapLocale.SPAIN)
 
         private var index: Int = 0
 

--- a/app/src/main/res/menu/menu_languages.xml
+++ b/app/src/main/res/menu/menu_languages.xml
@@ -58,4 +58,9 @@
         android:title="Korean"
         app:showAsAction="never"/>
 
+    <item
+        android:id="@+id/local"
+        android:title="Local names"
+        app:showAsAction="never"/>
+
 </menu>

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -33,7 +33,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 public final class LocalizationPlugin implements MapView.OnMapChangedListener {
 
   // expression syntax
-  private static final String EXPRESSION_REGEX = "\\bname_.{2}";
+  private static final String EXPRESSION_REGEX = "\\bname_.{2,7}\\b";
 
   private static final String EXPRESSION_V8_REGEX_BASE = "\\[\"get\", \"name_en\"], \\[\"get\", \"name\"]";
   private static final String EXPRESSION_V8_TEMPLATE_BASE = "[\"get\", \"name_en\"], [\"get\", \"name\"]";

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -27,7 +27,16 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
  * Useful class for quickly adjusting the maps language and the maps camera starting position.
  * You can either use {@link #matchMapLanguageWithDeviceDefault()} to match the map language with
  * the one being currently used on the device. Using {@link #setMapLanguage(Locale)} and it's
- * variants, you can also change the maps langauge at anytime to any of the supported languages.
+ * variants, you can also change the maps language at anytime to any of the supported languages.
+ * <p>
+ * The plugin uses a fallback logic in case there are missing resources
+ * - if there is no available localization for a label, the plugin will use local name, if it's Latin script based,
+ * otherwise English. Traditional Chinese falls back to Simplified Chinese before executing before mentioned logic.
+ * <p>
+ * The plugin only support Mapbox sources:<br/>
+ * - mapbox.mapbox-streets-v6<br/>
+ * - mapbox.mapbox-streets-v7<br/>
+ * - mapbox.mapbox-streets-v8
  *
  * @since 0.1.0
  */
@@ -137,8 +146,6 @@ public final class LocalizationPlugin {
    * locale you are trying to use, has a complementary {@link MapLocale} for it.
    *
    * @param locale a {@link Locale} which has a complementary {@link MapLocale} for it
-   * @throws NullPointerException thrown when the locale passed into the method doesn't have a
-   *                              matching {@link MapLocale}
    * @since 0.1.0
    */
   public void setMapLanguage(@NonNull Locale locale) {
@@ -178,7 +185,15 @@ public final class LocalizationPlugin {
           }
         }
       } else {
-        Timber.w("The source is not based on Mapbox Vector Tiles. Supported sources:\n %s", SUPPORTED_SOURCES);
+        String url = null;
+        if (source instanceof VectorSource) {
+          url = ((VectorSource) source).getUrl();
+        }
+        if (url == null) {
+          url = "not found";
+        }
+        Timber.w("The \"%s\" source is not based on Mapbox Vector Tiles. Supported sources:\n %s",
+          url, SUPPORTED_SOURCES);
       }
     }
   }
@@ -249,8 +264,6 @@ public final class LocalizationPlugin {
    *
    * @param locale  a {@link Locale} which has a complementary {@link MapLocale} for it
    * @param padding camera padding
-   * @throws NullPointerException thrown when the locale passed into the method doesn't have a
-   *                              matching {@link MapLocale}
    * @since 0.1.0
    */
   public void setCameraToLocaleCountry(Locale locale, int padding) {
@@ -268,8 +281,6 @@ public final class LocalizationPlugin {
    *
    * @param mapLocale the {@link MapLocale} object which contains the desired map bounds
    * @param padding   camera padding
-   * @throws NullPointerException thrown when it was expecting a {@link LatLngBounds} but instead
-   *                              it was null
    * @since 0.1.0
    */
   public void setCameraToLocaleCountry(MapLocale mapLocale, int padding) {

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -86,6 +86,11 @@ public final class MapLocale {
   public static final String CHINESE = "name_zh";
 
   /**
+   * Chinese (if available, otherwise same as name)
+   */
+  static final String CHINESE_V8 = "name_zh-Hant";
+
+  /**
    * Simplified Chinese (if available, otherwise same as name)
    */
   public static final String SIMPLIFIED_CHINESE = "name_zh-Hans";
@@ -282,7 +287,7 @@ public final class MapLocale {
    * @param mapLanguage a non-null string which is allowed from {@link Languages}
    * @since 0.1.0
    */
-  public MapLocale(@NonNull @Languages String mapLanguage) {
+  public MapLocale(@NonNull String mapLanguage) {
     this(mapLanguage, null);
   }
 

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -172,13 +172,6 @@ public final class MapLocale {
     .include(new LatLng(41.371582, 9.561556)).build();
 
   /**
-   * Italy Bounding Box extracted from Open Street Map
-   */
-  static final LatLngBounds ITALY_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(47.095196, 6.614889))
-    .include(new LatLng(36.652779, 18.513445)).build();
-
-  /**
    * Peoples Republic of China Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds PRC_BBOX = new LatLngBounds.Builder()
@@ -186,11 +179,18 @@ public final class MapLocale {
     .include(new LatLng(15.775416, 134.773911)).build();
 
   /**
-   * Russian Bounding box extraced from Open Street Map
+   * Russian Bounding box extracted from Open Street Map
    */
   static final LatLngBounds RUSSIA_BBOX = new LatLngBounds.Builder()
     .include(new LatLng(81.856903, -168.997849))
     .include(new LatLng(41.185902, 19.638861)).build();
+
+  /**
+   * Spain Bounding box extracted from Open Street Map
+   */
+  static final LatLngBounds SPAIN_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(27.4335426, -18.3936845))
+    .include(new LatLng(43.9933088, 4.5918885)).build();
 
   /*
    * Some MapLocales already defined (these match with the predefined ones in the Locale class)
@@ -209,17 +209,12 @@ public final class MapLocale {
   /**
    * Useful constant for country.
    */
-  public static final MapLocale ITALY = new MapLocale(LOCAL_NAME, ITALY_BBOX);
+  public static final MapLocale JAPAN = new MapLocale(JAPANESE, JAPAN_BBOX);
 
   /**
    * Useful constant for country.
    */
-  public static final MapLocale JAPAN = new MapLocale(LOCAL_NAME, JAPAN_BBOX);
-
-  /**
-   * Useful constant for country.
-   */
-  public static final MapLocale KOREA = new MapLocale(LOCAL_NAME, KOREA_BBOX);
+  public static final MapLocale KOREA = new MapLocale(KOREAN, KOREA_BBOX);
 
   /**
    * Useful constant for country.
@@ -257,6 +252,11 @@ public final class MapLocale {
   public static final MapLocale RUSSIA = new MapLocale(RUSSIAN, RUSSIA_BBOX);
 
   /**
+   * Useful constant for country.
+   */
+  public static final MapLocale SPAIN = new MapLocale(SPANISH, SPAIN_BBOX);
+
+  /**
    * Maps out the Matching pair of {@link Locale} and {@link MapLocale}. In other words, if I have a
    * {@link Locale#CANADA}, this should be matched up with {@link MapLocale#CANADA}.
    */
@@ -269,13 +269,13 @@ public final class MapLocale {
     LOCALE_SET.put(Locale.CANADA, MapLocale.CANADA);
     LOCALE_SET.put(Locale.CHINA, MapLocale.CHINA);
     LOCALE_SET.put(Locale.PRC, MapLocale.PRC);
-    LOCALE_SET.put(Locale.ITALY, MapLocale.ITALY);
     LOCALE_SET.put(Locale.UK, MapLocale.UK);
     LOCALE_SET.put(Locale.JAPAN, MapLocale.JAPAN);
     LOCALE_SET.put(Locale.KOREA, MapLocale.KOREA);
     LOCALE_SET.put(Locale.GERMANY, MapLocale.GERMANY);
     LOCALE_SET.put(Locale.FRANCE, MapLocale.FRANCE);
     LOCALE_SET.put(new Locale("ru", "RU"), RUSSIA);
+    LOCALE_SET.put(new Locale("es", "ES"), SPAIN);
   }
 
   private final LatLngBounds countryBounds;

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -41,67 +41,67 @@ public final class MapLocale {
    */
 
   /**
-   * the name (or names) used locally for the place.
+   * The name (or names) used locally for the place.
    */
   public static final String LOCAL_NAME = "name";
 
   /**
-   * English (if available, otherwise same as name)
+   * English (if available)
    */
   public static final String ENGLISH = "name_en";
 
   /**
-   * French (if available, otherwise same as name_en)
+   * French (if available)
    */
   public static final String FRENCH = "name_fr";
 
   /**
-   * Arabic (if available, otherwise same as name)
+   * Arabic (if available)
    */
   public static final String ARABIC = "name_ar";
 
   /**
-   * Spanish (if available, otherwise same as name_en)
+   * Spanish (if available)
    */
   public static final String SPANISH = "name_es";
 
   /**
-   * German (if available, otherwise same as name_en)
+   * German (if available)
    */
   public static final String GERMAN = "name_de";
 
   /**
-   * Portuguese (if available, otherwise same as name_en)
+   * Portuguese (if available)
    */
   public static final String PORTUGUESE = "name_pt";
 
   /**
-   * Russian (if available, otherwise same as name)
+   * Russian (if available)
    */
   public static final String RUSSIAN = "name_ru";
 
   /**
-   * Chinese (if available, otherwise same as name)
+   * Chinese (if available)
    */
   public static final String CHINESE = "name_zh";
 
   /**
-   * Chinese (if available, otherwise same as name)
+   * Chinese (if available)
    */
   static final String CHINESE_V8 = "name_zh-Hant";
 
   /**
-   * Simplified Chinese (if available, otherwise same as name)
+   * Simplified Chinese (if available)
    */
   public static final String SIMPLIFIED_CHINESE = "name_zh-Hans";
 
   /**
-   * Japanese (if available, otherwise same as name)
+   * Japanese (if available)
    */
   public static final String JAPANESE = "name_ja";
 
   /**
-   * Korean (if available, otherwise same as name)
+   * Korean (if available)
    */
   public static final String KOREAN = "name_ko";
 


### PR DESCRIPTION
This PR adds support for `streets.v8` based tile sources and fixes issues when switching from Simplified Chinese or local name to any other locale.

In `streets.v8` sources language fallback logic in case of missing resources should be executed on style level, rather than source level.

Fallback for resources looks as follows:
- For Latin script based local names:
```
Localization -> Local name
```
- For Simplified Chinese:
```
Simplified Chinese -> Local name or English (depending whether local name is Latin script based)
```
- For Traditional Chinese:
```
Traditional Chinese -> Simplified Chinese -> Local name or English (depending whether local name is Latin script based)
```
- Any other:
```
Localization -> English -> Local name
```

/cc @nickidlugash 