### PR TITLE
Add automated resource loading of icon-images

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/ImageLoaderTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/ImageLoaderTest.java
@@ -1,0 +1,122 @@
+package com.mapbox.mapboxsdk.plugins.annotation;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(AndroidJUnit4.class)
+public class ImageLoaderTest {
+
+  @Rule
+  public ActivityTestRule<TestActivity> rule = new ActivityTestRule<>(TestActivity.class);
+
+  private MapView mapView;
+  private SymbolManager symbolManager;
+  private CountDownLatch countDownLatch = new CountDownLatch(1);
+
+  @Before
+  public void setUp() {
+    mapView = rule.getActivity().mapView;
+  }
+
+  @Test
+  public void testImageLoadingString() throws TimeoutException {
+    rule.getActivity().runOnUiThread(() -> {
+      mapView.getMapAsync(mapboxMap -> {
+        mapboxMap.moveCamera(CameraUpdateFactory.zoomBy(3));
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+          symbolManager = new SymbolManager(mapView, mapboxMap, style);
+          SymbolOptions symbolOptions = new SymbolOptions()
+            .withLatLng(new LatLng())
+            .withIconImage("mapbox_compass_icon");
+          mapView.addOnDidBecomeIdleListener(() -> {
+            assertNotNull(style.getImage("mapbox_compass_icon"));
+            countDownLatch.countDown();
+          });
+          symbolManager.create(symbolOptions);
+        });
+      });
+    });
+    try {
+      boolean timeout = !countDownLatch.await(10, TimeUnit.SECONDS);
+      if (timeout) {
+        throw new TimeoutException();
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testImageLoadingId() throws TimeoutException {
+    rule.getActivity().runOnUiThread(() -> {
+      mapView.getMapAsync(mapboxMap -> {
+        mapboxMap.moveCamera(CameraUpdateFactory.zoomBy(3));
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+          symbolManager = new SymbolManager(mapView, mapboxMap, style);
+          SymbolOptions symbolOptions = new SymbolOptions()
+            .withLatLng(new LatLng())
+            .withIconImage(rule.getActivity(), R.drawable.mapbox_compass_icon);
+          mapView.addOnDidBecomeIdleListener(() -> {
+            assertNotNull(style.getImage("mapbox_compass_icon"));
+            countDownLatch.countDown();
+          });
+          symbolManager.create(symbolOptions);
+        });
+      });
+    });
+    try {
+      boolean timeout = !countDownLatch.await(10, TimeUnit.SECONDS);
+      if (timeout) {
+        throw new TimeoutException();
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testInvalidImageLoading() throws TimeoutException {
+    rule.getActivity().runOnUiThread(() -> {
+      mapView.getMapAsync(mapboxMap -> {
+        mapboxMap.moveCamera(CameraUpdateFactory.zoomBy(3));
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+          symbolManager = new SymbolManager(mapView, mapboxMap, style);
+          SymbolOptions symbolOptions = new SymbolOptions()
+            .withLatLng(new LatLng())
+            .withIconImage("unknown");
+          mapView.addOnDidBecomeIdleListener(() -> {
+            assertNull(style.getImage("unknown"));
+            countDownLatch.countDown();
+          });
+          symbolManager.create(symbolOptions);
+        });
+      });
+    });
+    try {
+      boolean timeout = !countDownLatch.await(10, TimeUnit.SECONDS);
+      if (timeout) {
+        throw new TimeoutException();
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+}
+

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -15,6 +16,7 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.plugins.annotation.AnnotationManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
@@ -145,6 +147,21 @@ public class PressForSymbolActivity extends AppCompatActivity {
       drawable.draw(canvas);
       return bitmap;
     }
+  }
+
+  @VisibleForTesting
+  public MapView getMapView(){
+    return mapView;
+  }
+
+  @VisibleForTesting
+  public SymbolManager getSymbolManager(){
+    return symbolManager;
+  }
+
+  @VisibleForTesting
+  public MapboxMap getMapboxMap(){
+    return mapboxMap;
   }
 }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -46,7 +46,6 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.toNumber;
  */
 public class SymbolActivity extends AppCompatActivity {
 
-  private static final String ID_ICON_AIRPORT = "airport";
   private static final String MAKI_ICON_CAR = "car-15";
   private static final String MAKI_ICON_CAFE = "cafe-15";
   private static final String MAKI_ICON_CIRCLE = "fire-station-15";
@@ -72,10 +71,6 @@ public class SymbolActivity extends AppCompatActivity {
 
       mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-      style.addImage(ID_ICON_AIRPORT,
-        BitmapUtils.getBitmapFromDrawable(getResources().getDrawable(R.drawable.ic_airplanemode_active_black_24dp)),
-        true);
-
       // create symbol manager
       GeoJsonOptions geoJsonOptions = new GeoJsonOptions().withTolerance(0.4f);
       symbolManager = new SymbolManager(mapView, mapboxMap, style, null, geoJsonOptions);
@@ -96,7 +91,7 @@ public class SymbolActivity extends AppCompatActivity {
       // create a symbol
       SymbolOptions symbolOptions = new SymbolOptions()
         .withLatLng(new LatLng(6.687337, 0.381457))
-        .withIconImage(ID_ICON_AIRPORT)
+        .withIconImage("ic_airplanemode_active_black_24dp")
         .withIconSize(1.3f)
         .withSymbolSortKey(10.0f)
         .withDraggable(true);

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -7,23 +7,30 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 
+import android.support.v4.content.res.ResourcesCompat;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,12 +81,15 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   @UiThread
   public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener>(mapView, mapboxMap), new ImageLoader(mapView));
   }
 
   @VisibleForTesting
-  <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController) {
+  <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<<%- camelize(type) %>, On<%- camelize(type) %>DragListener> draggableAnnotationController, ImageLoader imageLoader) {
     super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+<% if (type === "symbol") { -%>
+    mapView.addOnStyleImageMissingListener(imageLoader);
+<% } -%>
   }
 
   @Override

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -58,7 +58,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testInitialization() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(<%- type  %>Layer);
     assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -73,7 +73,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testInitializationOnStyleReload() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(<%- type  %>Layer);
     assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -116,7 +116,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testLayerBelowInitialization() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayerBelow(<%- type  %>Layer, "test_layer");
     assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -130,7 +130,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testGeoJsonOptionsInitialization() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController, null);
     verify(style).addSource(optionedGeoJsonSource);
     verify(style).addLayer(<%- type  %>Layer);
     assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -145,7 +145,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testNoUpdateOnStyleReload() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
 
     when(style.isFullyLoaded()).thenReturn(false);
@@ -155,7 +155,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testAdd<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -178,7 +178,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void add<%- camelize(type) %>FromFeatureCollection() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     Geometry geometry = Point.fromLngLat(10, 10);
 <% } else if (type === "line") { -%>
@@ -237,7 +237,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void add<%- camelize(type) %>s() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     List<LatLng> latLngList = new ArrayList<>();
     latLngList.add(new LatLng());
@@ -297,7 +297,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testDelete<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -320,7 +320,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testGeometry<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     LatLng latLng = new LatLng(12, 34);
     <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(latLng);
@@ -375,7 +375,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testFeatureId<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
     <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
@@ -401,7 +401,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void test<%- camelize(type) %>DraggableFlag() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -431,7 +431,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void test<%- camelize(property.name) %>LayerProperty() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
 <% if (type === "circle" || type === "symbol") { -%>
@@ -461,7 +461,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void test<%- camelize(type) %>LayerFilter() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(<%- type %>Layer, times(0)).setFilter(expression);
 
@@ -476,7 +476,7 @@ public class <%- camelize(type) %>ManagerTest {
   @Test
   public void testClickListener() {
     On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
-    <%- type  %>Manager = new  <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new  <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
     <%- type  %>Manager.addClickListener(listener);
     assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
@@ -487,7 +487,7 @@ public class <%- camelize(type) %>ManagerTest {
   @Test
   public void testLongClickListener() {
     On<%- camelize(type) %>LongClickListener listener = mock(On<%- camelize(type) %>LongClickListener.class);
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
     <%- type  %>Manager.addLongClickListener(listener);
     assertTrue(<%- type  %>Manager.getLongClickListeners().contains(listener));
@@ -498,7 +498,7 @@ public class <%- camelize(type) %>ManagerTest {
   @Test
   public void testDragListener() {
     On<%- camelize(type) %>DragListener listener = mock(On<%- camelize(type) %>DragListener.class);
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
     <%- type  %>Manager.addDragListener(listener);
     assertTrue(<%- type  %>Manager.getDragListeners().contains(listener));
@@ -508,7 +508,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testCustomData() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
@@ -532,7 +532,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testClearAll() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
@@ -557,7 +557,7 @@ public class <%- camelize(type) %>ManagerTest {
 
   @Test
   public void testIgnoreClearedAnnotations() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
 <% if (type === "circle" || type === "symbol") { -%>
     <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -7,6 +7,10 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+<% if ( type === "symbol") { -%>
+import android.content.Context;
+import android.support.annotation.DrawableRes;
+<% } -%>
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -45,9 +49,9 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
 <% } -%>
 <% } -%>
   private static final String PROPERTY_IS_DRAGGABLE = "is-draggable";
+
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-
   /**
    * Set <%- property.name %> to initialise the <%- type %> with.
    * <p>
@@ -71,10 +75,25 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
   public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
     return <%- camelizeWithLeadingLowercase(property.name) %>;
   }
+
+<% if (property.name === 'icon-image') { -%>
+  /**
+   * Set icon-image resource id to initialise the symbol with.
+   * <p>
+   * Name of resource to use for drawing an image background.
+   * </p>
+   * @param resourceDrawable the icon-image resource drawable id value
+   * @return this
+   */
+  public SymbolOptions withIconImage(@NonNull Context context, @DrawableRes int resourceDrawable) {
+    this.iconImage =  context.getResources().getResourceEntryName(resourceDrawable);
+    return this;
+  }
+
+<% } -%>
 <% } -%>
 <% } -%>
 <% if (type === "circle" || type === "symbol") { -%>
-
   /**
    * Set the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
    *
@@ -117,8 +136,8 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
   public Point getGeometry() {
     return geometry;
   }
-<% } else if (type === "line") { -%>
 
+<% } else if (type === "line") { -%>
   /**
    * Set a list of LatLng for the line, which represents the locations of the line on the map
    *
@@ -168,8 +187,8 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
   public LineString getGeometry() {
     return geometry;
   }
-<% } else { -%>
 
+<% } else { -%>
   /**
    * Set a list of lists of LatLng for the fill, which represents the locations of the fill on the map
    *
@@ -227,8 +246,8 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
   public Polygon getGeometry() {
     return geometry;
   }
-<% } -%>
 
+<% } -%>
   /**
    * Returns whether this <%- type %> is draggable, meaning it can be dragged across the screen when touched and moved.
    *

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -2,23 +2,30 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 
+import android.support.v4.content.res.ResourcesCompat;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.CircleLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,11 +75,11 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    */
   @UiThread
   public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Circle, OnCircleDragListener>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Circle, OnCircleDragListener>(mapView, mapboxMap), new ImageLoader(mapView));
   }
 
   @VisibleForTesting
-  CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Circle, OnCircleDragListener> draggableAnnotationController) {
+  CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Circle, OnCircleDragListener> draggableAnnotationController, ImageLoader imageLoader) {
     super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -2,23 +2,30 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 
+import android.support.v4.content.res.ResourcesCompat;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.FillLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,11 +74,11 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    */
   @UiThread
   public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Fill, OnFillDragListener>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Fill, OnFillDragListener>(mapView, mapboxMap), new ImageLoader(mapView));
   }
 
   @VisibleForTesting
-  FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController) {
+  FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Fill, OnFillDragListener> draggableAnnotationController, ImageLoader imageLoader) {
     super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ImageLoader.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ImageLoader.java
@@ -1,0 +1,76 @@
+package com.mapbox.mapboxsdk.plugins.annotation;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+import android.support.v4.content.res.ResourcesCompat;
+import com.mapbox.mapboxsdk.log.Logger;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * ImageLoader is responsible for automating loading of drawable resources to the style.
+ * These images are loaded through the iconImage configuration of SymbolOptions and
+ * leverages the OnStyleImageMissingListener to lazily load images.
+ */
+public class ImageLoader implements MapView.OnStyleImageMissingListener {
+
+  private static final String TAG = "ImageLoader";
+  private WeakReference<MapView> mapViewWeakReference;
+
+  ImageLoader(MapView mapView) {
+    this.mapViewWeakReference = new WeakReference<>(mapView);
+  }
+
+  @Override
+  public void onStyleImageMissing(@NonNull final String id) {
+    if (id.isEmpty()) {
+      return;
+    }
+
+    MapView mapView = mapViewWeakReference.get();
+    if (mapView != null) {
+      Context context = mapView.getContext();
+      if (context != null) {
+        getDrawable(context, mapView, id);
+      }
+    }
+  }
+
+  private void getDrawable(@NonNull Context context, @NonNull MapView mapView, String id) {
+    Resources resources = context.getResources();
+    int drawableId = resources.getIdentifier(id, "drawable", context.getPackageName());
+    try {
+      Drawable drawable = ResourcesCompat.getDrawable(resources, drawableId, context.getTheme());
+      final Bitmap bitmap = BitmapUtils.getBitmapFromDrawable(drawable);
+      if (bitmap != null) {
+        addBitmapToMap(mapView, id, bitmap);
+      }
+    } catch (Resources.NotFoundException exception) {
+      Logger.e(TAG, String.format(
+        "Image lookup fail, adding image missing %s failed with exception:", id
+      ), exception);
+    }
+  }
+
+  private void addBitmapToMap(@NonNull MapView mapView, @NonNull final String id, @NonNull final Bitmap bitmap) {
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+        mapboxMap.getStyle(new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+            style.addImage(id, bitmap, true);
+          }
+        });
+      }
+    });
+  }
+}

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -2,23 +2,30 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 
+import android.support.v4.content.res.ResourcesCompat;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.LineLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -70,11 +77,11 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   @UiThread
   public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Line, OnLineDragListener>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Line, OnLineDragListener>(mapView, mapboxMap), new ImageLoader(mapView));
   }
 
   @VisibleForTesting
-  LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController) {
+  LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Line, OnLineDragListener> draggableAnnotationController, ImageLoader imageLoader) {
     super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -2,23 +2,30 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 
+import android.support.v4.content.res.ResourcesCompat;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,12 +97,13 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   @UiThread
   public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Symbol, OnSymbolDragListener>(mapView, mapboxMap));
+    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, geoJsonOptions, new DraggableAnnotationController<Symbol, OnSymbolDragListener>(mapView, mapboxMap), new ImageLoader(mapView));
   }
 
   @VisibleForTesting
-  SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController) {
+  SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController<Symbol, OnSymbolDragListener> draggableAnnotationController, ImageLoader imageLoader) {
     super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    mapView.addOnStyleImageMissingListener(imageLoader);
   }
 
   @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -2,6 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.content.Context;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -155,6 +157,19 @@ public class SymbolOptions extends Options<Symbol> {
    */
   public String getIconImage() {
     return iconImage;
+  }
+
+  /**
+   * Set icon-image resource id to initialise the symbol with.
+   * <p>
+   * Name of resource to use for drawing an image background.
+   * </p>
+   * @param resourceDrawable the icon-image resource drawable id value
+   * @return this
+   */
+  public SymbolOptions withIconImage(@NonNull Context context, @DrawableRes int resourceDrawable) {
+    this.iconImage =  context.getResources().getResourceEntryName(resourceDrawable);
+    return this;
   }
 
   /**

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -53,7 +53,7 @@ public class CircleManagerTest {
 
   @Test
   public void testInitialization() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(circleLayer);
     assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -68,7 +68,7 @@ public class CircleManagerTest {
 
   @Test
   public void testInitializationOnStyleReload() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(circleLayer);
     assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -111,7 +111,7 @@ public class CircleManagerTest {
 
   @Test
   public void testLayerBelowInitialization() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayerBelow(circleLayer, "test_layer");
     assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class CircleManagerTest {
 
   @Test
   public void testGeoJsonOptionsInitialization() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController, null);
     verify(style).addSource(optionedGeoJsonSource);
     verify(style).addLayer(circleLayer);
     assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -140,7 +140,7 @@ public class CircleManagerTest {
 
   @Test
   public void testNoUpdateOnStyleReload() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
 
     when(style.isFullyLoaded()).thenReturn(false);
@@ -150,14 +150,14 @@ public class CircleManagerTest {
 
   @Test
   public void testAddCircle() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     assertEquals(circleManager.getAnnotations().get(0), circle);
   }
 
   @Test
   public void addCircleFromFeatureCollection() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Geometry geometry = Point.fromLngLat(10, 10);
 
     Feature feature = Feature.fromGeometry(geometry);
@@ -186,7 +186,7 @@ public class CircleManagerTest {
 
   @Test
   public void addCircles() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng> latLngList = new ArrayList<>();
     latLngList.add(new LatLng());
     latLngList.add(new LatLng(1, 1));
@@ -201,7 +201,7 @@ public class CircleManagerTest {
 
   @Test
   public void testDeleteCircle() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     circleManager.delete(circle);
     assertTrue(circleManager.getAnnotations().size() == 0);
@@ -209,7 +209,7 @@ public class CircleManagerTest {
 
   @Test
   public void testGeometryCircle() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     LatLng latLng = new LatLng(12, 34);
     CircleOptions options = new CircleOptions().withLatLng(latLng);
     Circle circle = circleManager.create(options);
@@ -221,7 +221,7 @@ public class CircleManagerTest {
 
   @Test
   public void testFeatureIdCircle() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     Circle circleOne = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
     assertEquals(circleZero.getFeature().get(Circle.ID_KEY).getAsLong(), 0);
@@ -230,7 +230,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleDraggableFlag() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
 
     assertFalse(circleZero.isDraggable());
@@ -243,7 +243,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleRadiusLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleRadius(get("circle-radius")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleRadius(0.3f);
@@ -256,7 +256,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleColorLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleColor(get("circle-color")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleColor("rgba(0, 0, 0, 1)");
@@ -269,7 +269,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleBlurLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleBlur(get("circle-blur")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleBlur(0.3f);
@@ -282,7 +282,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleOpacityLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleOpacity(get("circle-opacity")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleOpacity(0.3f);
@@ -295,7 +295,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleStrokeWidthLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeWidth(get("circle-stroke-width")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeWidth(0.3f);
@@ -308,7 +308,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleStrokeColorLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeColor(get("circle-stroke-color")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeColor("rgba(0, 0, 0, 1)");
@@ -321,7 +321,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleStrokeOpacityLayerProperty() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeOpacity(get("circle-stroke-opacity")))));
 
     CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeOpacity(0.3f);
@@ -334,7 +334,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCircleLayerFilter() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(circleLayer, times(0)).setFilter(expression);
 
@@ -349,7 +349,7 @@ public class CircleManagerTest {
   @Test
   public void testClickListener() {
     OnCircleClickListener listener = mock(OnCircleClickListener.class);
-    circleManager = new  CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new  CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(circleManager.getClickListeners().isEmpty());
     circleManager.addClickListener(listener);
     assertTrue(circleManager.getClickListeners().contains(listener));
@@ -360,7 +360,7 @@ public class CircleManagerTest {
   @Test
   public void testLongClickListener() {
     OnCircleLongClickListener listener = mock(OnCircleLongClickListener.class);
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(circleManager.getLongClickListeners().isEmpty());
     circleManager.addLongClickListener(listener);
     assertTrue(circleManager.getLongClickListeners().contains(listener));
@@ -371,7 +371,7 @@ public class CircleManagerTest {
   @Test
   public void testDragListener() {
     OnCircleDragListener listener = mock(OnCircleDragListener.class);
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(circleManager.getDragListeners().isEmpty());
     circleManager.addDragListener(listener);
     assertTrue(circleManager.getDragListeners().contains(listener));
@@ -381,7 +381,7 @@ public class CircleManagerTest {
 
   @Test
   public void testCustomData() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     CircleOptions options = new CircleOptions().withLatLng(new LatLng());
     options.withData(new JsonPrimitive("hello"));
     Circle circle = circleManager.create(options);
@@ -390,7 +390,7 @@ public class CircleManagerTest {
 
   @Test
   public void testClearAll() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     CircleOptions options = new CircleOptions().withLatLng(new LatLng());
     circleManager.create(options);
     assertEquals(1, circleManager.getAnnotations().size());
@@ -400,7 +400,7 @@ public class CircleManagerTest {
 
   @Test
   public void testIgnoreClearedAnnotations() {
-    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     CircleOptions options = new CircleOptions().withLatLng(new LatLng());
      Circle  circle = circleManager.create(options);
     assertEquals(1, circleManager.annotations.size());

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -53,7 +53,7 @@ public class FillManagerTest {
 
   @Test
   public void testInitialization() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(fillLayer);
     assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -68,7 +68,7 @@ public class FillManagerTest {
 
   @Test
   public void testInitializationOnStyleReload() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(fillLayer);
     assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -111,7 +111,7 @@ public class FillManagerTest {
 
   @Test
   public void testLayerBelowInitialization() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayerBelow(fillLayer, "test_layer");
     assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class FillManagerTest {
 
   @Test
   public void testGeoJsonOptionsInitialization() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController, null);
     verify(style).addSource(optionedGeoJsonSource);
     verify(style).addLayer(fillLayer);
     assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -140,7 +140,7 @@ public class FillManagerTest {
 
   @Test
   public void testNoUpdateOnStyleReload() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
 
     when(style.isFullyLoaded()).thenReturn(false);
@@ -150,7 +150,7 @@ public class FillManagerTest {
 
   @Test
   public void testAddFill() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -164,7 +164,7 @@ public class FillManagerTest {
 
   @Test
   public void addFillFromFeatureCollection() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<Point> innerPoints = new ArrayList<>();
     innerPoints.add(Point.fromLngLat(0, 0));
     innerPoints.add(Point.fromLngLat(1, 1));
@@ -194,7 +194,7 @@ public class FillManagerTest {
 
   @Test
   public void addFills() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     final List<List<LatLng>> latLngListOne = new ArrayList<>();
     latLngListOne.add(new ArrayList<LatLng>() {{
       add(new LatLng(2, 2));
@@ -230,7 +230,7 @@ public class FillManagerTest {
 
   @Test
   public void testDeleteFill() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -244,7 +244,7 @@ public class FillManagerTest {
 
   @Test
   public void testGeometryFill() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -273,7 +273,7 @@ public class FillManagerTest {
 
   @Test
   public void testFeatureIdFill() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -288,7 +288,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillDraggableFlag() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -307,7 +307,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillOpacityLayerProperty() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOpacity(get("fill-opacity")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -326,7 +326,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillColorLayerProperty() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillColor(get("fill-color")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -345,7 +345,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillOutlineColorLayerProperty() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOutlineColor(get("fill-outline-color")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -364,7 +364,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillPatternLayerProperty() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillPattern(get("fill-pattern")))));
 
     List<LatLng>innerLatLngs = new ArrayList<>();
@@ -383,7 +383,7 @@ public class FillManagerTest {
 
   @Test
   public void testFillLayerFilter() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(fillLayer, times(0)).setFilter(expression);
 
@@ -398,7 +398,7 @@ public class FillManagerTest {
   @Test
   public void testClickListener() {
     OnFillClickListener listener = mock(OnFillClickListener.class);
-    fillManager = new  FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new  FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(fillManager.getClickListeners().isEmpty());
     fillManager.addClickListener(listener);
     assertTrue(fillManager.getClickListeners().contains(listener));
@@ -409,7 +409,7 @@ public class FillManagerTest {
   @Test
   public void testLongClickListener() {
     OnFillLongClickListener listener = mock(OnFillLongClickListener.class);
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(fillManager.getLongClickListeners().isEmpty());
     fillManager.addLongClickListener(listener);
     assertTrue(fillManager.getLongClickListeners().contains(listener));
@@ -420,7 +420,7 @@ public class FillManagerTest {
   @Test
   public void testDragListener() {
     OnFillDragListener listener = mock(OnFillDragListener.class);
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(fillManager.getDragListeners().isEmpty());
     fillManager.addDragListener(listener);
     assertTrue(fillManager.getDragListeners().contains(listener));
@@ -430,7 +430,7 @@ public class FillManagerTest {
 
   @Test
   public void testCustomData() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -445,7 +445,7 @@ public class FillManagerTest {
 
   @Test
   public void testClearAll() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));
@@ -461,7 +461,7 @@ public class FillManagerTest {
 
   @Test
   public void testIgnoreClearedAnnotations() {
-    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>innerLatLngs = new ArrayList<>();
     innerLatLngs.add(new LatLng());
     innerLatLngs.add(new LatLng(1,1));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -53,7 +53,7 @@ public class LineManagerTest {
 
   @Test
   public void testInitialization() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(lineLayer);
     assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -68,7 +68,7 @@ public class LineManagerTest {
 
   @Test
   public void testInitializationOnStyleReload() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(lineLayer);
     assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -111,7 +111,7 @@ public class LineManagerTest {
 
   @Test
   public void testLayerBelowInitialization() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayerBelow(lineLayer, "test_layer");
     assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class LineManagerTest {
 
   @Test
   public void testGeoJsonOptionsInitialization() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController, null);
     verify(style).addSource(optionedGeoJsonSource);
     verify(style).addLayer(lineLayer);
     assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -140,7 +140,7 @@ public class LineManagerTest {
 
   @Test
   public void testNoUpdateOnStyleReload() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
 
     when(style.isFullyLoaded()).thenReturn(false);
@@ -150,7 +150,7 @@ public class LineManagerTest {
 
   @Test
   public void testAddLine() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -160,7 +160,7 @@ public class LineManagerTest {
 
   @Test
   public void addLineFromFeatureCollection() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<Point> points = new ArrayList<>();
     points.add(Point.fromLngLat(0, 0));
     points.add(Point.fromLngLat(1, 1));
@@ -194,7 +194,7 @@ public class LineManagerTest {
 
   @Test
   public void addLines() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<List<LatLng>> latLngList = new ArrayList<>();
     latLngList.add(new ArrayList<LatLng>() {{
       add(new LatLng(2, 2));
@@ -215,7 +215,7 @@ public class LineManagerTest {
 
   @Test
   public void testDeleteLine() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -226,7 +226,7 @@ public class LineManagerTest {
 
   @Test
   public void testGeometryLine() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -246,7 +246,7 @@ public class LineManagerTest {
 
   @Test
   public void testFeatureIdLine() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -258,7 +258,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineDraggableFlag() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -274,7 +274,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineJoinLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineJoin(get("line-join")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -290,7 +290,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineOpacityLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOpacity(get("line-opacity")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -306,7 +306,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineColorLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineColor(get("line-color")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -322,7 +322,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineWidthLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineWidth(get("line-width")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -338,7 +338,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineGapWidthLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineGapWidth(get("line-gap-width")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -354,7 +354,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineOffsetLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOffset(get("line-offset")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -370,7 +370,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineBlurLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineBlur(get("line-blur")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -386,7 +386,7 @@ public class LineManagerTest {
 
   @Test
   public void testLinePatternLayerProperty() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(linePattern(get("line-pattern")))));
 
     List<LatLng>latLngs = new ArrayList<>();
@@ -402,7 +402,7 @@ public class LineManagerTest {
 
   @Test
   public void testLineLayerFilter() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(lineLayer, times(0)).setFilter(expression);
 
@@ -417,7 +417,7 @@ public class LineManagerTest {
   @Test
   public void testClickListener() {
     OnLineClickListener listener = mock(OnLineClickListener.class);
-    lineManager = new  LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new  LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(lineManager.getClickListeners().isEmpty());
     lineManager.addClickListener(listener);
     assertTrue(lineManager.getClickListeners().contains(listener));
@@ -428,7 +428,7 @@ public class LineManagerTest {
   @Test
   public void testLongClickListener() {
     OnLineLongClickListener listener = mock(OnLineLongClickListener.class);
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(lineManager.getLongClickListeners().isEmpty());
     lineManager.addLongClickListener(listener);
     assertTrue(lineManager.getLongClickListeners().contains(listener));
@@ -439,7 +439,7 @@ public class LineManagerTest {
   @Test
   public void testDragListener() {
     OnLineDragListener listener = mock(OnLineDragListener.class);
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(lineManager.getDragListeners().isEmpty());
     lineManager.addDragListener(listener);
     assertTrue(lineManager.getDragListeners().contains(listener));
@@ -449,7 +449,7 @@ public class LineManagerTest {
 
   @Test
   public void testCustomData() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -461,7 +461,7 @@ public class LineManagerTest {
 
   @Test
   public void testClearAll() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));
@@ -474,7 +474,7 @@ public class LineManagerTest {
 
   @Test
   public void testIgnoreClearedAnnotations() {
-    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng>latLngs = new ArrayList<>();
     latLngs.add(new LatLng());
     latLngs.add(new LatLng(1,1));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -53,7 +53,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testInitialization() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(symbolLayer);
     assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -68,7 +68,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testInitializationOnStyleReload() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayer(symbolLayer);
     assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -111,7 +111,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testLayerBelowInitialization() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(style).addSource(geoJsonSource);
     verify(style).addLayerBelow(symbolLayer, "test_layer");
     assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testGeoJsonOptionsInitialization() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController, null);
     verify(style).addSource(optionedGeoJsonSource);
     verify(style).addLayer(symbolLayer);
     assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -140,7 +140,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testNoUpdateOnStyleReload() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController, null);
     verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
 
     when(style.isFullyLoaded()).thenReturn(false);
@@ -150,14 +150,14 @@ public class SymbolManagerTest {
 
   @Test
   public void testAddSymbol() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Symbol symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
     assertEquals(symbolManager.getAnnotations().get(0), symbol);
   }
 
   @Test
   public void addSymbolFromFeatureCollection() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Geometry geometry = Point.fromLngLat(10, 10);
 
     Feature feature = Feature.fromGeometry(geometry);
@@ -230,7 +230,7 @@ public class SymbolManagerTest {
 
   @Test
   public void addSymbols() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     List<LatLng> latLngList = new ArrayList<>();
     latLngList.add(new LatLng());
     latLngList.add(new LatLng(1, 1));
@@ -245,7 +245,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testDeleteSymbol() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Symbol symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
     symbolManager.delete(symbol);
     assertTrue(symbolManager.getAnnotations().size() == 0);
@@ -253,7 +253,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testGeometrySymbol() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     LatLng latLng = new LatLng(12, 34);
     SymbolOptions options = new SymbolOptions().withLatLng(latLng);
     Symbol symbol = symbolManager.create(options);
@@ -265,7 +265,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testFeatureIdSymbol() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Symbol symbolZero = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
     Symbol symbolOne = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
     assertEquals(symbolZero.getFeature().get(Symbol.ID_KEY).getAsLong(), 0);
@@ -274,7 +274,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testSymbolDraggableFlag() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Symbol symbolZero = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
 
     assertFalse(symbolZero.isDraggable());
@@ -287,7 +287,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testSymbolSortKeyLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(symbolSortKey(get("symbol-sort-key")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withSymbolSortKey(0.3f);
@@ -300,7 +300,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconSizeLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconSize(get("icon-size")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconSize(0.3f);
@@ -313,7 +313,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconImageLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconImage(get("icon-image")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconImage("undefined");
@@ -326,7 +326,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconRotateLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconRotate(get("icon-rotate")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconRotate(0.3f);
@@ -339,7 +339,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconOffsetLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconOffset(get("icon-offset")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOffset(new Float[] {0f, 0f});
@@ -352,7 +352,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconAnchorLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconAnchor(get("icon-anchor")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconAnchor(ICON_ANCHOR_CENTER);
@@ -365,7 +365,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextFieldLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textField(get("text-field")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextField("");
@@ -378,7 +378,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextFontLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textFont(get("text-font")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"});
@@ -391,7 +391,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextSizeLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textSize(get("text-size")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextSize(0.3f);
@@ -404,7 +404,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextMaxWidthLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textMaxWidth(get("text-max-width")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextMaxWidth(0.3f);
@@ -417,7 +417,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextLetterSpacingLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textLetterSpacing(get("text-letter-spacing")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextLetterSpacing(0.3f);
@@ -430,7 +430,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextJustifyLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textJustify(get("text-justify")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextJustify(TEXT_JUSTIFY_AUTO);
@@ -443,7 +443,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextRadialOffsetLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textRadialOffset(get("text-radial-offset")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRadialOffset(0.3f);
@@ -456,7 +456,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextAnchorLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textAnchor(get("text-anchor")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextAnchor(TEXT_ANCHOR_CENTER);
@@ -469,7 +469,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextRotateLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textRotate(get("text-rotate")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRotate(0.3f);
@@ -482,7 +482,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextTransformLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textTransform(get("text-transform")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextTransform(TEXT_TRANSFORM_NONE);
@@ -495,7 +495,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextOffsetLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textOffset(get("text-offset")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOffset(new Float[] {0f, 0f});
@@ -508,7 +508,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconOpacityLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconOpacity(get("icon-opacity")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOpacity(0.3f);
@@ -521,7 +521,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconColorLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconColor(get("icon-color")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconColor("rgba(0, 0, 0, 1)");
@@ -534,7 +534,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconHaloColorLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloColor(get("icon-halo-color")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloColor("rgba(0, 0, 0, 1)");
@@ -547,7 +547,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconHaloWidthLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloWidth(get("icon-halo-width")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloWidth(0.3f);
@@ -560,7 +560,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIconHaloBlurLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloBlur(get("icon-halo-blur")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloBlur(0.3f);
@@ -573,7 +573,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextOpacityLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textOpacity(get("text-opacity")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOpacity(0.3f);
@@ -586,7 +586,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextColorLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textColor(get("text-color")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextColor("rgba(0, 0, 0, 1)");
@@ -599,7 +599,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextHaloColorLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloColor(get("text-halo-color")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloColor("rgba(0, 0, 0, 1)");
@@ -612,7 +612,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextHaloWidthLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloWidth(get("text-halo-width")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloWidth(0.3f);
@@ -625,7 +625,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testTextHaloBlurLayerProperty() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloBlur(get("text-halo-blur")))));
 
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloBlur(0.3f);
@@ -638,7 +638,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testSymbolLayerFilter() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     Expression expression = Expression.eq(Expression.get("test"), "selected");
     verify(symbolLayer, times(0)).setFilter(expression);
 
@@ -653,7 +653,7 @@ public class SymbolManagerTest {
   @Test
   public void testClickListener() {
     OnSymbolClickListener listener = mock(OnSymbolClickListener.class);
-    symbolManager = new  SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new  SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(symbolManager.getClickListeners().isEmpty());
     symbolManager.addClickListener(listener);
     assertTrue(symbolManager.getClickListeners().contains(listener));
@@ -664,7 +664,7 @@ public class SymbolManagerTest {
   @Test
   public void testLongClickListener() {
     OnSymbolLongClickListener listener = mock(OnSymbolLongClickListener.class);
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(symbolManager.getLongClickListeners().isEmpty());
     symbolManager.addLongClickListener(listener);
     assertTrue(symbolManager.getLongClickListeners().contains(listener));
@@ -675,7 +675,7 @@ public class SymbolManagerTest {
   @Test
   public void testDragListener() {
     OnSymbolDragListener listener = mock(OnSymbolDragListener.class);
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     assertTrue(symbolManager.getDragListeners().isEmpty());
     symbolManager.addDragListener(listener);
     assertTrue(symbolManager.getDragListeners().contains(listener));
@@ -685,7 +685,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testCustomData() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
     options.withData(new JsonPrimitive("hello"));
     Symbol symbol = symbolManager.create(options);
@@ -694,7 +694,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testClearAll() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
     symbolManager.create(options);
     assertEquals(1, symbolManager.getAnnotations().size());
@@ -704,7 +704,7 @@ public class SymbolManagerTest {
 
   @Test
   public void testIgnoreClearedAnnotations() {
-    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController, null);
     SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
      Symbol  symbol = symbolManager.create(options);
     assertEquals(1, symbolManager.annotations.size());


### PR DESCRIPTION
This PR is a proposal to automate loading of icon-image property of symbols. If core misses an style image, it will emit the image missing event. The symbol manager will pick this up and will attempt to load a drawable from resources with this id. This way users [don't need to call addImage](https://github.com/mapbox/mapbox-plugins-android/compare/tvn-load-icons?expand=1#diff-34b94cbd412d63114950931bdb2c79bcL75) themselves, they can just pass in the id of the drawable resource as a String (see [here](https://github.com/mapbox/mapbox-plugins-android/compare/tvn-load-icons?expand=1#diff-34b94cbd412d63114950931bdb2c79bcR94)).

Closes #742 

@mapbox/maps-android 