### PR TITLE
Make LAYER_ID of BuildingPlugin public

### DIFF
--- a/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
+++ b/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
@@ -42,6 +42,9 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
  */
 public final class BuildingPlugin {
 
+  /**
+   * LAYER_ID is exposed public so it can be utilized by layerBelow and layerAbove arguments
+   */
   public static final String LAYER_ID = "mapbox-android-plugin-3d-buildings";
 
   private FillExtrusionLayer fillExtrusionLayer;

--- a/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
+++ b/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
@@ -42,7 +42,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
  */
 public final class BuildingPlugin {
 
-  private static final String LAYER_ID = "mapbox-android-plugin-3d-buildings";
+  public static final String LAYER_ID = "mapbox-android-plugin-3d-buildings";
 
   private FillExtrusionLayer fillExtrusionLayer;
   private boolean visible;


### PR DESCRIPTION
This is helpful so other tools can reference it as an argument in `layerBelow` or `layerAbove`