### PR TITLE
added onClick check of max and min zoom values in OfflineDownloadActivity

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
@@ -31,7 +31,12 @@ class OfflineDownloadActivity : AppCompatActivity() {
         setContentView(R.layout.activity_offline_download)
         initUi()
         initSeekbarListeners()
-        fabStartDownload.setOnClickListener { onDownloadRegion() }
+        fabStartDownload.setOnClickListener {
+            if (seekbarMaxZoom.progress.toFloat() > seekbarMinZoom.progress.toFloat())
+                onDownloadRegion() else Toast.makeText(this,
+                    "Please make sure that the Max zoom value is larger" +
+                            " than the Min zoom level", Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun initUi() {


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/925 by adding an `onClick` check of the set offline region min and max zoom levels. Toast is thrown if they're invalid values.

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/55902050-80b79580-5b7f-11e9-9a6c-ca69c3c63270.gif)
