### PR TITLE
Increase usefulness of warning log for Localization sources

### DIFF
--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -214,8 +214,8 @@ public final class LocalizationPlugin {
         if (url == null) {
           url = "not found";
         }
-        Timber.w("The \"%s\" source is not based on Mapbox Vector Tiles. Supported sources:\n %s",
-          url, SUPPORTED_SOURCES);
+        Timber.w("The %s (%s) source is not based on Mapbox Vector Tiles. Supported sources:\n %s",
+          source.getId(), url, SUPPORTED_SOURCES);
       }
     }
   }


### PR DESCRIPTION
It's impossible to understand what source is triggering these warning messages currently, so including the ID can be very helpful here I would think.