### PR TITLE
Adding includeReverseGeocoding call method to PlacePickerOptions

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.widget.Switch
 import android.widget.Toast
 
 import com.mapbox.mapboxsdk.Mapbox
@@ -20,12 +21,20 @@ class PickerLauncherActivity : AppCompatActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_picker_launcher)
+        reverseGeocodingSwitch.text = getString(R.string.reverse_geocoding_disabled)
+        reverseGeocodingSwitch.setOnCheckedChangeListener { compoundButton, checked ->
+            reverseGeocodingSwitch.text = if (checked)
+                getString(R.string.reverse_geocoding_enabled)
+            else getString(R.string.reverse_geocoding_disabled)
+        }
+
         fabLocationPicker.setOnClickListener { _ ->
             Mapbox.getAccessToken()?.let {
                 startActivityForResult(
                         PlacePicker.IntentBuilder()
                                 .accessToken(it)
                                 .placeOptions(PlacePickerOptions.builder()
+                                        .includeReverseGeocode(reverseGeocodingSwitch.isChecked)
                                         .statingCameraPosition(CameraPosition.Builder()
                                                 .target(LatLng(40.7544, -73.9862))
                                                 .zoom(16.0)
@@ -39,8 +48,13 @@ class PickerLauncherActivity : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            val carmenFeature = PlacePicker.getPlace(data)
-            Toast.makeText(this, carmenFeature?.placeName(), Toast.LENGTH_LONG).show()
+            if (reverseGeocodingSwitch.isChecked) {
+                val carmenFeature = PlacePicker.getPlace(data)
+                Toast.makeText(this, carmenFeature?.placeName(), Toast.LENGTH_LONG).show()
+            } else {
+                val cameraPosition = PlacePicker.getLastCameraPosition(data)
+                Toast.makeText(this, cameraPosition.target.toString(), Toast.LENGTH_LONG).show()
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_picker_launcher.xml
+++ b/app/src/main/res/layout/activity_picker_launcher.xml
@@ -1,39 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <Switch
+      android:id="@+id/reverseGeocodingSwitch"
+      android:layout_width="wrap_content"
+      android:layout_height="22dp"
+      android:layout_marginStart="8dp"
+      android:layout_marginLeft="8dp"
+      android:layout_marginEnd="8dp"
+      android:layout_marginRight="8dp"
+      android:layout_marginBottom="8dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.5"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/textView"/>
 
   <TextView
-    android:id="@+id/textView"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginBottom="8dp"
-    android:layout_marginEnd="8dp"
-    android:layout_marginStart="8dp"
-    android:layout_marginTop="8dp"
-    android:text="@string/detailed_description_place_picker"
-    android:textAlignment="center"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_bias="0.25"/>
+      android:id="@+id/textView"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="8dp"
+      android:layout_marginTop="8dp"
+      android:layout_marginEnd="8dp"
+      android:text="@string/detailed_description_place_picker"
+      android:textAlignment="center"
+      app:layout_constraintBottom_toTopOf="@+id/reverseGeocodingSwitch"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.5"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"/>
 
   <android.support.design.widget.FloatingActionButton
-    android:id="@+id/fabLocationPicker"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginBottom="16dp"
-    android:layout_marginEnd="16dp"
-    android:layout_marginRight="16dp"
-    android:tint="@android:color/white"
-    app:backgroundTint="@color/colorPrimary"
-    app:fabSize="normal"
-    app:layout_anchorGravity="bottom|right|end"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:srcCompat="@drawable/mapbox_ic_place"/>
+      android:id="@+id/fabLocationPicker"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginEnd="16dp"
+      android:layout_marginRight="16dp"
+      android:layout_marginBottom="16dp"
+      android:tint="@android:color/white"
+      app:backgroundTint="@color/colorPrimary"
+      app:fabSize="normal"
+      app:layout_anchorGravity="bottom|right|end"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:srcCompat="@drawable/mapbox_ic_place"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,8 @@
 
   <!-- Place picker -->
   <string name="detailed_description_place_picker">Example shows how to launch the Place Picker using the Floating action button and receiving a result in onActivityResult.</string>
+  <string name="reverse_geocoding_enabled">Reverse geocoding enabled</string>
+  <string name="reverse_geocoding_disabled">Reverse geocoding disabled</string>
 
   <!-- Misc -->
   <string name="min_zoom_textview">Min zoom: %1$d</string>

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/model/PlacePickerOptions.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/model/PlacePickerOptions.java
@@ -33,8 +33,11 @@ public abstract class PlacePickerOptions implements BasePlaceOptions, Parcelable
   @Nullable
   public abstract CameraPosition statingCameraPosition();
 
+  public abstract boolean includeReverseGeocode();
+
   public static Builder builder() {
-    return new AutoValue_PlacePickerOptions.Builder();
+    return new AutoValue_PlacePickerOptions.Builder()
+        .includeReverseGeocode(true);
   }
 
   @AutoValue.Builder
@@ -54,6 +57,16 @@ public abstract class PlacePickerOptions implements BasePlaceOptions, Parcelable
     public abstract Builder startingBounds(@NonNull LatLngBounds bounds);
 
     public abstract Builder statingCameraPosition(@NonNull CameraPosition cameraPosition);
+
+    /**
+     *
+     * @param includeReverseGeocode whether or not to make a reverse geocoding call to
+     *                              retrieve and display information associated with
+     *                              the picked location's coordinates. Defaults to true.
+     *
+     * @return this builder instance for chaining options together
+     */
+    public abstract Builder includeReverseGeocode(boolean includeReverseGeocode);
 
     public abstract PlacePickerOptions build();
   }


### PR DESCRIPTION
This pr resolves #857 by adding a `PlacePickerOptions.Builder()` method to `includeReverseGeocode(boolean)`. If `false` is passed through, the bottom sheet is hidden and _no geocoding call is made_ (saving developer $). If `true`, bottom sheet is shown with reverse geocoding information displayed. 

cc @kbauhaus as fyi about search-related functionality.


![ezgif com-resize (3)](https://user-images.githubusercontent.com/4394910/58215814-7c1eea80-7cb0-11e9-827e-f83f7ba9241a.gif)

