### PR TITLE
Adding Portuguese language support to Localization Plugin

### DIFF
--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -192,6 +192,20 @@ public final class MapLocale {
     .include(new LatLng(27.4335426, -18.3936845))
     .include(new LatLng(43.9933088, 4.5918885)).build();
 
+  /**
+   * Portugal Bounding box extracted from Open Street Map
+   */
+  static final LatLngBounds PORTUGAL_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(27.4335426, -18.3936845))
+    .include(new LatLng(42.280468655, -6.3890876937)).build();
+
+  /**
+   * Brazil Bounding box extracted from Open Street Map
+   */
+  static final LatLngBounds BRAZIL_BBOX = new LatLngBounds.Builder()
+    .include(new LatLng(5.2842873, -33.8689056))
+    .include(new LatLng(-28.6341164, -73.9830625)).build();
+
   /*
    * Some MapLocales already defined (these match with the predefined ones in the Locale class)
    */
@@ -267,6 +281,16 @@ public final class MapLocale {
   public static final MapLocale SPAIN = new MapLocale(SPANISH, SPAIN_BBOX);
 
   /**
+   * Useful constant for country.
+   */
+  public static final MapLocale PORTUGAL = new MapLocale(PORTUGUESE, PORTUGAL_BBOX);
+
+  /**
+   * Useful constant for country.
+   */
+  public static final MapLocale BRAZIL = new MapLocale(PORTUGUESE, BRAZIL_BBOX);
+
+  /**
    * Maps out the Matching pair of {@link Locale} and {@link MapLocale}. In other words, if I have a
    * {@link Locale#CANADA}, this should be matched up with {@link MapLocale#CANADA}.
    */
@@ -286,6 +310,8 @@ public final class MapLocale {
     LOCALE_SET.put(Locale.FRANCE, MapLocale.FRANCE);
     LOCALE_SET.put(new Locale("ru", "RU"), RUSSIA);
     LOCALE_SET.put(new Locale("es", "ES"), SPAIN);
+    LOCALE_SET.put(new Locale("pt", "PT"), PORTUGAL);
+    LOCALE_SET.put(new Locale("pt", "BR"), BRAZIL);
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
       Locale zh_CN_Hans = new Locale.Builder().setLanguage("zh").setRegion("CN").setScript("Hans").build();


### PR DESCRIPTION
Resolves @leocarona 's https://github.com/mapbox/mapbox-plugins-android/issues/978. The Localization Plugin for Android didn't have support for Portuguese (Portugal/Brazil). This pr adds supports for it. 

To test this pr, install this repo's test app on `master`. Go to the Localization Plugin activity and switch your phone device into Portugal or Brazil Portuguese. You'll see the map doesn't switch to Portuguese. 
![Screen Shot 2019-06-05 at 12 21 06 PM](https://user-images.githubusercontent.com/4394910/58983806-7931f880-878c-11e9-97f4-98432706a4e6.png)

![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/58983767-6c150980-878c-11e9-90ca-710fbd60b710.gif)

Then switch to this pr's branch and reinstall this app. The map does switch to Portuguese for Portugal and Brazil. 

![ezgif com-resize (3)](https://user-images.githubusercontent.com/4394910/58984114-155bff80-878d-11e9-8654-d4eecafd1539.gif)

