### PR TITLE
Maps SDK 8.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '8.1.0',
+      mapboxMapSdk       : '8.2.0',
       mapboxJava         : '4.8.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',


### PR DESCRIPTION
This pr is to track the eventual upgrade of the plugins' dependency on the Maps SDK for Android to `8.2.0`.

- [x] 8.2.0-alpha.1
- [x] 8.2.0-alpha.2
- [x] 8.2.0-alpha.3
- [ ] 8.2.0-beta.1
- [ ] 8.2.0

cc @mapbox/maps-android 