### PR TITLE
Bumped plugin version numbers in README files for giant release following Maps 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Plugins are single-purpose libraries built on top of the [Mapbox Maps SDK for An
 
 * [**Localization:** Have your map's text automatically match the device's default language setting.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-localization)
 
+* [**Scale bar:** Provide a visual map scale bar for your users to determine distance.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-scalebar)
+
 ## Installing a plugin
 
 By using a plugin, you also have to include the Mapbox Maps SDK for Android which means that you'll need to setup your project to use the Maps SDK if you haven't already. Head over to the [overview page for the Maps SDK](https://www.mapbox.com/android-docs/map-sdk/overview/) to learn more.

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:0.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.7.0'
 }
 ```
 
@@ -48,7 +48,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:0.7.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.8.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -1,4 +1,4 @@
-# Mapbox building plugin
+# Mapbox Building Plugin
 
 ![buildings-plugin](https://user-images.githubusercontent.com/4394910/28844435-71442d04-76b9-11e7-8866-ee6a94306353.gif)
 
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v7:0.5.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v8:0.6.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v7:0.6.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v8:0.7.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v7:0.9.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.10.0'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v7:0.10.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.11.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-markerview/README.md
+++ b/plugin-markerview/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v7:0.2.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v8:0.3.0'
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v7:0.3.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v8:0.4.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v7:0.5.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v8:0.6.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v7:0.6.0-SNAPSHOT'
+	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v8:0.7.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-places/README.md
+++ b/plugin-places/README.md
@@ -21,7 +21,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.8.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v8:0.9.0'
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.9.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v8:0.10.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -1,14 +1,12 @@
-# Mapbox Traffic Plugin
+# Mapbox Scale Bar Plugin
 
-The traffic plugin adds a real-time traffic layer to any Mapbox basemap. 
+The scale bar plugin adds a responsive scale bar on top of the map. The scale bar gives a visual indication of how far various map features are from one another at a certain zoom level. The scale bar can be customized with options such as the text color/size, referesh interval, margins, and border width.
 
-![ezgif com-crop](https://cloud.githubusercontent.com/assets/4394910/24972279/bf88b170-1f6f-11e7-8638-6afe08369d9d.gif)
+![ezgif com-resize (2)](https://user-images.githubusercontent.com/8577318/57837052-89416280-77f4-11e9-9d97-f164737acd46.gif)
 
 ## Getting Started
 
-[More documentation about the plugin can be found here](https://www.mapbox.com/android-docs/plugins/overview/traffic/)
-
-To use the traffic plugin, you include it in your `build.gradle` file.
+To use the scale bar plugin, you include it in your `build.gradle` file.
 
 ```
 // In the root build.gradle file
@@ -20,11 +18,11 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v8:0.9.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v8:0.1.0'
 }
 ```
 
-The traffic plugin is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
+The scale bar plugin is published to Maven Central and nightly SNAPSHOTs are available on Sonatype:
 
 ```
 // In the root build.gradle file
@@ -37,14 +35,13 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v8:0.10.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v8:0.2.0-SNAPSHOT'
 }
 ```
 
-## Traffic plugin examples
+## Scale bar plugin examples
 
-- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/traffic/TrafficActivity.kt)
-- [In the Mapbox Android demo app](https://github.com/mapbox/mapbox-android-demo/blob/a411fa95cd71c1b90a30895060b319310444aebb/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java) – (Don't have the app? [Download it on Google Play](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).)
+- [In this repo's test app](https://github.com/mapbox/mapbox-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt)
 
 ## Help and Usage
 


### PR DESCRIPTION
Part of https://github.com/mapbox/mapbox-plugins-android/issues/987

Also adds a README for the new Scale Bar Plugin: https://github.com/mapbox/mapbox-plugins-android/blob/83fdc9765e37c940d0cc07740b9bd94227248398/plugin-scalebar/README.md