### PR TITLE
Added user location button to Places Plugin's PlacePickerActivity

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
@@ -28,6 +28,13 @@ class PickerLauncherActivity : AppCompatActivity() {
             else getString(R.string.reverse_geocoding_disabled)
         }
 
+        userLocationSwitch.text = getString(R.string.user_location_button_disabled)
+        userLocationSwitch.setOnCheckedChangeListener { compoundButton, checked ->
+            userLocationSwitch.text = if (checked)
+                getString(R.string.user_location_button_enabled)
+            else getString(R.string.user_location_button_disabled)
+        }
+
         fabLocationPicker.setOnClickListener { _ ->
             Mapbox.getAccessToken()?.let {
                 startActivityForResult(
@@ -35,6 +42,7 @@ class PickerLauncherActivity : AppCompatActivity() {
                                 .accessToken(it)
                                 .placeOptions(PlacePickerOptions.builder()
                                         .includeReverseGeocode(reverseGeocodingSwitch.isChecked)
+                                        .includeDeviceLocationButton(userLocationSwitch.isChecked)
                                         .statingCameraPosition(CameraPosition.Builder()
                                                 .target(LatLng(40.7544, -73.9862))
                                                 .zoom(16.0)

--- a/app/src/main/res/layout/activity_picker_launcher.xml
+++ b/app/src/main/res/layout/activity_picker_launcher.xml
@@ -21,6 +21,21 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/textView"/>
 
+  <Switch
+      android:id="@+id/userLocationSwitch"
+      android:layout_width="wrap_content"
+      android:layout_height="22dp"
+      android:layout_marginStart="8dp"
+      android:layout_marginLeft="8dp"
+      android:layout_marginEnd="8dp"
+      android:layout_marginRight="8dp"
+      android:layout_marginBottom="8dp"
+      app:layout_constraintBottom_toTopOf="@+id/reverseGeocodingSwitch"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.5"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/textView" />
+
   <TextView
       android:id="@+id/textView"
       android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,8 @@
   <string name="detailed_description_place_picker">Example shows how to launch the Place Picker using the Floating action button and receiving a result in onActivityResult.</string>
   <string name="reverse_geocoding_enabled">Reverse geocoding enabled</string>
   <string name="reverse_geocoding_disabled">Reverse geocoding disabled</string>
+  <string name="user_location_button_enabled">User location button enabled</string>
+  <string name="user_location_button_disabled">User location button disabled</string>
 
   <!-- Misc -->
   <string name="min_zoom_textview">Min zoom: %1$d</string>

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/model/PlacePickerOptions.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/model/PlacePickerOptions.java
@@ -35,9 +35,12 @@ public abstract class PlacePickerOptions implements BasePlaceOptions, Parcelable
 
   public abstract boolean includeReverseGeocode();
 
+  public abstract boolean includeDeviceLocationButton();
+
   public static Builder builder() {
     return new AutoValue_PlacePickerOptions.Builder()
-        .includeReverseGeocode(true);
+        .includeReverseGeocode(true)
+        .includeDeviceLocationButton(false);
   }
 
   @AutoValue.Builder
@@ -59,6 +62,10 @@ public abstract class PlacePickerOptions implements BasePlaceOptions, Parcelable
     public abstract Builder statingCameraPosition(@NonNull CameraPosition cameraPosition);
 
     /**
+     * Determine whether to include a bottom sheet in the PlacePickerActivity to display
+     * geocoding information associated with coordinates at the center of the map. A new
+     * geocoding call is made every time the map is moved when true is passed through
+     * includeReverseGeocode().
      *
      * @param includeReverseGeocode whether or not to make a reverse geocoding call to
      *                              retrieve and display information associated with
@@ -67,6 +74,18 @@ public abstract class PlacePickerOptions implements BasePlaceOptions, Parcelable
      * @return this builder instance for chaining options together
      */
     public abstract Builder includeReverseGeocode(boolean includeReverseGeocode);
+
+    /**
+     * Determine whether an Android-system Floating Action Button is included in
+     * the PlacePickerActivity UI. Clicking on this Floating Action Button will
+     * move the map camera to the device's location. False is the default if
+     * this method isn't used in building the PlacePickerOptions object.
+     *
+     * @param includeDeviceLocationButton
+     *
+     * @return this builder instance for chaining options together
+     */
+    public abstract Builder includeDeviceLocationButton(boolean includeDeviceLocationButton);
 
     public abstract PlacePickerOptions build();
   }

--- a/plugin-places/src/main/res/drawable/mapbox_plugins_ic_user_location.xml
+++ b/plugin-places/src/main/res/drawable/mapbox_plugins_ic_user_location.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#606060"
+        android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM20.94,11c-0.46,-4.17 -3.77,-7.48 -7.94,-7.94L13,1h-2v2.06C6.83,3.52 3.52,6.83 3.06,11L1,11v2h2.06c0.46,4.17 3.77,7.48 7.94,7.94L11,23h2v-2.06c4.17,-0.46 7.48,-3.77 7.94,-7.94L23,13v-2h-2.06zM12,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/plugin-places/src/main/res/layout/mapbox_view_bottom_sheet_container.xml
+++ b/plugin-places/src/main/res/layout/mapbox_view_bottom_sheet_container.xml
@@ -1,66 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:layout_gravity="bottom">
-
-  <!-- TODO add move camera to user location fab -->
-  <!--<android.support.design.widget.FloatingActionButton-->
-    <!--android:layout_width="wrap_content"-->
-    <!--android:layout_height="wrap_content"-->
-    <!--android:layout_gravity="top|end"-->
-    <!--android:layout_marginEnd="8dp"-->
-    <!--android:layout_marginRight="8dp"-->
-    <!--app:elevation="3dp"-->
-    <!--app:layout_anchor="@id/place_chosen_button"-->
-    <!--app:layout_anchorGravity="top"-->
-    <!--app:backgroundTint="@color/mapbox_plugins_white"-->
-    <!--app:useCompatPadding="true"-->
-    <!--app:srcCompat="@drawable/mapbox_plugins_ic_user_location"/>-->
-
-  <android.support.design.widget.FloatingActionButton
-    android:id="@+id/place_chosen_button"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:tint="@color/mapbox_plugins_white"
-    android:layout_margin="16dp"
-    app:backgroundTint="@color/mapbox_plugins_green"
-    app:elevation="3dp"
-    app:layout_anchor="@id/root_bottom_sheet"
-    app:layout_anchorGravity="top|end"
-    app:srcCompat="@drawable/mapbox_ic_check"/>
-
-  <ImageView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="start"
-    android:layout_marginLeft="4dp"
-    android:layout_marginStart="4dp"
-    android:paddingBottom="4dp"
-    app:layout_anchor="@id/root_bottom_sheet"
-    app:srcCompat="@drawable/mapbox_logo_icon"/>
-
-  <LinearLayout
-    android:id="@+id/root_bottom_sheet"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+    android:layout_height="match_parent"
+    android:layout_gravity="bottom">
 
-    <View
-      android:id="@+id/shadow"
-      android:layout_width="match_parent"
-      android:layout_height="4dp"
-      android:layout_gravity="top"
-      android:background="@drawable/mapbox_gradient_shadow_up"
-      app:layout_anchor="@+id/root_bottom_sheet"
-      app:layout_anchorGravity="top"/>
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/user_location_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:visibility="gone"
+        app:backgroundTint="@color/mapbox_plugins_white"
+        app:elevation="3dp"
+        app:layout_anchor="@id/place_chosen_button"
+        app:layout_anchorGravity="top"
+        app:srcCompat="@drawable/mapbox_plugins_ic_user_location"
+        app:useCompatPadding="true" />
 
-    <include
-      layout="@layout/mapbox_view_details_bottom_header"/>
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/place_chosen_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:tint="@color/mapbox_plugins_white"
+        android:layout_margin="16dp"
+        app:backgroundTint="@color/mapbox_plugins_green"
+        app:elevation="3dp"
+        app:layout_anchor="@id/root_bottom_sheet"
+        app:layout_anchorGravity="top|end"
+        app:srcCompat="@drawable/mapbox_ic_check"/>
 
-  </LinearLayout>
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginLeft="4dp"
+        android:layout_marginStart="4dp"
+        android:paddingBottom="4dp"
+        app:layout_anchor="@id/root_bottom_sheet"
+        app:srcCompat="@drawable/mapbox_logo_icon"/>
+
+    <LinearLayout
+        android:id="@+id/root_bottom_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+
+        <View
+            android:id="@+id/shadow"
+            android:layout_width="match_parent"
+            android:layout_height="4dp"
+            android:layout_gravity="top"
+            android:background="@drawable/mapbox_gradient_shadow_up"
+            app:layout_anchor="@+id/root_bottom_sheet"
+            app:layout_anchorGravity="top"/>
+
+        <include
+            layout="@layout/mapbox_view_details_bottom_header"/>
+
+    </LinearLayout>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/plugin-places/src/main/res/values/strings.xml
+++ b/plugin-places/src/main/res/values/strings.xml
@@ -17,4 +17,8 @@
   <string name="mapbox_plugins_cd_search_clear_button">Clear Search Query</string>
   <string name="mapbox_plugins_cd_offline_icon">Offline icon</string>
 
+  <!-- PlacePicker Activity device location toasts -->
+  <string name="mapbox_plugins_place_picker_user_location_permission_explanation">This app needs location permissions in order to find the device location.</string>
+  <string name="mapbox_plugins_place_picker_user_location_permission_not_granted">Location permissions not granted.</string>
+  <string name="mapbox_plugins_place_picker_user_location_not_found">Location can\'t be found.</string>
 </resources>


### PR DESCRIPTION
Resolves #973 by adding a device location Floating Action Button to the `PlacePickerActivity`. The button is hooked into the Maps SDK's `LocationComponent`, so this pr also adds the `LocationComponent` setup to the `PlacePickerActivity`.

This pr also adds a `includeDeviceLocationButton()` option to `PlacePickerOptions.java`. If the `includeDeviceLocationButton()` method isn't used, the default is to _not_ include the button in the `PlacePickerActivity` UI.

cc @androideveloper, who requested this.


![ezgif com-resize (2)](https://user-images.githubusercontent.com/4394910/59810631-17f54380-92bb-11e9-84b4-d2be9701d7df.gif)
