### PR TITLE
Adding note about Java 8 requirement for Annotation Plugin

### DIFF
--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -8,15 +8,28 @@
 
 To use the annotation plugin you include it in your `build.gradle` file.
 
-```
-// In the root build.gradle file
+In the root `build.gradle` file:
+
+```groovy
 repositories {
     mavenCentral()
 }
 
-...
+```
 
-// In the app build.gradle file
+In the app-level `build.gradle` file:
+
+```groovy
+android {
+
+	// The Annotation Plugin requires Java 8 usage
+	compileOptions {
+	    sourceCompatibility JavaVersion.VERSION_1_8
+	    targetCompatibility JavaVersion.VERSION_1_8
+	}
+
+}
+
 dependencies {
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:0.5.0'
 }


### PR DESCRIPTION
This pr adds a note about needing Java 8 when using the Annotation Plugin. 

This addition comes from @ANGerz 's recommendation at https://github.com/mapbox/mapbox-plugins-android/issues/900#issuecomment-478983005


Related pr in `/android-docs`: https://github.com/mapbox/android-docs/pull/908