### PR TITLE
 [localization] Add better support for Chinese languages (fix #877)

### DIFF
--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -231,7 +231,6 @@ public final class LocalizationPlugin {
     for (Source source : style.getSources()) {
       if (sourceIsFromMapbox(source)) {
         boolean isStreetsV8 = sourceIsStreetsV8(source);
-        boolean isStreetsV7 = sourceIsStreetsV7(source);
         for (Layer layer : layers) {
           if (layer instanceof SymbolLayer) {
             PropertyValue<?> textFieldProperty = ((SymbolLayer) layer).getTextField();
@@ -239,6 +238,7 @@ public final class LocalizationPlugin {
               if (isStreetsV8) {
                 convertExpressionV8(mapLocale, layer, textFieldProperty);
               } else {
+                boolean isStreetsV7 = sourceIsStreetsV7(source);
                 convertExpression(mapLocale, layer, textFieldProperty, isStreetsV7);
               }
             }
@@ -287,6 +287,9 @@ public final class LocalizationPlugin {
 
       String mapLanguage = mapLocale.getMapLanguage();
       if (!mapLanguage.equals(MapLocale.ENGLISH)) {
+        if (mapLanguage.equals("name_zh")) {
+          mapLanguage = MapLocale.SIMPLIFIED_CHINESE;
+        }
         stringExpression = stringExpression.replaceAll(EXPRESSION_V8_REGEX_BASE,
           String.format(Locale.US,
             EXPRESSION_V8_TEMPLATE_LOCALIZED,

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -260,11 +260,6 @@ public final class LocalizationPlugin {
 
       String mapLanguage = mapLocale.getMapLanguage();
       if (!mapLanguage.equals(MapLocale.ENGLISH)) {
-        if (mapLanguage.equals(MapLocale.CHINESE)) {
-          // in streets v8 tiles chinese is declared as "name_zh-Hant" instead of "name_zh"
-          mapLanguage = MapLocale.CHINESE_V8;
-        }
-
         stringExpression = stringExpression.replaceAll(EXPRESSION_V8_REGEX_BASE,
           String.format(Locale.US,
             EXPRESSION_V8_TEMPLATE_LOCALIZED,

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -227,6 +227,16 @@ public final class MapLocale {
   public static final MapLocale TAIWAN = new MapLocale(TRADITIONAL_CHINESE, TAIWAN_BBOX);
 
   /**
+   * Useful constant for country. General Simplified Chinese
+   */
+  public static final MapLocale  CHINESE_HANS = new MapLocale(SIMPLIFIED_CHINESE);
+
+  /**
+   * Useful constant for country. General Traditional Chinese
+   */
+  public static final MapLocale CHINESE_HANT = new MapLocale(TRADITIONAL_CHINESE);
+
+  /**
    * Useful constant for country.
    */
   public static final MapLocale UK = new MapLocale(ENGLISH, UK_BBOX);
@@ -276,6 +286,28 @@ public final class MapLocale {
     LOCALE_SET.put(Locale.FRANCE, MapLocale.FRANCE);
     LOCALE_SET.put(new Locale("ru", "RU"), RUSSIA);
     LOCALE_SET.put(new Locale("es", "ES"), SPAIN);
+
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+      Locale zh_CN_Hans = new Locale.Builder().setLanguage("zh").setRegion("CN").setScript("Hans").build();
+      Locale zh_HK_Hans = new Locale.Builder().setLanguage("zh").setRegion("HK").setScript("Hans").build();
+      Locale zh_MO_Hans = new Locale.Builder().setLanguage("zh").setRegion("MO").setScript("Hans").build();
+      Locale zh_SG_Hans = new Locale.Builder().setLanguage("zh").setRegion("SG").setScript("Hans").build();
+
+      Locale zh_TW_Hant = new Locale.Builder().setLanguage("zh").setRegion("TW").setScript("Hant").build();
+      Locale zh_HK_Hant = new Locale.Builder().setLanguage("zh").setRegion("HK").setScript("Hant").build();
+      Locale zh_MO_Hant = new Locale.Builder().setLanguage("zh").setRegion("MO").setScript("Hant").build();
+
+      // streets v8 supports name_zh-Hans(MapLocale.CHINESE_HANS) and name_zh-Hant(MapLocale.CHINESE_HANT)
+      // https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#name-text--name_lang-code-text
+      LOCALE_SET.put(zh_CN_Hans, MapLocale.CHINESE_HANS);
+      LOCALE_SET.put(zh_HK_Hans, MapLocale.CHINESE_HANS);
+      LOCALE_SET.put(zh_MO_Hans, MapLocale.CHINESE_HANS);
+      LOCALE_SET.put(zh_SG_Hans, MapLocale.CHINESE_HANS);
+
+      LOCALE_SET.put(zh_TW_Hant, MapLocale.TAIWAN);
+      LOCALE_SET.put(zh_HK_Hant, MapLocale.CHINESE_HANT);
+      LOCALE_SET.put(zh_MO_Hant, MapLocale.CHINESE_HANT);
+    }
   }
 
   private final LatLngBounds countryBounds;

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -277,7 +277,7 @@ public final class MapLocale {
     LOCALE_SET.put(Locale.US, MapLocale.US);
     LOCALE_SET.put(Locale.CANADA_FRENCH, MapLocale.CANADA_FRENCH);
     LOCALE_SET.put(Locale.CANADA, MapLocale.CANADA);
-    LOCALE_SET.put(Locale.CHINA, MapLocale.CHINA);
+    LOCALE_SET.put(Locale.CHINA, MapLocale.CHINESE_HANS);
     LOCALE_SET.put(Locale.TAIWAN, MapLocale.TAIWAN);
     LOCALE_SET.put(Locale.UK, MapLocale.UK);
     LOCALE_SET.put(Locale.JAPAN, MapLocale.JAPAN);

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -86,9 +86,9 @@ public final class MapLocale {
   public static final String CHINESE = "name_zh";
 
   /**
-   * Chinese (if available)
+   * Traditional Chinese (if available)
    */
-  static final String CHINESE_V8 = "name_zh-Hant";
+  static final String TRADITIONAL_CHINESE = "name_zh-Hant";
 
   /**
    * Simplified Chinese (if available)
@@ -106,8 +106,8 @@ public final class MapLocale {
   public static final String KOREAN = "name_ko";
 
   @Retention(SOURCE)
-  @StringDef( {LOCAL_NAME, ENGLISH, FRENCH, SIMPLIFIED_CHINESE, ARABIC, SPANISH, GERMAN, PORTUGUESE,
-    RUSSIAN, CHINESE, JAPANESE, KOREAN})
+  @StringDef( {LOCAL_NAME, ARABIC, CHINESE, SIMPLIFIED_CHINESE, TRADITIONAL_CHINESE, ENGLISH,
+          FRENCH, GERMAN, JAPANESE, KOREAN, PORTUGUESE, RUSSIAN, SPANISH})
   public @interface Languages {
   }
 
@@ -144,6 +144,13 @@ public final class MapLocale {
     .include(new LatLng(15.775416, 134.773911)).build();
 
   /**
+   * Taiwan Bounding Box extracted from Open Street Map
+   */
+  static final LatLngBounds TAIWAN_BBOX = new LatLngBounds.Builder()
+          .include(new LatLng(26.389444, 118.115255566105))
+          .include(new LatLng(21.733333, 122.107778)).build();
+
+  /**
    * Germany Bounding Box extracted from Open Street Map
    */
   static final LatLngBounds GERMANY_BBOX = new LatLngBounds.Builder()
@@ -170,13 +177,6 @@ public final class MapLocale {
   static final LatLngBounds FRANCE_BBOX = new LatLngBounds.Builder()
     .include(new LatLng(51.092804, -5.142222))
     .include(new LatLng(41.371582, 9.561556)).build();
-
-  /**
-   * Peoples Republic of China Bounding Box extracted from Open Street Map
-   */
-  static final LatLngBounds PRC_BBOX = new LatLngBounds.Builder()
-    .include(new LatLng(53.56086, 73.557693))
-    .include(new LatLng(15.775416, 134.773911)).build();
 
   /**
    * Russian Bounding box extracted from Open Street Map
@@ -224,7 +224,7 @@ public final class MapLocale {
   /**
    * Useful constant for country.
    */
-  public static final MapLocale PRC = new MapLocale(SIMPLIFIED_CHINESE, PRC_BBOX);
+  public static final MapLocale TAIWAN = new MapLocale(TRADITIONAL_CHINESE, TAIWAN_BBOX);
 
   /**
    * Useful constant for country.
@@ -268,7 +268,7 @@ public final class MapLocale {
     LOCALE_SET.put(Locale.CANADA_FRENCH, MapLocale.CANADA_FRENCH);
     LOCALE_SET.put(Locale.CANADA, MapLocale.CANADA);
     LOCALE_SET.put(Locale.CHINA, MapLocale.CHINA);
-    LOCALE_SET.put(Locale.PRC, MapLocale.PRC);
+    LOCALE_SET.put(Locale.TAIWAN, MapLocale.TAIWAN);
     LOCALE_SET.put(Locale.UK, MapLocale.UK);
     LOCALE_SET.put(Locale.JAPAN, MapLocale.JAPAN);
     LOCALE_SET.put(Locale.KOREA, MapLocale.KOREA);


### PR DESCRIPTION
This PR aims to add better support for Chinese languages in localization plugin. With this change the plugin can support more types of Android system Chinese Locales and has better support for mapbox-streets-v8's new name_zh_Hant Traditional Chinese labels.