### PR TITLE
[test-app] Fixed possible NullPointerException

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
@@ -186,7 +186,11 @@ public class BulkSymbolActivity extends AppCompatActivity implements AdapterView
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    symbolManager.onDestroy();
+
+    if (symbolManager != null) {
+      symbolManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -168,7 +168,11 @@ public class CircleActivity extends AppCompatActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    circleManager.onDestroy();
+
+    if (circleManager != null) {
+      circleManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
@@ -131,7 +131,11 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    symbolManager.onDestroy();
+
+    if (symbolManager != null) {
+      symbolManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
@@ -155,7 +155,11 @@ public class FillActivity extends AppCompatActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    fillManager.onDestroy();
+
+    if (fillManager != null) {
+      fillManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
@@ -124,7 +124,11 @@ public class FillChangeActivity extends AppCompatActivity implements OnMapReadyC
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    fillManager.onDestroy();
+
+    if (fillManager != null) {
+      fillManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
@@ -146,7 +146,11 @@ public class LineActivity extends AppCompatActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    lineManager.onDestroy();
+
+    if (lineManager != null) {
+      lineManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
@@ -156,7 +156,11 @@ public class LineChangeActivity extends AppCompatActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    lineManager.onDestroy();
+
+    if (lineManager != null) {
+      lineManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
@@ -114,7 +114,11 @@ public class PressForSymbolActivity extends AppCompatActivity {
     super.onDestroy();
     mapboxMap.removeOnMapClickListener(this::addSymbol);
     mapboxMap.removeOnMapLongClickListener(this::addSymbol);
-    symbolManager.onDestroy();
+
+    if (symbolManager != null) {
+      symbolManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -287,7 +287,11 @@ public class SymbolActivity extends AppCompatActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    symbolManager.onDestroy();
+
+    if (symbolManager != null) {
+      symbolManager.onDestroy();
+    }
+
     mapView.onDestroy();
   }
 


### PR DESCRIPTION
If map style can't be loaded(for example no Internet), annotation
managers won't be initiated. And calling these managers' onDestroy
method would throw a NullPointerException. Fixed it by checking if the
manager is null before calling its onDestroy method.