### PR TITLE
Fixup remove drag listener naming

### DIFF
--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -451,4 +451,38 @@ public class <%- camelize(type) %>ManagerTest {
     assertEquals(expression, <%- type %>Manager.getFilter());
     assertEquals(expression, <%- type %>Manager.layerFilter);
   }
+
+  @Test
+  public void testClickListener(){
+    On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
+    <%- type  %>Manager = new  <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
+    <%- type  %>Manager.addClickListener(listener);
+    assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
+    <%- type  %>Manager.removeClickListener(listener);
+    assertTrue( <%- type  %>Manager.getClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testLongClickListener(){
+    On<%- camelize(type) %>LongClickListener listener = mock(On<%- camelize(type) %>LongClickListener.class);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
+    <%- type  %>Manager.addLongClickListener(listener);
+    assertTrue(<%- type  %>Manager.getLongClickListeners().contains(listener));
+    <%- type  %>Manager.removeLongClickListener(listener);
+    assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testDragListener(){
+    On<%- camelize(type) %>DragListener listener = mock(On<%- camelize(type) %>DragListener.class);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
+    <%- type  %>Manager.addDragListener(listener);
+    assertTrue(<%- type  %>Manager.getDragListeners().contains(listener));
+    <%- type  %>Manager.removeDragListener(listener);
+    assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -4,6 +4,7 @@ import android.graphics.PointF;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.LongSparseArray;
 
 import com.mapbox.geojson.Feature;
@@ -237,7 +238,7 @@ public abstract class AnnotationManager<
    * @param d the callback to be removed
    */
   @UiThread
-  public void removeClickListener(@NonNull D d) {
+  public void removeDragListener(@NonNull D d) {
     dragListeners.remove(d);
   }
 
@@ -281,6 +282,21 @@ public abstract class AnnotationManager<
     longClickListeners.remove(v);
   }
 
+  @VisibleForTesting
+  List<U> getClickListeners() {
+    return clickListeners;
+  }
+
+  @VisibleForTesting
+  List<V> getLongClickListeners() {
+    return longClickListeners;
+  }
+
+  @VisibleForTesting
+  List<D> getDragListeners() {
+    return dragListeners;
+  }
+
   /**
    * Cleanup annotation manager, used to clear listeners
    */
@@ -300,10 +316,6 @@ public abstract class AnnotationManager<
   abstract void initializeDataDrivenPropertyMap();
 
   abstract void setFilter(@NonNull Expression expression);
-
-  List<D> getDragListeners() {
-    return dragListeners;
-  }
 
   private void initializeSourcesAndLayers() {
     geoJsonSource = coreElementProvider.getSource();

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -321,4 +321,38 @@ public class CircleManagerTest {
     assertEquals(expression, circleManager.getFilter());
     assertEquals(expression, circleManager.layerFilter);
   }
+
+  @Test
+  public void testClickListener(){
+    OnCircleClickListener listener = mock(OnCircleClickListener.class);
+    circleManager = new  CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(circleManager.getClickListeners().isEmpty());
+    circleManager.addClickListener(listener);
+    assertTrue(circleManager.getClickListeners().contains(listener));
+    circleManager.removeClickListener(listener);
+    assertTrue( circleManager.getClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testLongClickListener(){
+    OnCircleLongClickListener listener = mock(OnCircleLongClickListener.class);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(circleManager.getLongClickListeners().isEmpty());
+    circleManager.addLongClickListener(listener);
+    assertTrue(circleManager.getLongClickListeners().contains(listener));
+    circleManager.removeLongClickListener(listener);
+    assertTrue(circleManager.getLongClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testDragListener(){
+    OnCircleDragListener listener = mock(OnCircleDragListener.class);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(circleManager.getDragListeners().isEmpty());
+    circleManager.addDragListener(listener);
+    assertTrue(circleManager.getDragListeners().contains(listener));
+    circleManager.removeDragListener(listener);
+    assertTrue(circleManager.getDragListeners().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -365,4 +365,38 @@ public class FillManagerTest {
     assertEquals(expression, fillManager.getFilter());
     assertEquals(expression, fillManager.layerFilter);
   }
+
+  @Test
+  public void testClickListener(){
+    OnFillClickListener listener = mock(OnFillClickListener.class);
+    fillManager = new  FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(fillManager.getClickListeners().isEmpty());
+    fillManager.addClickListener(listener);
+    assertTrue(fillManager.getClickListeners().contains(listener));
+    fillManager.removeClickListener(listener);
+    assertTrue( fillManager.getClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testLongClickListener(){
+    OnFillLongClickListener listener = mock(OnFillLongClickListener.class);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(fillManager.getLongClickListeners().isEmpty());
+    fillManager.addLongClickListener(listener);
+    assertTrue(fillManager.getLongClickListeners().contains(listener));
+    fillManager.removeLongClickListener(listener);
+    assertTrue(fillManager.getLongClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testDragListener(){
+    OnFillDragListener listener = mock(OnFillDragListener.class);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(fillManager.getDragListeners().isEmpty());
+    fillManager.addDragListener(listener);
+    assertTrue(fillManager.getDragListeners().contains(listener));
+    fillManager.removeDragListener(listener);
+    assertTrue(fillManager.getDragListeners().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -387,4 +387,38 @@ public class LineManagerTest {
     assertEquals(expression, lineManager.getFilter());
     assertEquals(expression, lineManager.layerFilter);
   }
+
+  @Test
+  public void testClickListener(){
+    OnLineClickListener listener = mock(OnLineClickListener.class);
+    lineManager = new  LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(lineManager.getClickListeners().isEmpty());
+    lineManager.addClickListener(listener);
+    assertTrue(lineManager.getClickListeners().contains(listener));
+    lineManager.removeClickListener(listener);
+    assertTrue( lineManager.getClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testLongClickListener(){
+    OnLineLongClickListener listener = mock(OnLineLongClickListener.class);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(lineManager.getLongClickListeners().isEmpty());
+    lineManager.addLongClickListener(listener);
+    assertTrue(lineManager.getLongClickListeners().contains(listener));
+    lineManager.removeLongClickListener(listener);
+    assertTrue(lineManager.getLongClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testDragListener(){
+    OnLineDragListener listener = mock(OnLineDragListener.class);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(lineManager.getDragListeners().isEmpty());
+    lineManager.addDragListener(listener);
+    assertTrue(lineManager.getDragListeners().contains(listener));
+    lineManager.removeDragListener(listener);
+    assertTrue(lineManager.getDragListeners().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -609,4 +609,38 @@ public class SymbolManagerTest {
     assertEquals(expression, symbolManager.getFilter());
     assertEquals(expression, symbolManager.layerFilter);
   }
+
+  @Test
+  public void testClickListener(){
+    OnSymbolClickListener listener = mock(OnSymbolClickListener.class);
+    symbolManager = new  SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(symbolManager.getClickListeners().isEmpty());
+    symbolManager.addClickListener(listener);
+    assertTrue(symbolManager.getClickListeners().contains(listener));
+    symbolManager.removeClickListener(listener);
+    assertTrue( symbolManager.getClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testLongClickListener(){
+    OnSymbolLongClickListener listener = mock(OnSymbolLongClickListener.class);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(symbolManager.getLongClickListeners().isEmpty());
+    symbolManager.addLongClickListener(listener);
+    assertTrue(symbolManager.getLongClickListeners().contains(listener));
+    symbolManager.removeLongClickListener(listener);
+    assertTrue(symbolManager.getLongClickListeners().isEmpty());
+  }
+
+  @Test
+  public void testDragListener(){
+    OnSymbolDragListener listener = mock(OnSymbolDragListener.class);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    assertTrue(symbolManager.getDragListeners().isEmpty());
+    symbolManager.addDragListener(listener);
+    assertTrue(symbolManager.getDragListeners().contains(listener));
+    symbolManager.removeDragListener(listener);
+    assertTrue(symbolManager.getDragListeners().isEmpty());
+  }
+
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/831, next to addressing the naming, this PR adds some tests related to adding/removing listeners. 