### PR TITLE
AnnotationPlugin with Maps 7.0.0 and state save across style changes

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -5,12 +5,14 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -26,13 +28,13 @@ public class CircleManagerTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupCircleManager() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      circleManager = new CircleManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      circleManager = new CircleManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
     });
   }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -31,13 +33,13 @@ public class CircleTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupAnnotation() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      CircleManager circleManager = new CircleManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      CircleManager circleManager = new CircleManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
       circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     });
   }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -5,12 +5,14 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -26,13 +28,13 @@ public class FillManagerTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupFillManager() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      fillManager = new FillManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      fillManager = new FillManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
     });
   }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -31,13 +33,13 @@ public class FillTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupAnnotation() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      FillManager fillManager = new FillManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      FillManager fillManager = new FillManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
       List<LatLng>innerLatLngs = new ArrayList<>();
       innerLatLngs.add(new LatLng());
       innerLatLngs.add(new LatLng(1,1));

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -5,12 +5,14 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -26,13 +28,13 @@ public class LineManagerTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupLineManager() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      lineManager = new LineManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      lineManager = new LineManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
     });
   }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -31,13 +33,13 @@ public class LineTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupAnnotation() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      LineManager lineManager = new LineManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      LineManager lineManager = new LineManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
       List<LatLng>latLngs = new ArrayList<>();
       latLngs.add(new LatLng());
       latLngs.add(new LatLng(1,1));

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -5,12 +5,14 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -26,13 +28,13 @@ public class SymbolManagerTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupSymbolManager() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      symbolManager = new SymbolManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      symbolManager = new SymbolManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
     });
   }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
@@ -7,12 +7,14 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -31,13 +33,13 @@ public class SymbolTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupAnnotation() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      SymbolManager symbolManager = new SymbolManager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      SymbolManager symbolManager = new SymbolManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
       symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
     });
   }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/OnMapReadyIdlingResource.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/OnMapReadyIdlingResource.java
@@ -3,11 +3,13 @@ package com.mapbox.mapboxsdk.plugins.utils;
 import android.app.Activity;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.NonNull;
 import android.support.test.espresso.IdlingResource;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 
 public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallback {
@@ -37,7 +39,7 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
 
   @Override
   public boolean isIdleNow() {
-    return mapboxMap != null;
+    return mapboxMap != null && mapboxMap.getStyle() != null && mapboxMap.getStyle().isFullyLoaded();
   }
 
   @Override
@@ -54,10 +56,12 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
   }
 
   @Override
-  public void onMapReady(MapboxMap mapboxMap) {
+  public void onMapReady(@NonNull MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    if (resourceCallback != null) {
-      resourceCallback.onTransitionToIdle();
-    }
+    mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+      if (resourceCallback != null) {
+        resourceCallback.onTransitionToIdle();
+      }
+    });
   }
 }

--- a/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
+++ b/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
@@ -1,0 +1,53 @@
+package com.mapbox.mapboxsdk.plugins.testapp.activity
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.plugins.testapp.R
+
+class TestActivity : AppCompatActivity() {
+
+  lateinit var mapView: MapView
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_test)
+    this.mapView = findViewById(R.id.mapView)
+    mapView.onCreate(savedInstanceState)
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onResume() {
+    super.onResume()
+    mapView.onResume()
+  }
+
+  override fun onPause() {
+    super.onPause()
+    mapView.onPause()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    mapView.onSaveInstanceState(outState)
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+}

--- a/app/src/debug/res/layout/activity_test.xml
+++ b/app/src/debug/res/layout/activity_test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.TestActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</RelativeLayout>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="title_activity_test">TestActivity</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -194,6 +194,11 @@
               android:value=".activity.FeatureOverviewActivity" />
     </activity>
 
+    <activity
+        android:name=".activity.TestActivity"
+        android:label="@string/title_activity_test"
+        android:theme="@style/AppTheme.NoActionBar"/>
+
     <service
       android:name="com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadService"
       android:exported="false"/>

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -54,7 +54,7 @@ public class CircleActivity extends AppCompatActivity {
         mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
         // create circle manager
-        circleManager = new CircleManager(mapView, mapboxMap);
+        circleManager = new CircleManager(mapView, mapboxMap, style);
         circleManager.addClickListener(circle -> Toast.makeText(CircleActivity.this,
           String.format("Circle clicked %s", circle.getId()),
           Toast.LENGTH_SHORT

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -9,7 +9,6 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -20,7 +19,6 @@ import com.mapbox.mapboxsdk.plugins.annotation.CircleOptions;
 import com.mapbox.mapboxsdk.plugins.annotation.OnCircleDragListener;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.io.IOException;
@@ -48,70 +46,70 @@ public class CircleActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-    mapView.getMapAsync(mapboxMap ->
-      mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+    mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+      findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
-        mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-        // create circle manager
-        circleManager = new CircleManager(mapView, mapboxMap, style);
-        circleManager.addClickListener(circle -> Toast.makeText(CircleActivity.this,
-          String.format("Circle clicked %s", circle.getId()),
-          Toast.LENGTH_SHORT
-        ).show());
-        circleManager.addLongClickListener(circle -> Toast.makeText(CircleActivity.this,
-          String.format("Circle long clicked %s", circle.getId()),
-          Toast.LENGTH_SHORT
-        ).show());
+      // create circle manager
+      circleManager = new CircleManager(mapView, mapboxMap, style);
+      circleManager.addClickListener(circle -> Toast.makeText(CircleActivity.this,
+        String.format("Circle clicked %s", circle.getId()),
+        Toast.LENGTH_SHORT
+      ).show());
+      circleManager.addLongClickListener(circle -> Toast.makeText(CircleActivity.this,
+        String.format("Circle long clicked %s", circle.getId()),
+        Toast.LENGTH_SHORT
+      ).show());
 
-        // create a fixed circle
-        CircleOptions circleOptions = new CircleOptions()
-          .withLatLng(new LatLng(6.687337, 0.381457))
-          .withCircleColor(ColorUtils.colorToRgbaString(Color.YELLOW))
-          .withCircleRadius(12f)
-          .setDraggable(true);
-        circleManager.create(circleOptions);
+      // create a fixed circle
+      CircleOptions circleOptions = new CircleOptions()
+        .withLatLng(new LatLng(6.687337, 0.381457))
+        .withCircleColor(ColorUtils.colorToRgbaString(Color.YELLOW))
+        .withCircleRadius(12f)
+        .setDraggable(true);
+      circleManager.create(circleOptions);
 
-        // random add circles across the globe
-        List<CircleOptions> circleOptionsList = new ArrayList<>();
-        for (int i = 0; i < 20; i++) {
-          int color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256));
-          circleOptionsList.add(new CircleOptions()
-            .withLatLng(createRandomLatLng())
-            .withCircleColor(ColorUtils.colorToRgbaString(color))
-            .withCircleRadius(8f)
-            .setDraggable(true)
-          );
+      // random add circles across the globe
+      List<CircleOptions> circleOptionsList = new ArrayList<>();
+      for (int i = 0; i < 20; i++) {
+        int color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256));
+        circleOptionsList.add(new CircleOptions()
+          .withLatLng(createRandomLatLng())
+          .withCircleColor(ColorUtils.colorToRgbaString(color))
+          .withCircleRadius(8f)
+          .setDraggable(true)
+        );
+      }
+      circleManager.create(circleOptionsList);
+
+      try {
+        circleManager.create(Utils.INSTANCE.loadStringFromAssets(this, "annotations.json"));
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to parse annotations.json");
+      }
+
+      circleManager.addDragListener(new OnCircleDragListener() {
+        @Override
+        public void onAnnotationDragStarted(Circle annotation) {
+          draggableInfoTv.setVisibility(View.VISIBLE);
         }
-        circleManager.create(circleOptionsList);
 
-        try {
-          circleManager.create(Utils.INSTANCE.loadStringFromAssets(this, "annotations.json"));
-        } catch (IOException e) {
-          throw new RuntimeException("Unable to parse annotations.json");
+        @Override
+        public void onAnnotationDrag(Circle annotation) {
+          draggableInfoTv.setText(String.format(
+            Locale.US,
+            "ID: %s\nLatLng:%f, %f",
+            annotation.getId(),
+            annotation.getLatLng().getLatitude(), annotation.getLatLng().getLongitude()));
         }
 
-        circleManager.addDragListener(new OnCircleDragListener() {
-          @Override
-          public void onAnnotationDragStarted(Circle annotation) {
-            draggableInfoTv.setVisibility(View.VISIBLE);
-          }
-
-          @Override
-          public void onAnnotationDrag(Circle annotation) {
-            draggableInfoTv.setText(String.format(
-              Locale.US,
-              "ID: %s\nLatLng:%f, %f",
-              annotation.getId(),
-              annotation.getLatLng().getLatitude(), annotation.getLatLng().getLongitude()));
-          }
-
-          @Override
-          public void onAnnotationDragFinished(Circle annotation) {
-            draggableInfoTv.setVisibility(View.GONE);
-          }
-        });
-      }));
+        @Override
+        public void onAnnotationDragFinished(Circle annotation) {
+          draggableInfoTv.setVisibility(View.GONE);
+        }
+      });
+    }));
   }
 
   private LatLng createRandomLatLng() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
@@ -45,7 +45,7 @@ public class FillActivity extends AppCompatActivity {
 
         mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-        fillManager = new FillManager(mapView, mapboxMap);
+        fillManager = new FillManager(mapView, mapboxMap, style);
         fillManager.addClickListener(fill -> Toast.makeText(FillActivity.this,
           String.format("Fill clicked %s", fill.getId()),
           Toast.LENGTH_SHORT

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
@@ -43,7 +43,7 @@ public class LineActivity extends AppCompatActivity {
       mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
         mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-        lineManager = new LineManager(mapView, mapboxMap);
+        lineManager = new LineManager(mapView, mapboxMap, style);
         lineManager.addClickListener(line -> Toast.makeText(LineActivity.this,
           String.format("Line clicked %s", line.getId()),
           Toast.LENGTH_SHORT

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
@@ -7,15 +7,15 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
-import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.plugins.annotation.*;
+import com.mapbox.mapboxsdk.plugins.annotation.Line;
+import com.mapbox.mapboxsdk.plugins.annotation.LineManager;
+import com.mapbox.mapboxsdk.plugins.annotation.LineOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.io.IOException;
@@ -39,50 +39,51 @@ public class LineActivity extends AppCompatActivity {
     setContentView(R.layout.activity_annotation);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-    mapView.getMapAsync(mapboxMap ->
-      mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
-        mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
+    mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+      findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
-        lineManager = new LineManager(mapView, mapboxMap, style);
-        lineManager.addClickListener(line -> Toast.makeText(LineActivity.this,
-          String.format("Line clicked %s", line.getId()),
-          Toast.LENGTH_SHORT
-        ).show());
-        lineManager.addLongClickListener(line -> Toast.makeText(LineActivity.this,
-          String.format("Line long clicked %s", line.getId()),
-          Toast.LENGTH_SHORT
-        ).show());
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-        // create a fixed line
-        List<LatLng> latLngs = new ArrayList<>();
-        latLngs.add(new LatLng(-2.178992, -4.375974));
-        latLngs.add(new LatLng(-4.107888, -7.639772));
-        latLngs.add(new LatLng(2.798737, -11.439207));
-        LineOptions lineOptions = new LineOptions()
-          .withLatLngs(latLngs)
-          .withLineColor(ColorUtils.colorToRgbaString(Color.RED))
-          .withLineWidth(5.0f);
-        lineManager.create(lineOptions);
+      lineManager = new LineManager(mapView, mapboxMap, style);
+      lineManager.addClickListener(line -> Toast.makeText(LineActivity.this,
+        String.format("Line clicked %s", line.getId()),
+        Toast.LENGTH_SHORT
+      ).show());
+      lineManager.addLongClickListener(line -> Toast.makeText(LineActivity.this,
+        String.format("Line long clicked %s", line.getId()),
+        Toast.LENGTH_SHORT
+      ).show());
 
-        // random add lines across the globe
-        List<List<LatLng>> lists = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-          lists.add(createRandomLatLngs());
-        }
+      // create a fixed line
+      List<LatLng> latLngs = new ArrayList<>();
+      latLngs.add(new LatLng(-2.178992, -4.375974));
+      latLngs.add(new LatLng(-4.107888, -7.639772));
+      latLngs.add(new LatLng(2.798737, -11.439207));
+      LineOptions lineOptions = new LineOptions()
+        .withLatLngs(latLngs)
+        .withLineColor(ColorUtils.colorToRgbaString(Color.RED))
+        .withLineWidth(5.0f);
+      lineManager.create(lineOptions);
 
-        List<LineOptions> lineOptionsList = new ArrayList<>();
-        for (List<LatLng> list : lists) {
-          int color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256));
-          lineOptionsList.add(new LineOptions().withLatLngs(list).withLineColor(ColorUtils.colorToRgbaString(color)));
-        }
-        lineManager.create(lineOptionsList);
+      // random add lines across the globe
+      List<List<LatLng>> lists = new ArrayList<>();
+      for (int i = 0; i < 100; i++) {
+        lists.add(createRandomLatLngs());
+      }
 
-        try {
-          lineManager.create(Utils.INSTANCE.loadStringFromAssets(this, "annotations.json"));
-        } catch (IOException e) {
-          throw new RuntimeException("Unable to parse annotations.json");
-        }
-      }));
+      List<LineOptions> lineOptionsList = new ArrayList<>();
+      for (List<LatLng> list : lists) {
+        int color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256));
+        lineOptionsList.add(new LineOptions().withLatLngs(list).withLineColor(ColorUtils.colorToRgbaString(color)));
+      }
+      lineManager.create(lineOptionsList);
+
+      try {
+        lineManager.create(Utils.INSTANCE.loadStringFromAssets(this, "annotations.json"));
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to parse annotations.json");
+      }
+    }));
   }
 
   private List<LatLng> createRandomLatLngs() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -69,7 +69,7 @@ public class SymbolActivity extends AppCompatActivity {
         mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
         // create symbol manager
-        symbolManager = new SymbolManager(mapView, mapboxMap);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style);
         symbolManager.addClickListener(symbol -> Toast.makeText(SymbolActivity.this,
           String.format("Symbol clicked %s", symbol.getId()),
           Toast.LENGTH_SHORT

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
@@ -24,7 +24,7 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnM
 
     override fun onMapReady(mapboxMap: MapboxMap) {
         this.mapboxMap = mapboxMap
-        mapboxMap?.setStyle(Style.MAPBOX_STREETS) {
+        mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             mapboxMap.addOnMapClickListener(this)
             Toast.makeText(this,"Click on the map", Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/res/layout/activity_annotation.xml
+++ b/app/src/main/res/layout/activity_annotation.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -15,4 +16,17 @@
         android:layout_height="wrap_content"
         android:visibility="gone" />
 
-</android.support.design.widget.CoordinatorLayout>
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fabStyles"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:tint="@android:color/white"
+        app:backgroundTint="@color/colorAccent"
+        app:fabSize="normal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:srcCompat="@drawable/ic_layers" />
+
+</android.support.constraint.ConstraintLayout>

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -11,12 +11,14 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -35,13 +37,13 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setupAnnotation() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      <%- camelize(type) %>Manager <%- type %>Manager = new <%- camelize(type) %>Manager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      <%- camelize(type) %>Manager <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
 <% if (type === "circle" || type === "symbol") { -%>
       <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -16,6 +16,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -40,21 +41,23 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    * Create a <%- type %> manager, used to manage <%- type %>s.
    *
    * @param mapboxMap the map object to add <%- type %>s to
+   * @param style a valid a fully loaded style object
    */
   @UiThread
-  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
-    this(mapView, mapboxMap, null);
+  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    this(mapView, mapboxMap, style, null);
   }
 
   /**
    * Create a <%- type %> manager, used to manage <%- type %>s.
    *
    * @param mapboxMap the map object to add <%- type %>s to
+   * @param style a valid a fully loaded style object
    * @param belowLayerId the id of the layer above the circle layer
    */
   @UiThread
-  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable String belowLayerId) {
-    this(mapboxMap, new GeoJsonSource(ID_GEOJSON_SOURCE), new <%- camelize(type) %>Layer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
+  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
+    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new <%- camelize(type) %>Layer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
@@ -62,15 +65,16 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    * Create a <%- type %> manager, used to manage <%- type %>s.
    *
    * @param mapboxMap     the map object to add <%- type %>s to
+   * @param style a valid a fully loaded style object
    * @param geoJsonSource the geojson source to add <%- type %>s to
    * @param layer         the <%- type %> layer to visualise <%- camelize(type) %>s with
    */
   @VisibleForTesting
-  public <%- camelize(type) %>Manager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull <%- camelize(type) %>Layer layer, @Nullable String belowLayerId, DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController) {
+  public <%- camelize(type) %>Manager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull <%- camelize(type) %>Layer layer, @Nullable String belowLayerId, DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController) {
 <% if (type === "symbol") { -%>
-    super(mapboxMap, layer, geoJsonSource, new SymbolComparator(), draggableAnnotationController, belowLayerId);
+    super(mapboxMap, style, layer, geoJsonSource, new SymbolComparator(), draggableAnnotationController, belowLayerId);
 <% } else { -%>
-    super(mapboxMap, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
+    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
 <% } -%>
     initializeDataDrivenPropertyMap();
   }

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -19,6 +19,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
+import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.layers.Property;
 
@@ -57,8 +58,19 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   @UiThread
   public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new <%- camelize(type) %>Layer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
-    belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style,
+      new CoreElementProvider<<%- camelize(type) %>Layer>() {
+        @Override
+        public <%- camelize(type) %>Layer getLayer() {
+          return new <%- camelize(type) %>Layer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE);
+        }
+
+        @Override
+        public GeoJsonSource getSource() {
+          return new GeoJsonSource(ID_GEOJSON_SOURCE);
+        }
+      },
+     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
   /**
@@ -66,17 +78,44 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    *
    * @param mapboxMap     the map object to add <%- type %>s to
    * @param style a valid a fully loaded style object
-   * @param geoJsonSource the geojson source to add <%- type %>s to
-   * @param layer         the <%- type %> layer to visualise <%- camelize(type) %>s with
    */
   @VisibleForTesting
-  public <%- camelize(type) %>Manager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull <%- camelize(type) %>Layer layer, @Nullable String belowLayerId, DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController) {
+  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController) {
 <% if (type === "symbol") { -%>
-    super(mapboxMap, style, layer, geoJsonSource, new SymbolComparator(), draggableAnnotationController, belowLayerId);
+    super(mapView, mapboxMap, style, coreElementProvider, new SymbolComparator(), draggableAnnotationController, belowLayerId);
 <% } else { -%>
-    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
+    super(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController, belowLayerId);
 <% } -%>
-    initializeDataDrivenPropertyMap();
+  }
+
+  @Override
+  void initializeDataDrivenPropertyMap() {
+<% for (const property of properties) { -%>
+<% if (supportsPropertyFunction(property)) { -%>
+    dataDrivenPropertyUsageMap.put("<%- property.name %>", false);
+<% } -%>
+<% } -%>
+<% if (type === "symbol") { -%>
+    dataDrivenPropertyUsageMap.put(Z_INDEX, false);
+<% } -%>
+  }
+
+  @Override
+  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
+    switch (property) {
+<% for (const property of properties) { -%>
+<% if (supportsPropertyFunction(property)) { -%>
+      case "<%- property.name %>":
+        layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")));
+        break;
+<% } -%>
+<% } -%>
+<% if (type === "symbol") { -%>
+      case Z_INDEX:
+        layer.setProperties(symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE));
+        break;
+<% } -%>
+    }
   }
 
   /**
@@ -119,35 +158,6 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
     return create(options);
   }
 
-  private void initializeDataDrivenPropertyMap() {
-<% for (const property of properties) { -%>
-<% if (supportsPropertyFunction(property)) { -%>
-    propertyUsageMap.put("<%- property.name %>", false);
-<% } -%>
-<% } -%>
-<% if (type === "symbol") { -%>
-    propertyUsageMap.put(Z_INDEX, false);
-<% } -%>
-  }
-
-  @Override
-  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
-    switch (property) {
-<% for (const property of properties) { -%>
-<% if (supportsPropertyFunction(property)) { -%>
-      case "<%- property.name %>":
-        layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")));
-        break;
-<% } -%>
-<% } -%>
-<% if (type === "symbol") { -%>
-      case Z_INDEX:
-        layer.setProperties(symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE));
-        break;
-<% } -%>
-    }
-  }
-
   /**
    * Get the layer id of the annotation layer.
    *
@@ -186,7 +196,9 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    * @param value property wrapper value around <%- propertyType(property) %>
    */
   public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), "") %> <%- propertyType(property) %> value) {
-    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(value));
+    PropertyValue propertyValue = <%- camelizeWithLeadingLowercase(property.name) %>(value);
+    constantPropertyUsageMap.put("<%- property.name %>", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
 <% } -%>
@@ -196,8 +208,10 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    *
    * @param expression expression
    */
+   @Override
   public void setFilter(@NonNull Expression expression) {
-    layer.setFilter(expression);
+    layerFilter = expression;
+    layer.setFilter(layerFilter);
   }
 
   /**

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -9,12 +9,14 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.plugins.testapp.activity.building.BuildingActivity;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import timber.log.Timber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
@@ -30,13 +32,13 @@ public class <%- camelize(type) %>ManagerTest extends BaseActivityTest {
 
   @Override
   protected Class getActivityClass() {
-    return BuildingActivity.class;
+    return TestActivity.class;
   }
 
   private void setup<%- camelize(type) %>Manager() {
     Timber.i("Retrieving layer");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      <%- type %>Manager = new <%- camelize(type) %>Manager(((BuildingActivity) rule.getActivity()).getMapView(), mapboxMap);
+      <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
     });
   }
 <% for (const property of properties) { -%>

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -9,6 +9,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
@@ -17,6 +18,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,20 +36,106 @@ import static org.mockito.Mockito.*;
 public class <%- camelize(type) %>ManagerTest {
 
   private DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
+  private MapView mapView = mock(MapView.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
   private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private <%- camelize(type) %>Layer <%- type  %>Layer = mock(<%- camelize(type) %>Layer.class);
   private <%- camelize(type) %>Manager <%- type  %>Manager;
+  private CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider = mock(CoreElementProvider.class);
 
   @Before
   public void beforeTest() {
+    when(coreElementProvider.getLayer()).thenReturn(<%- type  %>Layer);
+    when(coreElementProvider.getSource()).thenReturn(geoJsonSource);
     when(style.isFullyLoaded()).thenReturn(true);
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapboxMap, style, geoJsonSource, <%- type  %>Layer, null, draggableAnnotationController);
+  }
+
+  @Test
+  public void testInitialization() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(<%- type  %>Layer);
+    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(<%- type  %>Layer, times(0)).setFilter(any());
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testInitializationOnStyleReload() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(<%- type  %>Layer);
+    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+
+    Expression filter = Expression.literal(false);
+    <%- type  %>Manager.setFilter(filter);
+
+    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
+    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+
+    ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
+    verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+
+    Style newStyle = mock(Style.class);
+    when(newStyle.isFullyLoaded()).thenReturn(true);
+    GeoJsonSource newSource = mock(GeoJsonSource.class);
+    when(coreElementProvider.getSource()).thenReturn(newSource);
+    <%- camelize(type)  %>Layer newLayer = mock(<%- camelize(type)  %>Layer.class);
+    when(coreElementProvider.getLayer()).thenReturn(newLayer);
+    styleLoadedArgumentCaptor.getValue().onStyleLoaded(newStyle);
+
+    verify(newStyle).addSource(newSource);
+    verify(newStyle).addLayer(newLayer);
+    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(newLayer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(<%- type  %>Layer).setFilter(filter);
+    verify(draggableAnnotationController, times(2)).onSourceUpdated();
+    verify(newSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testLayerBelowInitialization() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayerBelow(<%- type  %>Layer, "test_layer");
+    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testNoUpdateOnStyleReload() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
+
+    when(style.isFullyLoaded()).thenReturn(false);
+    <%- type  %>Manager.updateSource();
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
   }
 
   @Test
   public void testAdd<%- camelize(type) %>() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -70,6 +158,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void add<%- camelize(type) %>FromFeatureCollection() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     Geometry geometry = Point.fromLngLat(10, 10);
 <% } else if (type === "line") { -%>
@@ -134,6 +223,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void add<%- camelize(type) %>s() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     List<LatLng> latLngList = new ArrayList<>();
     latLngList.add(new LatLng());
@@ -193,6 +283,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testDelete<%- camelize(type) %>() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -215,6 +306,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testGeometry<%- camelize(type) %>() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng(12, 34)));
     assertEquals(<%- type  %>.getGeometry(), Point.fromLngLat(34, 12));
@@ -247,6 +339,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testFeatureId<%- camelize(type) %>() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
     <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
@@ -272,6 +365,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void test<%- camelize(type) %>DraggableFlag() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -301,6 +395,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void test<%- camelize(property.name) %>LayerProperty() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
 <% if (type === "circle" || type === "symbol") { -%>
@@ -331,6 +426,7 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "symbol") { -%>
   @Test
   public void testSymbolZOrderLayerProperty() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(symbolZOrder(Property.SYMBOL_Z_ORDER_SOURCE))));
 
     <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
@@ -344,6 +440,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void test<%- camelize(type) %>LayerFilter() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(<%- type %>Layer, times(0)).setFilter(expression);
 
@@ -352,5 +449,6 @@ public class <%- camelize(type) %>ManagerTest {
 
     when(<%- type %>Layer.getFilter()).thenReturn(expression);
     assertEquals(expression, <%- type %>Manager.getFilter());
+    assertEquals(expression, <%- type %>Manager.layerFilter);
   }
 }

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -10,6 +10,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -34,13 +35,15 @@ public class <%- camelize(type) %>ManagerTest {
 
   private DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
+  private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private <%- camelize(type) %>Layer <%- type  %>Layer = mock(<%- camelize(type) %>Layer.class);
   private <%- camelize(type) %>Manager <%- type  %>Manager;
 
   @Before
   public void beforeTest() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapboxMap, geoJsonSource, <%- type  %>Layer, null, draggableAnnotationController);
+    when(style.isFullyLoaded()).thenReturn(true);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapboxMap, style, geoJsonSource, <%- type  %>Layer, null, draggableAnnotationController);
   }
 
   @Test

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -11,6 +11,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -35,21 +36,23 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    * Create a circle manager, used to manage circles.
    *
    * @param mapboxMap the map object to add circles to
+   * @param style a valid a fully loaded style object
    */
   @UiThread
-  public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
-    this(mapView, mapboxMap, null);
+  public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    this(mapView, mapboxMap, style, null);
   }
 
   /**
    * Create a circle manager, used to manage circles.
    *
    * @param mapboxMap the map object to add circles to
+   * @param style a valid a fully loaded style object
    * @param belowLayerId the id of the layer above the circle layer
    */
   @UiThread
-  public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable String belowLayerId) {
-    this(mapboxMap, new GeoJsonSource(ID_GEOJSON_SOURCE), new CircleLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
+  public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
+    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new CircleLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
@@ -57,12 +60,13 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    * Create a circle manager, used to manage circles.
    *
    * @param mapboxMap     the map object to add circles to
+   * @param style a valid a fully loaded style object
    * @param geoJsonSource the geojson source to add circles to
    * @param layer         the circle layer to visualise Circles with
    */
   @VisibleForTesting
-  public CircleManager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull CircleLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Circle, OnCircleDragListener> draggableAnnotationController) {
-    super(mapboxMap, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
+  public CircleManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull CircleLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Circle, OnCircleDragListener> draggableAnnotationController) {
+    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
     initializeDataDrivenPropertyMap();
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
@@ -1,0 +1,11 @@
+package com.mapbox.mapboxsdk.plugins.annotation;
+
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+interface CoreElementProvider<L extends Layer> {
+
+  L getLayer();
+
+  GeoJsonSource getSource();
+}

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -14,6 +14,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.layers.Property;
 
@@ -52,8 +53,19 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    */
   @UiThread
   public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new FillLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
-    belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style,
+      new CoreElementProvider<FillLayer>() {
+        @Override
+        public FillLayer getLayer() {
+          return new FillLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE);
+        }
+
+        @Override
+        public GeoJsonSource getSource() {
+          return new GeoJsonSource(ID_GEOJSON_SOURCE);
+        }
+      },
+     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
   /**
@@ -61,13 +73,36 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    *
    * @param mapboxMap     the map object to add fills to
    * @param style a valid a fully loaded style object
-   * @param geoJsonSource the geojson source to add fills to
-   * @param layer         the fill layer to visualise Fills with
    */
   @VisibleForTesting
-  public FillManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull FillLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController) {
-    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
-    initializeDataDrivenPropertyMap();
+  public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController) {
+    super(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController, belowLayerId);
+  }
+
+  @Override
+  void initializeDataDrivenPropertyMap() {
+    dataDrivenPropertyUsageMap.put("fill-opacity", false);
+    dataDrivenPropertyUsageMap.put("fill-color", false);
+    dataDrivenPropertyUsageMap.put("fill-outline-color", false);
+    dataDrivenPropertyUsageMap.put("fill-pattern", false);
+  }
+
+  @Override
+  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
+    switch (property) {
+      case "fill-opacity":
+        layer.setProperties(fillOpacity(get("fill-opacity")));
+        break;
+      case "fill-color":
+        layer.setProperties(fillColor(get("fill-color")));
+        break;
+      case "fill-outline-color":
+        layer.setProperties(fillOutlineColor(get("fill-outline-color")));
+        break;
+      case "fill-pattern":
+        layer.setProperties(fillPattern(get("fill-pattern")));
+        break;
+    }
   }
 
   /**
@@ -110,31 +145,6 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
     return create(options);
   }
 
-  private void initializeDataDrivenPropertyMap() {
-    propertyUsageMap.put("fill-opacity", false);
-    propertyUsageMap.put("fill-color", false);
-    propertyUsageMap.put("fill-outline-color", false);
-    propertyUsageMap.put("fill-pattern", false);
-  }
-
-  @Override
-  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
-    switch (property) {
-      case "fill-opacity":
-        layer.setProperties(fillOpacity(get("fill-opacity")));
-        break;
-      case "fill-color":
-        layer.setProperties(fillColor(get("fill-color")));
-        break;
-      case "fill-outline-color":
-        layer.setProperties(fillOutlineColor(get("fill-outline-color")));
-        break;
-      case "fill-pattern":
-        layer.setProperties(fillPattern(get("fill-pattern")));
-        break;
-    }
-  }
-
   /**
    * Get the layer id of the annotation layer.
    *
@@ -171,7 +181,9 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    * @param value property wrapper value around Boolean
    */
   public void setFillAntialias( Boolean value) {
-    layer.setProperties(fillAntialias(value));
+    PropertyValue propertyValue = fillAntialias(value);
+    constantPropertyUsageMap.put("fill-antialias", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -189,7 +201,9 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    * @param value property wrapper value around Float[]
    */
   public void setFillTranslate( Float[] value) {
-    layer.setProperties(fillTranslate(value));
+    PropertyValue propertyValue = fillTranslate(value);
+    constantPropertyUsageMap.put("fill-translate", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -207,7 +221,9 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    * @param value property wrapper value around String
    */
   public void setFillTranslateAnchor(@Property.FILL_TRANSLATE_ANCHOR String value) {
-    layer.setProperties(fillTranslateAnchor(value));
+    PropertyValue propertyValue = fillTranslateAnchor(value);
+    constantPropertyUsageMap.put("fill-translate-anchor", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -215,8 +231,10 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    *
    * @param expression expression
    */
+   @Override
   public void setFilter(@NonNull Expression expression) {
-    layer.setFilter(expression);
+    layerFilter = expression;
+    layer.setFilter(layerFilter);
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -11,6 +11,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -35,21 +36,23 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    * Create a fill manager, used to manage fills.
    *
    * @param mapboxMap the map object to add fills to
+   * @param style a valid a fully loaded style object
    */
   @UiThread
-  public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
-    this(mapView, mapboxMap, null);
+  public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    this(mapView, mapboxMap, style, null);
   }
 
   /**
    * Create a fill manager, used to manage fills.
    *
    * @param mapboxMap the map object to add fills to
+   * @param style a valid a fully loaded style object
    * @param belowLayerId the id of the layer above the circle layer
    */
   @UiThread
-  public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable String belowLayerId) {
-    this(mapboxMap, new GeoJsonSource(ID_GEOJSON_SOURCE), new FillLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
+  public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
+    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new FillLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
@@ -57,12 +60,13 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    * Create a fill manager, used to manage fills.
    *
    * @param mapboxMap     the map object to add fills to
+   * @param style a valid a fully loaded style object
    * @param geoJsonSource the geojson source to add fills to
    * @param layer         the fill layer to visualise Fills with
    */
   @VisibleForTesting
-  public FillManager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull FillLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController) {
-    super(mapboxMap, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
+  public FillManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull FillLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController) {
+    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
     initializeDataDrivenPropertyMap();
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -14,6 +14,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.layers.Property;
 
@@ -52,8 +53,19 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   @UiThread
   public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new LineLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
-    belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style,
+      new CoreElementProvider<LineLayer>() {
+        @Override
+        public LineLayer getLayer() {
+          return new LineLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE);
+        }
+
+        @Override
+        public GeoJsonSource getSource() {
+          return new GeoJsonSource(ID_GEOJSON_SOURCE);
+        }
+      },
+     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
   /**
@@ -61,13 +73,52 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    *
    * @param mapboxMap     the map object to add lines to
    * @param style a valid a fully loaded style object
-   * @param geoJsonSource the geojson source to add lines to
-   * @param layer         the line layer to visualise Lines with
    */
   @VisibleForTesting
-  public LineManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull LineLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController) {
-    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
-    initializeDataDrivenPropertyMap();
+  public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController) {
+    super(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController, belowLayerId);
+  }
+
+  @Override
+  void initializeDataDrivenPropertyMap() {
+    dataDrivenPropertyUsageMap.put("line-join", false);
+    dataDrivenPropertyUsageMap.put("line-opacity", false);
+    dataDrivenPropertyUsageMap.put("line-color", false);
+    dataDrivenPropertyUsageMap.put("line-width", false);
+    dataDrivenPropertyUsageMap.put("line-gap-width", false);
+    dataDrivenPropertyUsageMap.put("line-offset", false);
+    dataDrivenPropertyUsageMap.put("line-blur", false);
+    dataDrivenPropertyUsageMap.put("line-pattern", false);
+  }
+
+  @Override
+  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
+    switch (property) {
+      case "line-join":
+        layer.setProperties(lineJoin(get("line-join")));
+        break;
+      case "line-opacity":
+        layer.setProperties(lineOpacity(get("line-opacity")));
+        break;
+      case "line-color":
+        layer.setProperties(lineColor(get("line-color")));
+        break;
+      case "line-width":
+        layer.setProperties(lineWidth(get("line-width")));
+        break;
+      case "line-gap-width":
+        layer.setProperties(lineGapWidth(get("line-gap-width")));
+        break;
+      case "line-offset":
+        layer.setProperties(lineOffset(get("line-offset")));
+        break;
+      case "line-blur":
+        layer.setProperties(lineBlur(get("line-blur")));
+        break;
+      case "line-pattern":
+        layer.setProperties(linePattern(get("line-pattern")));
+        break;
+    }
   }
 
   /**
@@ -110,47 +161,6 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
     return create(options);
   }
 
-  private void initializeDataDrivenPropertyMap() {
-    propertyUsageMap.put("line-join", false);
-    propertyUsageMap.put("line-opacity", false);
-    propertyUsageMap.put("line-color", false);
-    propertyUsageMap.put("line-width", false);
-    propertyUsageMap.put("line-gap-width", false);
-    propertyUsageMap.put("line-offset", false);
-    propertyUsageMap.put("line-blur", false);
-    propertyUsageMap.put("line-pattern", false);
-  }
-
-  @Override
-  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
-    switch (property) {
-      case "line-join":
-        layer.setProperties(lineJoin(get("line-join")));
-        break;
-      case "line-opacity":
-        layer.setProperties(lineOpacity(get("line-opacity")));
-        break;
-      case "line-color":
-        layer.setProperties(lineColor(get("line-color")));
-        break;
-      case "line-width":
-        layer.setProperties(lineWidth(get("line-width")));
-        break;
-      case "line-gap-width":
-        layer.setProperties(lineGapWidth(get("line-gap-width")));
-        break;
-      case "line-offset":
-        layer.setProperties(lineOffset(get("line-offset")));
-        break;
-      case "line-blur":
-        layer.setProperties(lineBlur(get("line-blur")));
-        break;
-      case "line-pattern":
-        layer.setProperties(linePattern(get("line-pattern")));
-        break;
-    }
-  }
-
   /**
    * Get the layer id of the annotation layer.
    *
@@ -187,7 +197,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * @param value property wrapper value around String
    */
   public void setLineCap(@Property.LINE_CAP String value) {
-    layer.setProperties(lineCap(value));
+    PropertyValue propertyValue = lineCap(value);
+    constantPropertyUsageMap.put("line-cap", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -205,7 +217,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * @param value property wrapper value around Float
    */
   public void setLineMiterLimit( Float value) {
-    layer.setProperties(lineMiterLimit(value));
+    PropertyValue propertyValue = lineMiterLimit(value);
+    constantPropertyUsageMap.put("line-miter-limit", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -223,7 +237,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * @param value property wrapper value around Float
    */
   public void setLineRoundLimit( Float value) {
-    layer.setProperties(lineRoundLimit(value));
+    PropertyValue propertyValue = lineRoundLimit(value);
+    constantPropertyUsageMap.put("line-round-limit", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -241,7 +257,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * @param value property wrapper value around Float[]
    */
   public void setLineTranslate( Float[] value) {
-    layer.setProperties(lineTranslate(value));
+    PropertyValue propertyValue = lineTranslate(value);
+    constantPropertyUsageMap.put("line-translate", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -259,7 +277,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * @param value property wrapper value around String
    */
   public void setLineTranslateAnchor(@Property.LINE_TRANSLATE_ANCHOR String value) {
-    layer.setProperties(lineTranslateAnchor(value));
+    PropertyValue propertyValue = lineTranslateAnchor(value);
+    constantPropertyUsageMap.put("line-translate-anchor", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -277,7 +297,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * @param value property wrapper value around Float[]
    */
   public void setLineDasharray( Float[] value) {
-    layer.setProperties(lineDasharray(value));
+    PropertyValue propertyValue = lineDasharray(value);
+    constantPropertyUsageMap.put("line-dasharray", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -285,8 +307,10 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    *
    * @param expression expression
    */
+   @Override
   public void setFilter(@NonNull Expression expression) {
-    layer.setFilter(expression);
+    layerFilter = expression;
+    layer.setFilter(layerFilter);
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -11,6 +11,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -35,21 +36,23 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * Create a line manager, used to manage lines.
    *
    * @param mapboxMap the map object to add lines to
+   * @param style a valid a fully loaded style object
    */
   @UiThread
-  public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
-    this(mapView, mapboxMap, null);
+  public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    this(mapView, mapboxMap, style, null);
   }
 
   /**
    * Create a line manager, used to manage lines.
    *
    * @param mapboxMap the map object to add lines to
+   * @param style a valid a fully loaded style object
    * @param belowLayerId the id of the layer above the circle layer
    */
   @UiThread
-  public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable String belowLayerId) {
-    this(mapboxMap, new GeoJsonSource(ID_GEOJSON_SOURCE), new LineLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
+  public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
+    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new LineLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
@@ -57,12 +60,13 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    * Create a line manager, used to manage lines.
    *
    * @param mapboxMap     the map object to add lines to
+   * @param style a valid a fully loaded style object
    * @param geoJsonSource the geojson source to add lines to
    * @param layer         the line layer to visualise Lines with
    */
   @VisibleForTesting
-  public LineManager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull LineLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController) {
-    super(mapboxMap, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
+  public LineManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull LineLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController) {
+    super(mapboxMap, style, layer, geoJsonSource, null, draggableAnnotationController, belowLayerId);
     initializeDataDrivenPropertyMap();
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -14,6 +14,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.layers.Property;
 
@@ -52,8 +53,19 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   @UiThread
   public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new SymbolLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
-    belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style,
+      new CoreElementProvider<SymbolLayer>() {
+        @Override
+        public SymbolLayer getLayer() {
+          return new SymbolLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE);
+        }
+
+        @Override
+        public GeoJsonSource getSource() {
+          return new GeoJsonSource(ID_GEOJSON_SOURCE);
+        }
+      },
+     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
   /**
@@ -61,82 +73,40 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    *
    * @param mapboxMap     the map object to add symbols to
    * @param style a valid a fully loaded style object
-   * @param geoJsonSource the geojson source to add symbols to
-   * @param layer         the symbol layer to visualise Symbols with
    */
   @VisibleForTesting
-  public SymbolManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull SymbolLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController) {
-    super(mapboxMap, style, layer, geoJsonSource, new SymbolComparator(), draggableAnnotationController, belowLayerId);
-    initializeDataDrivenPropertyMap();
+  public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController) {
+    super(mapView, mapboxMap, style, coreElementProvider, new SymbolComparator(), draggableAnnotationController, belowLayerId);
   }
 
-  /**
-   * Create a list of symbols on the map.
-   * <p>
-   * Symbols are going to be created only for features with a matching geometry.
-   * <p>
-   * You can inspect a full list of supported feature properties in {@link SymbolOptions#fromFeature(Feature)}.
-   *
-   * @param json the GeoJSON defining the list of symbols to build
-   * @return the list of built symbols
-   */
-  @UiThread
-  public List<Symbol> create(@NonNull String json) {
-    return create(FeatureCollection.fromJson(json));
-  }
-
-  /**
-   * Create a list of symbols on the map.
-   * <p>
-   * Symbols are going to be created only for features with a matching geometry.
-   * <p>
-   * You can inspect a full list of supported feature properties in {@link SymbolOptions#fromFeature(Feature)}.
-   *
-   * @param featureCollection the featureCollection defining the list of symbols to build
-   * @return the list of built symbols
-   */
-  @UiThread
-  public List<Symbol> create(@NonNull FeatureCollection featureCollection) {
-    List<Feature> features = featureCollection.features();
-    List<SymbolOptions> options = new ArrayList<>();
-    if (features != null) {
-      for (Feature feature : features) {
-        SymbolOptions option = SymbolOptions.fromFeature(feature);
-        if (option != null) {
-          options.add(option);
-        }
-      }
-    }
-    return create(options);
-  }
-
-  private void initializeDataDrivenPropertyMap() {
-    propertyUsageMap.put("icon-size", false);
-    propertyUsageMap.put("icon-image", false);
-    propertyUsageMap.put("icon-rotate", false);
-    propertyUsageMap.put("icon-offset", false);
-    propertyUsageMap.put("icon-anchor", false);
-    propertyUsageMap.put("text-field", false);
-    propertyUsageMap.put("text-font", false);
-    propertyUsageMap.put("text-size", false);
-    propertyUsageMap.put("text-max-width", false);
-    propertyUsageMap.put("text-letter-spacing", false);
-    propertyUsageMap.put("text-justify", false);
-    propertyUsageMap.put("text-anchor", false);
-    propertyUsageMap.put("text-rotate", false);
-    propertyUsageMap.put("text-transform", false);
-    propertyUsageMap.put("text-offset", false);
-    propertyUsageMap.put("icon-opacity", false);
-    propertyUsageMap.put("icon-color", false);
-    propertyUsageMap.put("icon-halo-color", false);
-    propertyUsageMap.put("icon-halo-width", false);
-    propertyUsageMap.put("icon-halo-blur", false);
-    propertyUsageMap.put("text-opacity", false);
-    propertyUsageMap.put("text-color", false);
-    propertyUsageMap.put("text-halo-color", false);
-    propertyUsageMap.put("text-halo-width", false);
-    propertyUsageMap.put("text-halo-blur", false);
-    propertyUsageMap.put(Z_INDEX, false);
+  @Override
+  void initializeDataDrivenPropertyMap() {
+    dataDrivenPropertyUsageMap.put("icon-size", false);
+    dataDrivenPropertyUsageMap.put("icon-image", false);
+    dataDrivenPropertyUsageMap.put("icon-rotate", false);
+    dataDrivenPropertyUsageMap.put("icon-offset", false);
+    dataDrivenPropertyUsageMap.put("icon-anchor", false);
+    dataDrivenPropertyUsageMap.put("text-field", false);
+    dataDrivenPropertyUsageMap.put("text-font", false);
+    dataDrivenPropertyUsageMap.put("text-size", false);
+    dataDrivenPropertyUsageMap.put("text-max-width", false);
+    dataDrivenPropertyUsageMap.put("text-letter-spacing", false);
+    dataDrivenPropertyUsageMap.put("text-justify", false);
+    dataDrivenPropertyUsageMap.put("text-anchor", false);
+    dataDrivenPropertyUsageMap.put("text-rotate", false);
+    dataDrivenPropertyUsageMap.put("text-transform", false);
+    dataDrivenPropertyUsageMap.put("text-offset", false);
+    dataDrivenPropertyUsageMap.put("icon-opacity", false);
+    dataDrivenPropertyUsageMap.put("icon-color", false);
+    dataDrivenPropertyUsageMap.put("icon-halo-color", false);
+    dataDrivenPropertyUsageMap.put("icon-halo-width", false);
+    dataDrivenPropertyUsageMap.put("icon-halo-blur", false);
+    dataDrivenPropertyUsageMap.put("text-opacity", false);
+    dataDrivenPropertyUsageMap.put("text-color", false);
+    dataDrivenPropertyUsageMap.put("text-halo-color", false);
+    dataDrivenPropertyUsageMap.put("text-halo-width", false);
+    dataDrivenPropertyUsageMap.put("text-halo-blur", false);
+    dataDrivenPropertyUsageMap.put(Z_INDEX, false);
   }
 
   @Override
@@ -224,6 +194,46 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   }
 
   /**
+   * Create a list of symbols on the map.
+   * <p>
+   * Symbols are going to be created only for features with a matching geometry.
+   * <p>
+   * You can inspect a full list of supported feature properties in {@link SymbolOptions#fromFeature(Feature)}.
+   *
+   * @param json the GeoJSON defining the list of symbols to build
+   * @return the list of built symbols
+   */
+  @UiThread
+  public List<Symbol> create(@NonNull String json) {
+    return create(FeatureCollection.fromJson(json));
+  }
+
+  /**
+   * Create a list of symbols on the map.
+   * <p>
+   * Symbols are going to be created only for features with a matching geometry.
+   * <p>
+   * You can inspect a full list of supported feature properties in {@link SymbolOptions#fromFeature(Feature)}.
+   *
+   * @param featureCollection the featureCollection defining the list of symbols to build
+   * @return the list of built symbols
+   */
+  @UiThread
+  public List<Symbol> create(@NonNull FeatureCollection featureCollection) {
+    List<Feature> features = featureCollection.features();
+    List<SymbolOptions> options = new ArrayList<>();
+    if (features != null) {
+      for (Feature feature : features) {
+        SymbolOptions option = SymbolOptions.fromFeature(feature);
+        if (option != null) {
+          options.add(option);
+        }
+      }
+    }
+    return create(options);
+  }
+
+  /**
    * Get the layer id of the annotation layer.
    *
    * @return the layer id
@@ -259,7 +269,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setSymbolPlacement(@Property.SYMBOL_PLACEMENT String value) {
-    layer.setProperties(symbolPlacement(value));
+    PropertyValue propertyValue = symbolPlacement(value);
+    constantPropertyUsageMap.put("symbol-placement", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -277,7 +289,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float
    */
   public void setSymbolSpacing( Float value) {
-    layer.setProperties(symbolSpacing(value));
+    PropertyValue propertyValue = symbolSpacing(value);
+    constantPropertyUsageMap.put("symbol-spacing", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -295,7 +309,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setSymbolAvoidEdges( Boolean value) {
-    layer.setProperties(symbolAvoidEdges(value));
+    PropertyValue propertyValue = symbolAvoidEdges(value);
+    constantPropertyUsageMap.put("symbol-avoid-edges", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -313,7 +329,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setIconAllowOverlap( Boolean value) {
-    layer.setProperties(iconAllowOverlap(value));
+    PropertyValue propertyValue = iconAllowOverlap(value);
+    constantPropertyUsageMap.put("icon-allow-overlap", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -331,7 +349,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setIconIgnorePlacement( Boolean value) {
-    layer.setProperties(iconIgnorePlacement(value));
+    PropertyValue propertyValue = iconIgnorePlacement(value);
+    constantPropertyUsageMap.put("icon-ignore-placement", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -349,7 +369,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setIconOptional( Boolean value) {
-    layer.setProperties(iconOptional(value));
+    PropertyValue propertyValue = iconOptional(value);
+    constantPropertyUsageMap.put("icon-optional", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -367,7 +389,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setIconRotationAlignment(@Property.ICON_ROTATION_ALIGNMENT String value) {
-    layer.setProperties(iconRotationAlignment(value));
+    PropertyValue propertyValue = iconRotationAlignment(value);
+    constantPropertyUsageMap.put("icon-rotation-alignment", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -385,7 +409,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setIconTextFit(@Property.ICON_TEXT_FIT String value) {
-    layer.setProperties(iconTextFit(value));
+    PropertyValue propertyValue = iconTextFit(value);
+    constantPropertyUsageMap.put("icon-text-fit", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -403,7 +429,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float[]
    */
   public void setIconTextFitPadding( Float[] value) {
-    layer.setProperties(iconTextFitPadding(value));
+    PropertyValue propertyValue = iconTextFitPadding(value);
+    constantPropertyUsageMap.put("icon-text-fit-padding", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -421,7 +449,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float
    */
   public void setIconPadding( Float value) {
-    layer.setProperties(iconPadding(value));
+    PropertyValue propertyValue = iconPadding(value);
+    constantPropertyUsageMap.put("icon-padding", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -439,7 +469,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setIconKeepUpright( Boolean value) {
-    layer.setProperties(iconKeepUpright(value));
+    PropertyValue propertyValue = iconKeepUpright(value);
+    constantPropertyUsageMap.put("icon-keep-upright", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -457,7 +489,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setIconPitchAlignment(@Property.ICON_PITCH_ALIGNMENT String value) {
-    layer.setProperties(iconPitchAlignment(value));
+    PropertyValue propertyValue = iconPitchAlignment(value);
+    constantPropertyUsageMap.put("icon-pitch-alignment", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -475,7 +509,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setTextPitchAlignment(@Property.TEXT_PITCH_ALIGNMENT String value) {
-    layer.setProperties(textPitchAlignment(value));
+    PropertyValue propertyValue = textPitchAlignment(value);
+    constantPropertyUsageMap.put("text-pitch-alignment", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -493,7 +529,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setTextRotationAlignment(@Property.TEXT_ROTATION_ALIGNMENT String value) {
-    layer.setProperties(textRotationAlignment(value));
+    PropertyValue propertyValue = textRotationAlignment(value);
+    constantPropertyUsageMap.put("text-rotation-alignment", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -511,7 +549,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float
    */
   public void setTextLineHeight( Float value) {
-    layer.setProperties(textLineHeight(value));
+    PropertyValue propertyValue = textLineHeight(value);
+    constantPropertyUsageMap.put("text-line-height", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -529,7 +569,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float
    */
   public void setTextMaxAngle( Float value) {
-    layer.setProperties(textMaxAngle(value));
+    PropertyValue propertyValue = textMaxAngle(value);
+    constantPropertyUsageMap.put("text-max-angle", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -547,7 +589,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float
    */
   public void setTextPadding( Float value) {
-    layer.setProperties(textPadding(value));
+    PropertyValue propertyValue = textPadding(value);
+    constantPropertyUsageMap.put("text-padding", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -565,7 +609,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setTextKeepUpright( Boolean value) {
-    layer.setProperties(textKeepUpright(value));
+    PropertyValue propertyValue = textKeepUpright(value);
+    constantPropertyUsageMap.put("text-keep-upright", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -583,7 +629,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setTextAllowOverlap( Boolean value) {
-    layer.setProperties(textAllowOverlap(value));
+    PropertyValue propertyValue = textAllowOverlap(value);
+    constantPropertyUsageMap.put("text-allow-overlap", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -601,7 +649,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setTextIgnorePlacement( Boolean value) {
-    layer.setProperties(textIgnorePlacement(value));
+    PropertyValue propertyValue = textIgnorePlacement(value);
+    constantPropertyUsageMap.put("text-ignore-placement", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -619,7 +669,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Boolean
    */
   public void setTextOptional( Boolean value) {
-    layer.setProperties(textOptional(value));
+    PropertyValue propertyValue = textOptional(value);
+    constantPropertyUsageMap.put("text-optional", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -637,7 +689,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float[]
    */
   public void setIconTranslate( Float[] value) {
-    layer.setProperties(iconTranslate(value));
+    PropertyValue propertyValue = iconTranslate(value);
+    constantPropertyUsageMap.put("icon-translate", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -655,7 +709,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setIconTranslateAnchor(@Property.ICON_TRANSLATE_ANCHOR String value) {
-    layer.setProperties(iconTranslateAnchor(value));
+    PropertyValue propertyValue = iconTranslateAnchor(value);
+    constantPropertyUsageMap.put("icon-translate-anchor", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -673,7 +729,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around Float[]
    */
   public void setTextTranslate( Float[] value) {
-    layer.setProperties(textTranslate(value));
+    PropertyValue propertyValue = textTranslate(value);
+    constantPropertyUsageMap.put("text-translate", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -691,7 +749,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * @param value property wrapper value around String
    */
   public void setTextTranslateAnchor(@Property.TEXT_TRANSLATE_ANCHOR String value) {
-    layer.setProperties(textTranslateAnchor(value));
+    PropertyValue propertyValue = textTranslateAnchor(value);
+    constantPropertyUsageMap.put("text-translate-anchor", propertyValue);
+    layer.setProperties(propertyValue);
   }
 
   /**
@@ -699,8 +759,10 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    *
    * @param expression expression
    */
+   @Override
   public void setFilter(@NonNull Expression expression) {
-    layer.setFilter(expression);
+    layerFilter = expression;
+    layer.setFilter(layerFilter);
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -11,6 +11,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -35,21 +36,23 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * Create a symbol manager, used to manage symbols.
    *
    * @param mapboxMap the map object to add symbols to
+   * @param style a valid a fully loaded style object
    */
   @UiThread
-  public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
-    this(mapView, mapboxMap, null);
+  public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    this(mapView, mapboxMap, style, null);
   }
 
   /**
    * Create a symbol manager, used to manage symbols.
    *
    * @param mapboxMap the map object to add symbols to
+   * @param style a valid a fully loaded style object
    * @param belowLayerId the id of the layer above the circle layer
    */
   @UiThread
-  public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable String belowLayerId) {
-    this(mapboxMap, new GeoJsonSource(ID_GEOJSON_SOURCE), new SymbolLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
+  public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
+    this(mapboxMap, style, new GeoJsonSource(ID_GEOJSON_SOURCE), new SymbolLayer(ID_GEOJSON_LAYER, ID_GEOJSON_SOURCE),
     belowLayerId, new DraggableAnnotationController<>(mapView, mapboxMap));
   }
 
@@ -57,12 +60,13 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    * Create a symbol manager, used to manage symbols.
    *
    * @param mapboxMap     the map object to add symbols to
+   * @param style a valid a fully loaded style object
    * @param geoJsonSource the geojson source to add symbols to
    * @param layer         the symbol layer to visualise Symbols with
    */
   @VisibleForTesting
-  public SymbolManager(MapboxMap mapboxMap, @NonNull GeoJsonSource geoJsonSource, @NonNull SymbolLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController) {
-    super(mapboxMap, layer, geoJsonSource, new SymbolComparator(), draggableAnnotationController, belowLayerId);
+  public SymbolManager(@NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull GeoJsonSource geoJsonSource, @NonNull SymbolLayer layer, @Nullable String belowLayerId, DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController) {
+    super(mapboxMap, style, layer, geoJsonSource, new SymbolComparator(), draggableAnnotationController, belowLayerId);
     initializeDataDrivenPropertyMap();
   }
 

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -5,6 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -29,13 +30,15 @@ public class CircleManagerTest {
 
   private DraggableAnnotationController<Circle, OnCircleDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
+  private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private CircleLayer circleLayer = mock(CircleLayer.class);
   private CircleManager circleManager;
 
   @Before
   public void beforeTest() {
-    circleManager = new CircleManager(mapboxMap, geoJsonSource, circleLayer, null, draggableAnnotationController);
+    when(style.isFullyLoaded()).thenReturn(true);
+    circleManager = new CircleManager(mapboxMap, style, geoJsonSource, circleLayer, null, draggableAnnotationController);
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -4,6 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
@@ -12,6 +13,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,26 +31,113 @@ import static org.mockito.Mockito.*;
 public class CircleManagerTest {
 
   private DraggableAnnotationController<Circle, OnCircleDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
+  private MapView mapView = mock(MapView.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
   private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private CircleLayer circleLayer = mock(CircleLayer.class);
   private CircleManager circleManager;
+  private CoreElementProvider<CircleLayer> coreElementProvider = mock(CoreElementProvider.class);
 
   @Before
   public void beforeTest() {
+    when(coreElementProvider.getLayer()).thenReturn(circleLayer);
+    when(coreElementProvider.getSource()).thenReturn(geoJsonSource);
     when(style.isFullyLoaded()).thenReturn(true);
-    circleManager = new CircleManager(mapboxMap, style, geoJsonSource, circleLayer, null, draggableAnnotationController);
+  }
+
+  @Test
+  public void testInitialization() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(circleLayer);
+    assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : circleManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(circleLayer, times(0)).setFilter(any());
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testInitializationOnStyleReload() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(circleLayer);
+    assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : circleManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+
+    Expression filter = Expression.literal(false);
+    circleManager.setFilter(filter);
+
+    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
+    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+
+    ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
+    verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+
+    Style newStyle = mock(Style.class);
+    when(newStyle.isFullyLoaded()).thenReturn(true);
+    GeoJsonSource newSource = mock(GeoJsonSource.class);
+    when(coreElementProvider.getSource()).thenReturn(newSource);
+    CircleLayer newLayer = mock(CircleLayer.class);
+    when(coreElementProvider.getLayer()).thenReturn(newLayer);
+    styleLoadedArgumentCaptor.getValue().onStyleLoaded(newStyle);
+
+    verify(newStyle).addSource(newSource);
+    verify(newStyle).addLayer(newLayer);
+    assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : circleManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(newLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(circleLayer).setFilter(filter);
+    verify(draggableAnnotationController, times(2)).onSourceUpdated();
+    verify(newSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testLayerBelowInitialization() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayerBelow(circleLayer, "test_layer");
+    assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : circleManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testNoUpdateOnStyleReload() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
+
+    when(style.isFullyLoaded()).thenReturn(false);
+    circleManager.updateSource();
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
   }
 
   @Test
   public void testAddCircle() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     assertEquals(circleManager.getAnnotations().get(0), circle);
   }
 
   @Test
   public void addCircleFromFeatureCollection() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Geometry geometry = Point.fromLngLat(10, 10);
 
     Feature feature = Feature.fromGeometry(geometry);
@@ -77,6 +166,7 @@ public class CircleManagerTest {
 
   @Test
   public void addCircles() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng> latLngList = new ArrayList<>();
     latLngList.add(new LatLng());
     latLngList.add(new LatLng(1, 1));
@@ -91,6 +181,7 @@ public class CircleManagerTest {
 
   @Test
   public void testDeleteCircle() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     circleManager.delete(circle);
     assertTrue(circleManager.getAnnotations().size() == 0);
@@ -98,12 +189,14 @@ public class CircleManagerTest {
 
   @Test
   public void testGeometryCircle() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng(12, 34)));
     assertEquals(circle.getGeometry(), Point.fromLngLat(34, 12));
   }
 
   @Test
   public void testFeatureIdCircle() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     Circle circleOne = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     assertEquals(circleZero.getFeature().get(Circle.ID_KEY).getAsLong(), 0);
@@ -112,6 +205,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleDraggableFlag() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
 
     assertFalse(circleZero.isDraggable());
@@ -124,6 +218,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleRadiusLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleRadius(get("circle-radius")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleRadius(0.3f);
@@ -136,6 +231,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleColorLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleColor(get("circle-color")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleColor("rgba(0, 0, 0, 1)");
@@ -148,6 +244,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleBlurLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleBlur(get("circle-blur")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleBlur(0.3f);
@@ -160,6 +257,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleOpacityLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleOpacity(get("circle-opacity")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleOpacity(0.3f);
@@ -172,6 +270,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleStrokeWidthLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeWidth(get("circle-stroke-width")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeWidth(0.3f);
@@ -184,6 +283,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleStrokeColorLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeColor(get("circle-stroke-color")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeColor("rgba(0, 0, 0, 1)");
@@ -196,6 +296,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleStrokeOpacityLayerProperty() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeOpacity(get("circle-stroke-opacity")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeOpacity(0.3f);
@@ -209,6 +310,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleLayerFilter() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(circleLayer, times(0)).setFilter(expression);
 
@@ -217,5 +319,6 @@ public class CircleManagerTest {
 
     when(circleLayer.getFilter()).thenReturn(expression);
     assertEquals(expression, circleManager.getFilter());
+    assertEquals(expression, circleManager.layerFilter);
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -5,6 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -29,13 +30,15 @@ public class FillManagerTest {
 
   private DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
+  private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private FillLayer fillLayer = mock(FillLayer.class);
   private FillManager fillManager;
 
   @Before
   public void beforeTest() {
-    fillManager = new FillManager(mapboxMap, geoJsonSource, fillLayer, null, draggableAnnotationController);
+    when(style.isFullyLoaded()).thenReturn(true);
+    fillManager = new FillManager(mapboxMap, style, geoJsonSource, fillLayer, null, draggableAnnotationController);
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -4,6 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
@@ -12,6 +13,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,20 +31,106 @@ import static org.mockito.Mockito.*;
 public class FillManagerTest {
 
   private DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
+  private MapView mapView = mock(MapView.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
   private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private FillLayer fillLayer = mock(FillLayer.class);
   private FillManager fillManager;
+  private CoreElementProvider<FillLayer> coreElementProvider = mock(CoreElementProvider.class);
 
   @Before
   public void beforeTest() {
+    when(coreElementProvider.getLayer()).thenReturn(fillLayer);
+    when(coreElementProvider.getSource()).thenReturn(geoJsonSource);
     when(style.isFullyLoaded()).thenReturn(true);
-    fillManager = new FillManager(mapboxMap, style, geoJsonSource, fillLayer, null, draggableAnnotationController);
+  }
+
+  @Test
+  public void testInitialization() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(fillLayer);
+    assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : fillManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(fillLayer, times(0)).setFilter(any());
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testInitializationOnStyleReload() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(fillLayer);
+    assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : fillManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+
+    Expression filter = Expression.literal(false);
+    fillManager.setFilter(filter);
+
+    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
+    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+
+    ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
+    verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+
+    Style newStyle = mock(Style.class);
+    when(newStyle.isFullyLoaded()).thenReturn(true);
+    GeoJsonSource newSource = mock(GeoJsonSource.class);
+    when(coreElementProvider.getSource()).thenReturn(newSource);
+    FillLayer newLayer = mock(FillLayer.class);
+    when(coreElementProvider.getLayer()).thenReturn(newLayer);
+    styleLoadedArgumentCaptor.getValue().onStyleLoaded(newStyle);
+
+    verify(newStyle).addSource(newSource);
+    verify(newStyle).addLayer(newLayer);
+    assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : fillManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(newLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(fillLayer).setFilter(filter);
+    verify(draggableAnnotationController, times(2)).onSourceUpdated();
+    verify(newSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testLayerBelowInitialization() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayerBelow(fillLayer, "test_layer");
+    assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : fillManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testNoUpdateOnStyleReload() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
+
+    when(style.isFullyLoaded()).thenReturn(false);
+    fillManager.updateSource();
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
   }
 
   @Test
   public void testAddFill() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -56,6 +144,7 @@ public class FillManagerTest {
 
   @Test
   public void addFillFromFeatureCollection() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<Point> innerPoints = new ArrayList<>();
     innerPoints.add(Point.fromLngLat(0, 0));
     innerPoints.add(Point.fromLngLat(1, 1));
@@ -85,6 +174,7 @@ public class FillManagerTest {
 
   @Test
   public void addFills() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<List<LatLng>> latLngListOne = new ArrayList<>();
     latLngListOne.add(new ArrayList<LatLng>() {{
       add(new LatLng(2, 2));
@@ -120,6 +210,7 @@ public class FillManagerTest {
 
   @Test
   public void testDeleteFill() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -133,6 +224,7 @@ public class FillManagerTest {
 
   @Test
   public void testGeometryFill() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -151,6 +243,7 @@ public class FillManagerTest {
 
   @Test
   public void testFeatureIdFill() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -165,6 +258,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillDraggableFlag() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -183,6 +277,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillOpacityLayerProperty() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOpacity(get("fill-opacity")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -201,6 +296,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillColorLayerProperty() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillColor(get("fill-color")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -219,6 +315,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillOutlineColorLayerProperty() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOutlineColor(get("fill-outline-color")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -237,6 +334,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillPatternLayerProperty() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillPattern(get("fill-pattern")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -256,6 +354,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillLayerFilter() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(fillLayer, times(0)).setFilter(expression);
 
@@ -264,5 +363,6 @@ public class FillManagerTest {
 
     when(fillLayer.getFilter()).thenReturn(expression);
     assertEquals(expression, fillManager.getFilter());
+    assertEquals(expression, fillManager.layerFilter);
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -4,6 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
@@ -12,6 +13,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,20 +31,106 @@ import static org.mockito.Mockito.*;
 public class LineManagerTest {
 
   private DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
+  private MapView mapView = mock(MapView.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
   private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private LineLayer lineLayer = mock(LineLayer.class);
   private LineManager lineManager;
+  private CoreElementProvider<LineLayer> coreElementProvider = mock(CoreElementProvider.class);
 
   @Before
   public void beforeTest() {
+    when(coreElementProvider.getLayer()).thenReturn(lineLayer);
+    when(coreElementProvider.getSource()).thenReturn(geoJsonSource);
     when(style.isFullyLoaded()).thenReturn(true);
-    lineManager = new LineManager(mapboxMap, style, geoJsonSource, lineLayer, null, draggableAnnotationController);
+  }
+
+  @Test
+  public void testInitialization() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(lineLayer);
+    assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : lineManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(lineLayer, times(0)).setFilter(any());
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testInitializationOnStyleReload() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayer(lineLayer);
+    assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : lineManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+
+    Expression filter = Expression.literal(false);
+    lineManager.setFilter(filter);
+
+    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
+    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+
+    ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
+    verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+
+    Style newStyle = mock(Style.class);
+    when(newStyle.isFullyLoaded()).thenReturn(true);
+    GeoJsonSource newSource = mock(GeoJsonSource.class);
+    when(coreElementProvider.getSource()).thenReturn(newSource);
+    LineLayer newLayer = mock(LineLayer.class);
+    when(coreElementProvider.getLayer()).thenReturn(newLayer);
+    styleLoadedArgumentCaptor.getValue().onStyleLoaded(newStyle);
+
+    verify(newStyle).addSource(newSource);
+    verify(newStyle).addLayer(newLayer);
+    assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : lineManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(newLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(lineLayer).setFilter(filter);
+    verify(draggableAnnotationController, times(2)).onSourceUpdated();
+    verify(newSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testLayerBelowInitialization() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(style).addSource(geoJsonSource);
+    verify(style).addLayerBelow(lineLayer, "test_layer");
+    assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
+    for (Boolean value : lineManager.dataDrivenPropertyUsageMap.values()) {
+      assertFalse(value);
+    }
+    verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+    verify(draggableAnnotationController).onSourceUpdated();
+    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void testNoUpdateOnStyleReload() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", draggableAnnotationController);
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
+
+    when(style.isFullyLoaded()).thenReturn(false);
+    lineManager.updateSource();
+    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
   }
 
   @Test
   public void testAddLine() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -52,6 +140,7 @@ public class LineManagerTest {
 
   @Test
   public void addLineFromFeatureCollection() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<Point> points = new ArrayList<>();
     points.add(Point.fromLngLat(0, 0));
     points.add(Point.fromLngLat(1, 1));
@@ -85,6 +174,7 @@ public class LineManagerTest {
 
   @Test
   public void addLines() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<List<LatLng>> latLngList = new ArrayList<>();
     latLngList.add(new ArrayList<LatLng>() {{
       add(new LatLng(2, 2));
@@ -105,6 +195,7 @@ public class LineManagerTest {
 
   @Test
   public void testDeleteLine() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -115,6 +206,7 @@ public class LineManagerTest {
 
   @Test
   public void testGeometryLine() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -127,6 +219,7 @@ public class LineManagerTest {
 
   @Test
   public void testFeatureIdLine() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -138,6 +231,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineDraggableFlag() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -153,6 +247,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineJoinLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineJoin(get("line-join")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -168,6 +263,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineOpacityLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOpacity(get("line-opacity")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -183,6 +279,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineColorLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineColor(get("line-color")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -198,6 +295,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineWidthLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineWidth(get("line-width")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -213,6 +311,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineGapWidthLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineGapWidth(get("line-gap-width")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -228,6 +327,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineOffsetLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOffset(get("line-offset")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -243,6 +343,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineBlurLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineBlur(get("line-blur")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -258,6 +359,7 @@ public class LineManagerTest {
 
   @Test
   public void testLinePatternLayerProperty() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(linePattern(get("line-pattern")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -274,6 +376,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineLayerFilter() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(lineLayer, times(0)).setFilter(expression);
 
@@ -282,5 +385,6 @@ public class LineManagerTest {
 
     when(lineLayer.getFilter()).thenReturn(expression);
     assertEquals(expression, lineManager.getFilter());
+    assertEquals(expression, lineManager.layerFilter);
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -5,6 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -29,13 +30,15 @@ public class LineManagerTest {
 
   private DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
+  private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private LineLayer lineLayer = mock(LineLayer.class);
   private LineManager lineManager;
 
   @Before
   public void beforeTest() {
-    lineManager = new LineManager(mapboxMap, geoJsonSource, lineLayer, null, draggableAnnotationController);
+    when(style.isFullyLoaded()).thenReturn(true);
+    lineManager = new LineManager(mapboxMap, style, geoJsonSource, lineLayer, null, draggableAnnotationController);
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -5,6 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -29,13 +30,15 @@ public class SymbolManagerTest {
 
   private DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController = mock(DraggableAnnotationController.class);
   private MapboxMap mapboxMap = mock(MapboxMap.class);
+  private Style style = mock(Style.class);
   private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
   private SymbolLayer symbolLayer = mock(SymbolLayer.class);
   private SymbolManager symbolManager;
 
   @Before
   public void beforeTest() {
-    symbolManager = new SymbolManager(mapboxMap, geoJsonSource, symbolLayer, null, draggableAnnotationController);
+    when(style.isFullyLoaded()).thenReturn(true);
+    symbolManager = new SymbolManager(mapboxMap, style, geoJsonSource, symbolLayer, null, draggableAnnotationController);
   }
 
   @Test


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/737.
Refs https://github.com/mapbox/mapbox-plugins-android/pull/789.

This PR adapts the annotation plugin to be compatible with the Maps SDK `v7.x` and also adds logic to save state across map style changes.

![ezgif com-video-to-gif 9](https://user-images.githubusercontent.com/16925074/50341636-d6f4c000-051f-11e9-8fd5-efc611ee5b9e.gif)
