### PR TITLE
Downgrade log level of MapLocale no match scenarios

### DIFF
--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -209,7 +209,7 @@ public final class LocalizationPlugin {
       Timber.d("Locale: %s, set MapLocale: %s", locale.toString(), mapLocale.getMapLanguage());
       setMapLanguage(mapLocale);
     } else {
-      Timber.e("Couldn't match Locale %s %s to a MapLocale", locale.toString(), locale.getDisplayName());
+      Timber.d("Couldn't match Locale %s %s to a MapLocale", locale.toString(), locale.getDisplayName());
     }
   }
 
@@ -329,7 +329,7 @@ public final class LocalizationPlugin {
     if (mapLocale != null) {
       setCameraToLocaleCountry(mapLocale, padding);
     } else {
-      Timber.e("Couldn't match Locale %s to a MapLocale", locale.getDisplayName());
+      Timber.d("Couldn't match Locale %s to a MapLocale", locale.getDisplayName());
     }
   }
 


### PR DESCRIPTION
Since not finding matches for MapLocale is a very common and normal occurrence, I don't believe this should be logged thru Timber as an error. Moved it to debug instead. This currently litters logs with huge amounts of duplicative information.