### PR TITLE
Fallbacks for Localization plugin

### DIFF
--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -27,8 +27,8 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 
 /**
  * Useful class for quickly adjusting the maps language and the maps camera starting position.
- * You can either use {@link #matchMapLanguageWithDeviceDefault()} to match the map language with
- * the one being currently used on the device. Using {@link #setMapLanguage(Locale)} and it's
+ * You can either use {@link #matchMapLanguageWithDeviceDefault(boolean acceptFallback)} to match the map language with
+ * the one being currently used on the device. Using {@link #setMapLanguage(Locale,boolean acceptFallback)} and it's
  * variants, you can also change the maps language at anytime to any of the supported languages.
  * <p>
  * The plugin uses a fallback logic in case there are missing resources
@@ -139,10 +139,12 @@ public final class LocalizationPlugin {
    * Initializing this class and then calling this method oftentimes will be the only thing you'll
    * need to quickly adjust the map language to the devices specified language.
    *
+   * @param acceptFallback whether a fallback to a language default is desired
+   *
    * @since 0.1.0
    */
-  public void matchMapLanguageWithDeviceDefault() {
-    setMapLanguage(Locale.getDefault());
+  public void matchMapLanguageWithDeviceDefault(boolean acceptFallback) {
+    setMapLanguage(Locale.getDefault(),acceptFallback);
   }
 
   /**
@@ -163,10 +165,11 @@ public final class LocalizationPlugin {
    * locale you are trying to use, has a complementary {@link MapLocale} for it.
    *
    * @param locale a {@link Locale} which has a complementary {@link MapLocale} for it
+   * @param acceptFallback whether a fallback to a language default is desired
    * @since 0.1.0
    */
-  public void setMapLanguage(@NonNull Locale locale) {
-    MapLocale mapLocale = MapLocale.getMapLocale(locale);
+  public void setMapLanguage(@NonNull Locale locale, boolean acceptFallback) {
+    MapLocale mapLocale = MapLocale.getMapLocale(locale,acceptFallback);
     if (mapLocale != null) {
       setMapLanguage(mapLocale);
     } else {
@@ -289,7 +292,7 @@ public final class LocalizationPlugin {
    * @since 0.1.0
    */
   public void setCameraToLocaleCountry(Locale locale, int padding) {
-    MapLocale mapLocale = MapLocale.getMapLocale(locale);
+    MapLocale mapLocale = MapLocale.getMapLocale(locale,false);
     if (mapLocale != null) {
       setCameraToLocaleCountry(mapLocale, padding);
     } else {

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.plugins.localization;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
+import android.util.Log;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -364,7 +365,35 @@ public final class MapLocale {
    * @since 0.1.0
    */
   @Nullable
-  public static MapLocale getMapLocale(@NonNull Locale locale) {
-    return LOCALE_SET.get(locale);
+  public static MapLocale getMapLocale(@NonNull Locale locale, boolean acceptFallback) {
+    MapLocale foundLocale = LOCALE_SET.get(locale);
+    if (acceptFallback && foundLocale == null) {
+      foundLocale = getMapLocaleFallback(locale);
+    }
+    return foundLocale;
+  }
+
+  /**
+   * Passing in a Locale, you are able to receive the {@link MapLocale} object which it is currently
+   * paired with as a fallback. If this returns null, there was no matching {@link MapLocale} to go along with the
+   * passed in Locale. If you expected a non-null result, you should make sure you used
+   * {@link #addMapLocale(Locale, MapLocale)} before making this call.
+   *
+   * @param locale the locale which you'd like to receive its matching {@link MapLocale}(fallback) if one exists
+   * @return the matching {@link MapLocale} if one exists, otherwise null
+   * @since 0.1.0
+   */
+  @Nullable
+  private static MapLocale getMapLocaleFallback(@NonNull Locale locale) {
+    String fallbackCode = locale.getLanguage().substring(0,2);
+    MapLocale foundMapLocale = null;
+
+    for (Locale possibleLocale: LOCALE_SET.keySet()) {
+      if (possibleLocale.getLanguage().equals(fallbackCode)) {
+        foundMapLocale = LOCALE_SET.get(possibleLocale);
+        break;
+      }
+    }
+    return foundMapLocale;
   }
 }

--- a/plugin-localization/src/test/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.java
+++ b/plugin-localization/src/test/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.java
@@ -46,6 +46,6 @@ public class LocalizationPluginTest {
     thrown.expectMessage(containsString("has no matching MapLocale object. You need to create"));
     LocalizationPlugin localizationPlugin
       = new LocalizationPlugin(mock(MapView.class), mock(MapboxMap.class), style);
-    localizationPlugin.setMapLanguage(new Locale("foo", "bar"));
+    localizationPlugin.setMapLanguage(new Locale("foo", "bar"),false);
   }
 }

--- a/plugin-localization/src/test/java/com/mapbox/mapboxsdk/plugins/localization/MapLocaleTest.java
+++ b/plugin-localization/src/test/java/com/mapbox/mapboxsdk/plugins/localization/MapLocaleTest.java
@@ -22,7 +22,18 @@ public class MapLocaleTest {
     Locale locale = new Locale("foo", "bar");
     MapLocale mapLocale = new MapLocale("abc");
     MapLocale.addMapLocale(locale, mapLocale);
-    MapLocale mapLocale1 = MapLocale.getMapLocale(locale);
+    MapLocale mapLocale1 = MapLocale.getMapLocale(locale,false);
     Assert.assertThat(mapLocale1.getMapLanguage(), equalTo("abc"));
+  }
+
+  @Test
+  public void regionalVariantsCanFallbackCorrectly() throws Exception {
+    Locale localeHN = new Locale("es_HN", "Honduras");
+    MapLocale mapLocale1 = MapLocale.getMapLocale(localeHN,true);
+    assertThat(mapLocale1.getMapLanguage(), equalTo(MapLocale.SPANISH));
+
+    Locale localeUS = new Locale("es_US", "United States of America");
+    MapLocale mapLocale2 = MapLocale.getMapLocale(localeUS,true);
+    assertThat(mapLocale2.getMapLanguage(), equalTo(MapLocale.SPANISH));
   }
 }


### PR DESCRIPTION
Our logs are getting littered with these below error messages for regional/country variants after a recent APK update, so I figured I would give it a try so even when exact matches are not present, this plugin is valuable.

`Couldn't match Locale español (Colombia) to a MapLocale`
`Couldn't match Locale español (Estados Unidos) to a MapLocale`
`Couldn't match Locale español (Honduras) to a MapLocale`
`Couldn't match Locale español (Argentina) to a MapLocale`
`Couldn't match Locale español (México) to a MapLocale`








