### PR TITLE
Adding visual limit option to the number of recently seached places

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragmentTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragmentTest.java
@@ -28,6 +28,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.verify;
 @Ignore public class PlaceAutocompleteFragmentTest {
 
   private static final String ACCESS_TOKEN = "pk.XXX";
+  private static final Integer HISTORY_COUNT = 5;
 
   private PlaceAutocompleteFragment placeAutocompleteFragment;
 
@@ -53,6 +55,7 @@ import static org.mockito.Mockito.verify;
 
     // For style test
     builder.backgroundColor(Color.BLUE);
+    builder.historyCount(HISTORY_COUNT);
     builder.hint("foobar");
 
     placeAutocompleteFragment = PlaceAutocompleteFragment.newInstance(
@@ -68,6 +71,11 @@ import static org.mockito.Mockito.verify;
     assertThat(placeAutocompleteFragment.getAccessToken(), equalTo(ACCESS_TOKEN));
   }
 
+  @Test
+  public void styleView_setHistoryCountIsCorrect() throws Exception {
+    assertThat(placeAutocompleteFragment.getHistoryCount(), equalTo(HISTORY_COUNT));
+  }
+  
   @Test
   public void onCreateView_doesInflateCorrectModeView() throws Exception {
     onView(withId(R.id.cardView)).check(matches(isDisplayed()));

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/model/PlaceOptions.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/model/PlaceOptions.java
@@ -85,6 +85,16 @@ public abstract class PlaceOptions implements Parcelable {
   public abstract int limit();
 
   /**
+   * Limit the number of results returned. The default is the maximum number of
+   * historical searches already saved by the Places plugin.
+   *
+   * @return the number of past search results returned by the geocoder
+   * @since 0.9.0
+   */
+  @Nullable
+  public abstract Integer historyCount();
+
+  /**
    * Limit results to a bounding box. Options are in the format {@code minX,minY,maxX,maxY}.
    *
    * @return the string with the coordinate order minX,minY,maxX,maxY
@@ -244,6 +254,15 @@ public abstract class PlaceOptions implements Parcelable {
      * @since 0.1.0
      */
     public abstract Builder limit(@IntRange(from = 1, to = 10) int limit);
+
+    /**
+     * Limit the number of past search results shown.
+     *
+     * @param historyCount the number of past historical searches shown before a search starts.
+     * @return this builder instance for chaining options together
+     * @since 0.9.0
+     */
+    public abstract Builder historyCount(@Nullable @IntRange(from = 0) Integer historyCount);
 
     /**
      * Limit results to a bounding box.

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragment.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragment.java
@@ -44,6 +44,7 @@ public class PlaceAutocompleteFragment extends Fragment implements ResultClickCa
   private SearchView searchView;
   private View dropShadowView;
   private String accessToken;
+  private Integer historyCount;
   private View rootView;
   private int mode;
 
@@ -204,8 +205,15 @@ public class PlaceAutocompleteFragment extends Fragment implements ResultClickCa
   void updateSearchHistoryView(@Nullable List<SearchHistoryEntity> searchHistoryEntities) {
     searchHistoryView.getResultsList().clear();
     if (searchHistoryEntities != null) {
-      for (SearchHistoryEntity entity : searchHistoryEntities) {
-        searchHistoryView.getResultsList().add(entity.getCarmenFeature());
+      if (placeOptions.historyCount() != null) {
+        historyCount = placeOptions.historyCount();
+        for (int x = 0; x < historyCount; x++) {
+          searchHistoryView.getResultsList().add(searchHistoryEntities.get(x).getCarmenFeature());
+        }
+      } else {
+        for (SearchHistoryEntity entity : searchHistoryEntities) {
+          searchHistoryView.getResultsList().add(entity.getCarmenFeature());
+        }
       }
     }
     searchHistoryView.notifyDataSetChanged();
@@ -268,5 +276,9 @@ public class PlaceAutocompleteFragment extends Fragment implements ResultClickCa
 
   public String getAccessToken() {
     return accessToken;
+  }
+
+  public Integer getHistoryCount() {
+    return historyCount;
   }
 }


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/780 by visually limiting the number of past searches displayed in the Places Plugin recyclerview. Adds a `historyCount()` method to `PlaceOptions`.  Working for me just fine in the plugin test app.