### PR TITLE
disable vector drawable in download notification on pre lollipop devices

### DIFF
--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
@@ -48,7 +48,7 @@ public class NotificationUtils {
       .setSmallIcon(options.smallIconRes())
       .setOnlyAlertOnce(true)
       .setContentIntent(contentIntent)
-      .addAction(R.drawable.ic_cancel,
+      .addAction(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? 0 : R.drawable.ic_cancel,
         options.cancelText(),
         PendingIntent.getService(context, offlineDownload.uuid().intValue(), cancelIntent,
           PendingIntent.FLAG_CANCEL_CURRENT));


### PR DESCRIPTION
Otherwise the app will crash on android 4 devices.