### PR TITLE
Added check for null latLng in PlacePickerActivity makeReverseGeocodingSearch()

### DIFF
--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/PlacePickerActivity.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/PlacePickerActivity.java
@@ -174,10 +174,12 @@ public class PlacePickerActivity extends AppCompatActivity implements OnMapReady
 
   private void makeReverseGeocodingSearch() {
     LatLng latLng = mapboxMap.getCameraPosition().target;
-    viewModel.reverseGeocode(
-      Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()),
-      accessToken, options
-    );
+    if (latLng != null) {
+      viewModel.reverseGeocode(
+          Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()),
+          accessToken, options
+      );
+    }
   }
 
   private void addChosenLocationButton() {


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/817 by checking whether `latLng` from  `LatLng latLng = mapboxMap.getCameraPosition().target;` is null. Null `latLng` seemed to be the issue reported in #817 .