### PR TITLE
Check if annotation is an active annotation when updating

### DIFF
--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -510,4 +510,34 @@ public class <%- camelize(type) %>ManagerTest {
     assertEquals(0, <%- type  %>Manager.getAnnotations().size());
   }
 
+  @Test
+  public void testIgnoreClearedAnnotations() {
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+<% if (type === "circle" || type === "symbol") { -%>
+    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
+<% } else if (type === "line") { -%>
+    List<LatLng>latLngs = new ArrayList<>();
+    latLngs.add(new LatLng());
+    latLngs.add(new LatLng(1,1));
+    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+<% } else { -%>
+    List<LatLng>innerLatLngs = new ArrayList<>();
+    innerLatLngs.add(new LatLng());
+    innerLatLngs.add(new LatLng(1,1));
+    innerLatLngs.add(new LatLng(-1,-1));
+    List<List<LatLng>>latLngs = new ArrayList<>();
+    latLngs.add(innerLatLngs);
+    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+<% } -%>
+     <%- camelize(type) %>  <%- type %> = <%- type  %>Manager.create(options);
+    assertEquals(1, <%- type  %>Manager.annotations.size());
+
+    <%- type  %>Manager.getAnnotations().clear();
+    <%- type  %>Manager.updateSource();
+    assertTrue(<%- type  %>Manager.getAnnotations().isEmpty());
+
+    <%- type  %>Manager.update(<%- type  %>);
+    assertTrue(<%- type  %>Manager.getAnnotations().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -6,10 +6,10 @@ import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.LongSparseArray;
-
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
@@ -41,6 +41,8 @@ public abstract class AnnotationManager<
   D extends OnAnnotationDragListener<T>,
   U extends OnAnnotationClickListener<T>,
   V extends OnAnnotationLongClickListener<T>> {
+
+  private static final String TAG = "AnnotationManager";
 
   protected final MapboxMap mapboxMap;
   protected final LongSparseArray<T> annotations = new LongSparseArray<>();
@@ -177,8 +179,14 @@ public abstract class AnnotationManager<
    */
   @UiThread
   public void update(T annotation) {
-    annotations.put(annotation.getId(), annotation);
-    updateSource();
+    if (annotations.containsValue(annotation)) {
+      annotations.put(annotation.getId(), annotation);
+      updateSource();
+    } else {
+      Logger.e(TAG, "Can't update annotation: "
+        + annotation.toString()
+        + ", the annotation isn't active annotation.");
+    }
   }
 
   /**

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -365,4 +365,19 @@ public class CircleManagerTest {
     assertEquals(0, circleManager.getAnnotations().size());
   }
 
+  @Test
+  public void testIgnoreClearedAnnotations() {
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    CircleOptions options = new CircleOptions().withLatLng(new LatLng());
+     Circle  circle = circleManager.create(options);
+    assertEquals(1, circleManager.annotations.size());
+
+    circleManager.getAnnotations().clear();
+    circleManager.updateSource();
+    assertTrue(circleManager.getAnnotations().isEmpty());
+
+    circleManager.update(circle);
+    assertTrue(circleManager.getAnnotations().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -415,4 +415,25 @@ public class FillManagerTest {
     assertEquals(0, fillManager.getAnnotations().size());
   }
 
+  @Test
+  public void testIgnoreClearedAnnotations() {
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    List<LatLng>innerLatLngs = new ArrayList<>();
+    innerLatLngs.add(new LatLng());
+    innerLatLngs.add(new LatLng(1,1));
+    innerLatLngs.add(new LatLng(-1,-1));
+    List<List<LatLng>>latLngs = new ArrayList<>();
+    latLngs.add(innerLatLngs);
+    FillOptions options = new FillOptions().withLatLngs(latLngs);
+     Fill  fill = fillManager.create(options);
+    assertEquals(1, fillManager.annotations.size());
+
+    fillManager.getAnnotations().clear();
+    fillManager.updateSource();
+    assertTrue(fillManager.getAnnotations().isEmpty());
+
+    fillManager.update(fill);
+    assertTrue(fillManager.getAnnotations().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -434,4 +434,22 @@ public class LineManagerTest {
     assertEquals(0, lineManager.getAnnotations().size());
   }
 
+  @Test
+  public void testIgnoreClearedAnnotations() {
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    List<LatLng>latLngs = new ArrayList<>();
+    latLngs.add(new LatLng());
+    latLngs.add(new LatLng(1,1));
+    LineOptions options = new LineOptions().withLatLngs(latLngs);
+     Line  line = lineManager.create(options);
+    assertEquals(1, lineManager.annotations.size());
+
+    lineManager.getAnnotations().clear();
+    lineManager.updateSource();
+    assertTrue(lineManager.getAnnotations().isEmpty());
+
+    lineManager.update(line);
+    assertTrue(lineManager.getAnnotations().isEmpty());
+  }
+
 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -653,4 +653,19 @@ public class SymbolManagerTest {
     assertEquals(0, symbolManager.getAnnotations().size());
   }
 
+  @Test
+  public void testIgnoreClearedAnnotations() {
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, draggableAnnotationController);
+    SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
+     Symbol  symbol = symbolManager.create(options);
+    assertEquals(1, symbolManager.annotations.size());
+
+    symbolManager.getAnnotations().clear();
+    symbolManager.updateSource();
+    assertTrue(symbolManager.getAnnotations().isEmpty());
+
+    symbolManager.update(symbol);
+    assertTrue(symbolManager.getAnnotations().isEmpty());
+  }
+
 }


### PR DESCRIPTION
Capturing from a user that clearing all annotations and calling update on one the removed annotations results in readding that annotation. This PR checks if an annotation is added to the current active annotations before performing an update. 