### PR TITLE
Fix get metersPerPixel twice error.

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
@@ -23,8 +23,7 @@ public class ScaleBarPlugin {
     @Override
     public void onCameraMove() {
       CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      double metersPerPixel = projection.getMetersPerPixelAtLatitude(cameraPosition.target.getLatitude());
-      scaleBarWidget.setDistancePerPixel(projection.getMetersPerPixelAtLatitude(metersPerPixel));
+      scaleBarWidget.setDistancePerPixel(projection.getMetersPerPixelAtLatitude(cameraPosition.target.getLatitude()));
     }
   };
 
@@ -49,8 +48,7 @@ public class ScaleBarPlugin {
     mapboxMap.addOnCameraMoveListener(cameraMoveListener);
     mapView.addView(scaleBarWidget);
     CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-    double metersPerPixel = projection.getMetersPerPixelAtLatitude(cameraPosition.target.getLatitude());
-    scaleBarWidget.setDistancePerPixel(projection.getMetersPerPixelAtLatitude(metersPerPixel));
+    scaleBarWidget.setDistancePerPixel(projection.getMetersPerPixelAtLatitude(cameraPosition.target.getLatitude()));
     return scaleBarWidget;
   }
 


### PR DESCRIPTION
Resolves #972 . 
Root cause for this issue is that we call `projection.getMetersPerPixelAtLatitude` twice and get the wrong value.