### PR TITLE
Added plugin naming blurb to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ dependencies {
 ```
 5. Click the Sync Project with Gradle Files near the toolbar in Studio.
 
+## Maps SDK compatibility
+
+The Mapbox Plugins for Android are heavily dependent on the major semantic versioning number of the Maps SDK. They either won't compile or hide runtime bugs when paired with a different major version of the Maps SDK. Each plugin's dependency name has a `vX` suffix which states the major version of the Maps SDK that the plugin is compatible with. This suffix makes the transition between versions easier and more educated without the need to jump into changelogs and compare repositories.
+
 ## Help and Usage
 
 This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp) for ready-to-use snippets.

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation:0.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:0.4.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation:0.4.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:0.5.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v7:0.5.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building:0.4.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v7:0.6.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization:0.6.0'
+    implementation 'mapbox-android-plugin-localization-v7:0.7.0'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization:0.7.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization:0.8.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-markerview/README.md
+++ b/plugin-markerview/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview:0.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v7:0.2.0'
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview:0.2.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v7:0.3.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.2.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v7:0.4.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.3.0-SNAPSHOT'
+	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline:0.5.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-places/README.md
+++ b/plugin-places/README.md
@@ -21,7 +21,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places:0.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.7.0'
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places:0.7.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.8.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-traffic/README.md
+++ b/plugin-traffic/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v7:0.8.0'
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.7.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v7:0.9.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
Part of the Maps SDK 7.0.0 release .  Info in this pr's additions is basically the same as in https://github.com/mapbox/mapbox-gl-native/wiki/Android-6.x-to-7.x-migration-guide#new-plugin-naming
