### PR TITLE
Register only one style loaded listener

### DIFF
--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -82,9 +82,9 @@ public class <%- camelize(type) %>ManagerTest {
     Expression filter = Expression.literal(false);
     <%- type  %>Manager.setFilter(filter);
 
-    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
-    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
-    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+    ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
+    verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
     ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
     verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.LongSparseArray;
+
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -87,7 +88,7 @@ public abstract class AnnotationManager<
 
     initializeSourcesAndLayers();
 
-    mapView.addOnWillStartLoadingMapListener(() ->
+    mapView.addOnDidFinishLoadingStyleListener(() ->
       mapboxMap.getStyle(loadedStyle -> {
         this.style = loadedStyle;
         initializeSourcesAndLayers();

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -77,9 +77,9 @@ public class CircleManagerTest {
     Expression filter = Expression.literal(false);
     circleManager.setFilter(filter);
 
-    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
-    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
-    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+    ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
+    verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
     ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
     verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -77,9 +77,9 @@ public class FillManagerTest {
     Expression filter = Expression.literal(false);
     fillManager.setFilter(filter);
 
-    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
-    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
-    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+    ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
+    verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
     ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
     verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -77,9 +77,9 @@ public class LineManagerTest {
     Expression filter = Expression.literal(false);
     lineManager.setFilter(filter);
 
-    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
-    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
-    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+    ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
+    verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
     ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
     verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -77,9 +77,9 @@ public class SymbolManagerTest {
     Expression filter = Expression.literal(false);
     symbolManager.setFilter(filter);
 
-    ArgumentCaptor<MapView.OnWillStartLoadingMapListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnWillStartLoadingMapListener.class);
-    verify(mapView).addOnWillStartLoadingMapListener(loadingArgumentCaptor.capture());
-    loadingArgumentCaptor.getValue().onWillStartLoadingMap();
+    ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
+    verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
+    loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
     ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
     verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());

--- a/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
+++ b/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
@@ -78,9 +78,10 @@ public final class BuildingPlugin {
     }
 
     initLayer(belowLayer);
-    mapView.addOnWillStartLoadingMapListener(new MapView.OnWillStartLoadingMapListener() {
+
+    mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
       @Override
-      public void onWillStartLoadingMap() {
+      public void onDidFinishLoadingStyle() {
         mapboxMap.getStyle(new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -41,6 +41,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
  * <li>- mapbox.mapbox-streets-v7</li>
  * <li>- mapbox.mapbox-streets-v8</li>
  * </ul>
+ *
  * @since 0.1.0
  */
 @UiThread
@@ -109,9 +110,9 @@ public final class LocalizationPlugin {
       throw new RuntimeException("The style has to be non-null and fully loaded.");
     }
 
-    MapView.OnWillStartLoadingMapListener styleLoadListener = new MapView.OnWillStartLoadingMapListener() {
+    mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
       @Override
-      public void onWillStartLoadingMap() {
+      public void onDidFinishLoadingStyle() {
         mapboxMap.getStyle(new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
@@ -122,8 +123,7 @@ public final class LocalizationPlugin {
           }
         });
       }
-    };
-    mapView.addOnWillStartLoadingMapListener(styleLoadListener);
+    });
   }
 
   private MapLocale getChineseMapLocale(MapLocale mapLocale, boolean isStreetsV7) {

--- a/plugin-traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
+++ b/plugin-traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
@@ -85,7 +85,7 @@ public final class TrafficPlugin {
     this.mapboxMap = mapboxMap;
     this.style = style;
     this.belowLayer = belowLayer;
-    mapView.addOnWillStartLoadingMapListener(new StyleLoadHandler(this));
+    mapView.addOnDidFinishLoadingStyleListener(new StyleLoadHandler(this));
   }
 
   /**
@@ -552,7 +552,7 @@ public final class TrafficPlugin {
     static final int CASE_RED = Color.parseColor("#5f1117");
   }
 
-  private static class StyleLoadHandler implements MapView.OnWillStartLoadingMapListener {
+  private static class StyleLoadHandler implements MapView.OnDidFinishLoadingStyleListener {
 
     private WeakReference<TrafficPlugin> trafficPlugin;
 
@@ -561,15 +561,15 @@ public final class TrafficPlugin {
     }
 
     @Override
-    public void onWillStartLoadingMap() {
+    public void onDidFinishLoadingStyle() {
       TrafficPlugin trafficPlugin = this.trafficPlugin.get();
       if (trafficPlugin != null) {
-        trafficPlugin.onWillStartLoadingMap();
+        trafficPlugin.onDidFinishLoadingStyle();
       }
     }
   }
 
-  private void onWillStartLoadingMap() {
+  private void onDidFinishLoadingStyle() {
     mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/888.

In the event of multiple styles in a row not loading but not failing either (lack of the internet connection), we were registering a new style getter for each `#setStyle` invocation, which would fire all at once during the next successful style load event resulting in various possible issues.