### PR TITLE
Adding ability to set status bar color in places plugin search UI

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteFragmentActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteFragmentActivity.kt
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.places
 
+import android.graphics.Color
 import android.os.Bundle
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
@@ -23,6 +24,7 @@ class AutocompleteFragmentActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             val placeOptions = PlaceOptions.builder()
                     .toolbarColor(ContextCompat.getColor(this, R.color.colorPrimary))
+                    .statusbarColor(Color.YELLOW)
                     .hint("Begin searching...")
                     .build()
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteLauncherActivity.kt
@@ -71,6 +71,7 @@ class AutocompleteLauncherActivity : AppCompatActivity(), OnMapReadyCallback {
                                 .backgroundColor(Color.WHITE)
                                 .addInjectedFeature(home)
                                 .addInjectedFeature(work)
+                                .statusbarColor(Color.MAGENTA)
                                 .build())
                         .build(this@AutocompleteLauncherActivity)
                 startActivityForResult(intent, REQUEST_CODE_AUTOCOMPLETE)

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/model/PlaceOptions.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/model/PlaceOptions.java
@@ -170,6 +170,15 @@ public abstract class PlaceOptions implements Parcelable {
   public abstract int toolbarColor();
 
   /**
+   * Set the autocomplete's layout status bar color. Defaults {@link Color#BLACK}.
+   *
+   * @return the status bar color as a ColorInt
+   * @since 0.9.0
+   */
+  @ColorInt
+  public abstract int statusbarColor();
+
+  /**
    * Optionally set the hint string which is shown before the user inputs a search term inside the
    * top edit text.
    *
@@ -191,6 +200,7 @@ public abstract class PlaceOptions implements Parcelable {
     return new AutoValue_PlaceOptions.Builder()
       .backgroundColor(Color.TRANSPARENT)
       .toolbarColor(Color.WHITE)
+      .statusbarColor(Color.BLACK)
       .limit(10);
   }
 
@@ -397,6 +407,15 @@ public abstract class PlaceOptions implements Parcelable {
      * @since 0.1.0
      */
     public abstract Builder toolbarColor(@ColorInt int toolbarColor);
+
+    /**
+     * Set the autocomplete's layout status bar color. Defaults {@link Color#BLACK}.
+     *
+     * @param statusbarColor the views status bar color as a ColorInt
+     * @return this builder instance for chaining options together
+     * @since 0.9.0
+     */
+    public abstract Builder statusbarColor(@ColorInt int statusbarColor);
 
     /**
      * Optionally set the hint string which is shown before the user inputs a search term inside the

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteActivity.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteActivity.java
@@ -29,7 +29,6 @@ public class PlaceAutocompleteActivity extends AppCompatActivity implements Plac
       } else {
         fragment = PlaceAutocompleteFragment.newInstance(accessToken);
       }
-
       getSupportFragmentManager().beginTransaction()
         .add(R.id.fragment_container, fragment, PlaceAutocompleteFragment.TAG).commit();
 

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragment.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragment.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
+import android.app.Activity;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -103,6 +105,11 @@ public class PlaceAutocompleteFragment extends Fragment implements ResultClickCa
       View toolbar = rootView.findViewById(R.id.toolbar);
       if (toolbar != null) {
         toolbar.setBackgroundColor(placeOptions.toolbarColor());
+      }
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        Activity context = (Activity) rootView.getContext();
+        context.getWindow().setStatusBarColor(placeOptions.statusbarColor());
       }
 
       searchView = rootView.findViewById(R.id.searchView);


### PR DESCRIPTION
Resolves #954 by adding a `PlaceOptions.Builder` method to set the color of the [status bar](https://material.io/design/platform-guidance/android-bars.html#status-bar). If no color is passed through, the default color is black. This gives developers the ability to further customize the places plugin UI.

cc @Firzen7, who opened #954 


![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/58148963-b2f3f280-7c15-11e9-82fc-c8e091886cb3.gif)
