### PR TITLE
Update home/work placeName and coordinates injection for AutocompleteLauncherActivity

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteLauncherActivity.kt
@@ -80,15 +80,15 @@ class AutocompleteLauncherActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private fun addUserLocations() {
         home = CarmenFeature.builder().text("Directions to Home")
-                .geometry(Point.fromLngLat(1.0, 2.0))
+                .geometry(Point.fromLngLat(-77.015665, 38.8996419))
                 .placeName("300 Massachusetts Ave NW")
                 .id("directions-home")
                 .properties(JsonObject())
                 .build()
 
         work = CarmenFeature.builder().text("Directions to Work")
-                .placeName("1509 16th St NW")
-                .geometry(Point.fromLngLat(1.0, 2.0))
+                .placeName("740 15th St NW")
+                .geometry(Point.fromLngLat(-77.03389, 38.89985))
                 .id("directions-work")
                 .properties(JsonObject())
                 .build()


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/924 so that tapping on `Directions To Home` or `Directions To Work` in the recyclerview, doesn't take the map camera to `null island`.


![ezgif com-resize](https://user-images.githubusercontent.com/4394910/55975739-7ceb4800-5c3f-11e9-9192-fa7fa98a94f6.gif)
