### PR TITLE
Bumping Java SDK dependency to 4.8.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@
 
   version = [
       mapboxMapSdk       : '8.0.0',
-      mapboxJava         : '4.6.0',
+      mapboxJava         : '4.8.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.6',


### PR DESCRIPTION
This pr bumps the Java SDK dependency in this repo to the latest stable Java SDK version. I did manual QA on this branch and all test app examples are looking 💯 .