### PR TITLE
[all] - remove java 8 language support

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
 
   pluginVersion = [
       checkstyle: '8.10.1',
-      gradle    : '3.3.0',
+      gradle    : '3.4.0',
       kotlin    : '1.3.20',
       dokka     : '0.9.17'
   ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 24 11:40:33 CET 2019
+#Mon Apr 29 20:21:20 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/ktx-mapbox-maps/build.gradle
+++ b/ktx-mapbox-maps/build.gradle
@@ -25,11 +25,6 @@ android {
     tasks.withType(Javadoc).all {
         enabled = false
     }
-
-    compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
-    }
 }
 
 dependencies {

--- a/plugin-annotation/build.gradle
+++ b/plugin-annotation/build.gradle
@@ -20,11 +20,6 @@ android {
     testOptions {
         unitTests.returnDefaultValues true
     }
-
-    compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
-    }
 }
 
 dependencies {

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -74,7 +74,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   @UiThread
   public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener>(mapView, mapboxMap));
   }
 
   @VisibleForTesting

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -65,7 +65,7 @@ public class <%- camelize(type) %>ManagerTest {
       assertFalse(value);
     }
     verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(<%- type  %>Layer, times(0)).setFilter(any());
+    verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -137,7 +137,7 @@ public class <%- camelize(type) %>ManagerTest {
       assertFalse(value);
     }
     verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(<%- type  %>Layer, times(0)).setFilter(any());
+    verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -266,7 +266,7 @@ public class <%- camelize(type) %>ManagerTest {
       options.add(new LineOptions().withLatLngs(latLngs));
     }
 <% } else { -%>
-    List<List<LatLng>> latLngListOne = new ArrayList<>();
+    final List<List<LatLng>> latLngListOne = new ArrayList<>();
     latLngListOne.add(new ArrayList<LatLng>() {{
       add(new LatLng(2, 2));
       add(new LatLng(2, 3));
@@ -276,7 +276,7 @@ public class <%- camelize(type) %>ManagerTest {
       add(new LatLng(2, 3));
     }});
 
-    List<List<LatLng>> latLngListTwo = new ArrayList<>();
+    final List<List<LatLng>> latLngListTwo = new ArrayList<>();
     latLngListTwo.add(new ArrayList<LatLng>() {{
       add(new LatLng(5, 7));
       add(new LatLng(2, 3));

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -68,11 +68,11 @@ public abstract class AnnotationManager<
   private CoreElementProvider<L> coreElementProvider;
 
   @UiThread
-  protected AnnotationManager(MapView mapView, MapboxMap mapboxMap, Style style,
+  protected AnnotationManager(MapView mapView, final MapboxMap mapboxMap, Style style,
                               CoreElementProvider<L> coreElementProvider,
                               Comparator<Feature> comparator,
                               DraggableAnnotationController<T, D> draggableAnnotationController,
-                              String belowLayerId, GeoJsonOptions geoJsonOptions) {
+                              String belowLayerId, final GeoJsonOptions geoJsonOptions) {
     this.mapboxMap = mapboxMap;
     this.comparator = comparator;
     this.style = style;
@@ -90,12 +90,18 @@ public abstract class AnnotationManager<
 
     initializeSourcesAndLayers(geoJsonOptions);
 
-    mapView.addOnDidFinishLoadingStyleListener(() ->
-      mapboxMap.getStyle(loadedStyle -> {
-        this.style = loadedStyle;
-        initializeSourcesAndLayers(geoJsonOptions);
-      })
-    );
+    mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
+      @Override
+      public void onDidFinishLoadingStyle() {
+        mapboxMap.getStyle(new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style loadedStyle) {
+            AnnotationManager.this.style = loadedStyle;
+            initializeSourcesAndLayers(geoJsonOptions);
+          }
+        });
+      }
+    });
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -68,7 +68,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    */
   @UiThread
   public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Circle, OnCircleDragListener>(mapView, mapboxMap));
   }
 
   @VisibleForTesting

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -34,7 +34,7 @@ final class DraggableAnnotationController<T extends Annotation, D extends OnAnno
 
   @VisibleForTesting
   public DraggableAnnotationController(MapView mapView, MapboxMap mapboxMap,
-                                       AndroidGesturesManager androidGesturesManager,
+                                       final AndroidGesturesManager androidGesturesManager,
                                        int touchAreaShiftX, int touchAreaShiftY,
                                        int touchAreaMaxX, int touchAreaMaxY) {
     this.mapboxMap = mapboxMap;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -67,7 +67,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    */
   @UiThread
   public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Fill, OnFillDragListener>(mapView, mapboxMap));
   }
 
   @VisibleForTesting

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -70,7 +70,7 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   @UiThread
   public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Line, OnLineDragListener>(mapView, mapboxMap));
   }
 
   @VisibleForTesting

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -89,7 +89,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   @UiThread
   public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Symbol, OnSymbolDragListener>(mapView, mapboxMap));
   }
 
   @VisibleForTesting

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -60,7 +60,7 @@ public class CircleManagerTest {
       assertFalse(value);
     }
     verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(circleLayer, times(0)).setFilter(any());
+    verify(circleLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -132,7 +132,7 @@ public class CircleManagerTest {
       assertFalse(value);
     }
     verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(circleLayer, times(0)).setFilter(any());
+    verify(circleLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
   }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -60,7 +60,7 @@ public class FillManagerTest {
       assertFalse(value);
     }
     verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(fillLayer, times(0)).setFilter(any());
+    verify(fillLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -132,7 +132,7 @@ public class FillManagerTest {
       assertFalse(value);
     }
     verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(fillLayer, times(0)).setFilter(any());
+    verify(fillLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -194,7 +194,7 @@ public class FillManagerTest {
   @Test
   public void addFills() {
     fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    List<List<LatLng>> latLngListOne = new ArrayList<>();
+    final List<List<LatLng>> latLngListOne = new ArrayList<>();
     latLngListOne.add(new ArrayList<LatLng>() {{
       add(new LatLng(2, 2));
       add(new LatLng(2, 3));
@@ -204,7 +204,7 @@ public class FillManagerTest {
       add(new LatLng(2, 3));
     }});
 
-    List<List<LatLng>> latLngListTwo = new ArrayList<>();
+    final List<List<LatLng>> latLngListTwo = new ArrayList<>();
     latLngListTwo.add(new ArrayList<LatLng>() {{
       add(new LatLng(5, 7));
       add(new LatLng(2, 3));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -60,7 +60,7 @@ public class LineManagerTest {
       assertFalse(value);
     }
     verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(lineLayer, times(0)).setFilter(any());
+    verify(lineLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -132,7 +132,7 @@ public class LineManagerTest {
       assertFalse(value);
     }
     verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(lineLayer, times(0)).setFilter(any());
+    verify(lineLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
   }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -60,7 +60,7 @@ public class SymbolManagerTest {
       assertFalse(value);
     }
     verify(symbolLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(symbolLayer, times(0)).setFilter(any());
+    verify(symbolLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
   }
@@ -132,7 +132,7 @@ public class SymbolManagerTest {
       assertFalse(value);
     }
     verify(symbolLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(symbolLayer, times(0)).setFilter(any());
+    verify(symbolLayer, times(0)).setFilter(any(Expression.class));
     verify(draggableAnnotationController).onSourceUpdated();
     verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
   }

--- a/plugin-markerview/build.gradle
+++ b/plugin-markerview/build.gradle
@@ -20,11 +20,6 @@ android {
     testOptions {
         unitTests.returnDefaultValues true
     }
-
-    compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-plugins-android/issues/942 
- Remove java 8 from the plugin codebase 
 - Update to latest gradle android tooling and gradle wrapper