### PR TITLE
Adding Kotlin lint check plugin and cleanup tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ MBGL_ANDROID_PLUGINS += places;plugin-places
 MBGL_ANDROID_PLUGINS += localization;plugin-localization
 
 checkstyle:
-	./gradlew checkstyle
+	./gradlew checkstyle && ./gradlew lintKotlin
+
+kotlin-lint:
+	./gradlew lintKotlin
 
 test:
 	./gradlew test --info

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: "org.jmailen.kotlinter"
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,10 @@ android {
     abortOnError false
   }
 
+  kotlinter {
+    indentSize = 2
+  }
+
   dexOptions {
     maxProcessCount 8
     javaMaxHeapSize "2g"

--- a/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
+++ b/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
@@ -7,47 +7,47 @@ import com.mapbox.mapboxsdk.plugins.testapp.R
 
 class TestActivity : AppCompatActivity() {
 
-  lateinit var mapView: MapView
+    lateinit var mapView: MapView
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_test)
-    this.mapView = findViewById(R.id.mapView)
-    mapView.onCreate(savedInstanceState)
-  }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_test)
+        this.mapView = findViewById(R.id.mapView)
+        mapView.onCreate(savedInstanceState)
+    }
 
-  override fun onStart() {
-    super.onStart()
-    mapView.onStart()
-  }
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
 
-  override fun onResume() {
-    super.onResume()
-    mapView.onResume()
-  }
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
 
-  override fun onPause() {
-    super.onPause()
-    mapView.onPause()
-  }
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
 
-  override fun onStop() {
-    super.onStop()
-    mapView.onStop()
-  }
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
 
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    mapView.onSaveInstanceState(outState)
-  }
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
 
-  override fun onDestroy() {
-    super.onDestroy()
-    mapView.onDestroy()
-  }
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.onDestroy()
+    }
 
-  override fun onLowMemory() {
-    super.onLowMemory()
-    mapView.onLowMemory()
-  }
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
 }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/Utils.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/Utils.kt
@@ -12,64 +12,63 @@ import java.io.Reader
 import java.nio.charset.Charset
 import java.util.*
 
-
 /**
  * Useful utilities used throughout the testapp.
  */
 object Utils {
 
-  private val STYLES = arrayOf(Style.MAPBOX_STREETS, Style.OUTDOORS, Style.LIGHT, Style.DARK, Style.SATELLITE_STREETS)
+    private val STYLES = arrayOf(Style.MAPBOX_STREETS, Style.OUTDOORS, Style.LIGHT, Style.DARK, Style.SATELLITE_STREETS)
 
-  private var index: Int = 0
+    private var index: Int = 0
 
-  /**
-   * Utility to cycle through map styles. Useful to test if runtime styling source and layers transfer over to new
-   * style.
-   *
-   * @return a string ID representing the map style
-   */
-  val nextStyle: String
-    get() {
-      index++
-      if (index == STYLES.size) {
-        index = 0
-      }
-      return STYLES[index]
+    /**
+     * Utility to cycle through map styles. Useful to test if runtime styling source and layers transfer over to new
+     * style.
+     *
+     * @return a string ID representing the map style
+     */
+    val nextStyle: String
+        get() {
+            index++
+            if (index == STYLES.size) {
+                index = 0
+            }
+            return STYLES[index]
+        }
+
+    /**
+     * Utility for getting a random coordinate inside a provided bounding box and creates a [Location] from it.
+     *
+     * @param bbox double array forming the bounding box in the order of `[minx, miny, maxx, maxy]`
+     * @return a [Location] object using the random coordinate
+     */
+    fun getRandomLocation(bbox: DoubleArray): Location {
+        val random = Random()
+        val randomLat = bbox[1] + (bbox[3] - bbox[1]) * random.nextDouble()
+        val randomLon = bbox[0] + (bbox[2] - bbox[0]) * random.nextDouble()
+        val location = Location("random-loc")
+        location.longitude = randomLon
+        location.latitude = randomLat
+        Timber.d("getRandomLatLng: %s", location.toString())
+        return location
     }
 
-  /**
-   * Utility for getting a random coordinate inside a provided bounding box and creates a [Location] from it.
-   *
-   * @param bbox double array forming the bounding box in the order of `[minx, miny, maxx, maxy]`
-   * @return a [Location] object using the random coordinate
-   */
-  fun getRandomLocation(bbox: DoubleArray): Location {
-    val random = Random()
-    val randomLat = bbox[1] + (bbox[3] - bbox[1]) * random.nextDouble()
-    val randomLon = bbox[0] + (bbox[2] - bbox[0]) * random.nextDouble()
-    val location = Location("random-loc")
-    location.longitude = randomLon
-    location.latitude = randomLat
-    Timber.d("getRandomLatLng: %s", location.toString())
-    return location
-  }
-
-  @Throws(IOException::class)
-  fun loadStringFromAssets(context: Context, fileName: String): String {
-    if (TextUtils.isEmpty(fileName)) {
-      throw NullPointerException("No GeoJSON File Name passed in.")
+    @Throws(IOException::class)
+    fun loadStringFromAssets(context: Context, fileName: String): String {
+        if (TextUtils.isEmpty(fileName)) {
+            throw NullPointerException("No GeoJSON File Name passed in.")
+        }
+        val `is` = context.assets.open(fileName)
+        val rd = BufferedReader(InputStreamReader(`is`, Charset.forName("UTF-8")))
+        return readAll(rd)
     }
-    val `is` = context.assets.open(fileName)
-    val rd = BufferedReader(InputStreamReader(`is`, Charset.forName("UTF-8")))
-    return readAll(rd)
-  }
 
-  @Throws(IOException::class)
-  private fun readAll(rd: Reader): String {
-    val sb = StringBuilder()
-    rd.forEachLine {
-      sb.append(it)
+    @Throws(IOException::class)
+    private fun readAll(rd: Reader): String {
+        val sb = StringBuilder()
+        rd.forEachLine {
+            sb.append(it)
+        }
+        return sb.toString()
     }
-    return sb.toString()
-  }
 }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/building/BuildingActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/building/BuildingActivity.kt
@@ -43,7 +43,7 @@ class BuildingActivity : AppCompatActivity(), OnMapReadyCallback {
 
     override fun onMapReady(mapboxMap: MapboxMap) {
         this.mapboxMap = mapboxMap
-        mapboxMap.setStyle(Style.MAPBOX_STREETS){
+        mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             buildingPlugin = BuildingPlugin(mapView, mapboxMap, it)
             buildingPlugin?.setMinZoomLevel(15f)
             fabBuilding.visibility = View.VISIBLE

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
@@ -26,7 +26,7 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnM
         this.mapboxMap = mapboxMap
         mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             mapboxMap.addOnMapClickListener(this)
-            Toast.makeText(this,"Click on the map", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "Click on the map", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
@@ -16,161 +16,163 @@ import kotlinx.android.synthetic.main.activity_localization.*
 
 class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
 
-  private var localizationPlugin: LocalizationPlugin? = null
-  private var mapboxMap: MapboxMap? = null
-  private var mapIsLocalized: Boolean = false
+    private var localizationPlugin: LocalizationPlugin? = null
+    private var mapboxMap: MapboxMap? = null
+    private var mapIsLocalized: Boolean = false
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_localization)
-    mapIsLocalized = true
-    Toast.makeText(this, R.string.change_language_instruction, Toast.LENGTH_LONG).show()
-    mapView.onCreate(savedInstanceState)
-    mapView.getMapAsync(this)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_localization)
+        mapIsLocalized = true
+        Toast.makeText(this, R.string.change_language_instruction, Toast.LENGTH_LONG).show()
+        mapView.onCreate(savedInstanceState)
+        mapView.getMapAsync(this)
 
-    fabLocalize.setOnClickListener {
-      mapIsLocalized = if (mapIsLocalized) {
-        localizationPlugin?.setMapLanguage(MapLocale(MapLocale.FRENCH))
-        Toast.makeText(this, R.string.map_not_localized, Toast.LENGTH_SHORT).show()
-        false
-      } else {
-        localizationPlugin?.matchMapLanguageWithDeviceDefault()
-        Toast.makeText(this, R.string.map_localized, Toast.LENGTH_SHORT).show()
-        true
-      }
-    }
-
-    fabCamera.setOnClickListener {
-      val locale = nextMapLocale
-      localizationPlugin?.setMapLanguage(locale)
-      localizationPlugin?.setCameraToLocaleCountry(locale, 25)
-    }
-
-    fabStyles.setOnClickListener {
-      mapboxMap?.setStyle(Style.Builder().fromUri(Utils.nextStyle))
-    }
-  }
-
-  override fun onMapReady(mapboxMap: MapboxMap) {
-    this.mapboxMap = mapboxMap
-    mapboxMap.setStyle(Style.MAPBOX_STREETS) {
-      localizationPlugin = LocalizationPlugin(mapView, mapboxMap, it)
-      localizationPlugin?.matchMapLanguageWithDeviceDefault()
-    }
-  }
-
-  override fun onStart() {
-    super.onStart()
-    mapView.onStart()
-  }
-
-  override fun onResume() {
-    super.onResume()
-    mapView.onResume()
-  }
-
-  override fun onPause() {
-    super.onPause()
-    mapView.onPause()
-  }
-
-  override fun onStop() {
-    super.onStop()
-    mapView.onStop()
-  }
-
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    mapView.onSaveInstanceState(outState)
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    mapView.onDestroy()
-  }
-
-  override fun onLowMemory() {
-    super.onLowMemory()
-    mapView.onLowMemory()
-  }
-
-  override fun onCreateOptionsMenu(menu: Menu): Boolean {
-    menuInflater.inflate(R.menu.menu_languages, menu)
-    return true
-  }
-
-  override fun onOptionsItemSelected(item: MenuItem): Boolean {
-    when (item.itemId) {
-      R.id.english -> {
-        localizationPlugin?.setMapLanguage(MapLocale.ENGLISH)
-        return true
-      }
-      R.id.spanish -> {
-        localizationPlugin?.setMapLanguage(MapLocale.SPANISH)
-        return true
-      }
-      R.id.french -> {
-        localizationPlugin?.setMapLanguage(MapLocale.FRENCH)
-        return true
-      }
-      R.id.german -> {
-        localizationPlugin?.setMapLanguage(MapLocale.GERMAN)
-        return true
-      }
-      R.id.russian -> {
-        localizationPlugin?.setMapLanguage(MapLocale.RUSSIAN)
-        return true
-      }
-      R.id.chinese -> {
-        localizationPlugin?.setMapLanguage(MapLocale.CHINESE)
-        return true
-      }
-      R.id.simplified_chinese -> {
-        localizationPlugin?.setMapLanguage(MapLocale.SIMPLIFIED_CHINESE)
-        return true
-      }
-      R.id.portuguese -> {
-        localizationPlugin?.setMapLanguage(MapLocale.PORTUGUESE)
-        return true
-      }
-      R.id.arabic -> {
-        localizationPlugin?.setMapLanguage(MapLocale.ARABIC)
-        return true
-      }
-      R.id.japanese -> {
-        localizationPlugin?.setMapLanguage(MapLocale.JAPANESE)
-        return true
-      }
-      R.id.korean -> {
-        localizationPlugin?.setMapLanguage(MapLocale.KOREAN)
-        return true
-      }
-      R.id.local -> {
-        localizationPlugin?.setMapLanguage(MapLocale.LOCAL_NAME)
-        return true
-      }
-      android.R.id.home -> {
-        finish()
-        return true
-      }
-    }
-    return super.onOptionsItemSelected(item)
-  }
-
-  companion object {
-
-    private val LOCALES = arrayOf(MapLocale.CANADA, MapLocale.GERMANY, MapLocale.CHINA, MapLocale.US, MapLocale.CANADA_FRENCH, MapLocale.JAPAN, MapLocale.KOREA, MapLocale.FRANCE, MapLocale.SPAIN)
-
-    private var index: Int = 0
-
-    val nextMapLocale: MapLocale
-      get() {
-        index++
-        if (index == LOCALES.size) {
-          index = 0
+        fabLocalize.setOnClickListener {
+            mapIsLocalized = if (mapIsLocalized) {
+                localizationPlugin?.setMapLanguage(MapLocale(MapLocale.FRENCH))
+                Toast.makeText(this, R.string.map_not_localized, Toast.LENGTH_SHORT).show()
+                false
+            } else {
+                localizationPlugin?.matchMapLanguageWithDeviceDefault()
+                Toast.makeText(this, R.string.map_localized, Toast.LENGTH_SHORT).show()
+                true
+            }
         }
-        return LOCALES[index]
-      }
-  }
-}
 
+        fabCamera.setOnClickListener {
+            val locale = nextMapLocale
+            localizationPlugin?.setMapLanguage(locale)
+            localizationPlugin?.setCameraToLocaleCountry(locale, 25)
+        }
+
+        fabStyles.setOnClickListener {
+            mapboxMap?.setStyle(Style.Builder().fromUrl(Utils.nextStyle))
+        }
+    }
+
+    override fun onMapReady(mapboxMap: MapboxMap) {
+        this.mapboxMap = mapboxMap
+        mapboxMap.setStyle(Style.MAPBOX_STREETS) {
+            localizationPlugin = LocalizationPlugin(mapView, mapboxMap, it)
+            localizationPlugin?.matchMapLanguageWithDeviceDefault()
+            fabStyles.setOnClickListener {
+                mapboxMap?.setStyle(Style.Builder().fromUri(Utils.nextStyle))
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_languages, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.english -> {
+                localizationPlugin?.setMapLanguage(MapLocale.ENGLISH)
+                return true
+            }
+            R.id.spanish -> {
+                localizationPlugin?.setMapLanguage(MapLocale.SPANISH)
+                return true
+            }
+            R.id.french -> {
+                localizationPlugin?.setMapLanguage(MapLocale.FRENCH)
+                return true
+            }
+            R.id.german -> {
+                localizationPlugin?.setMapLanguage(MapLocale.GERMAN)
+                return true
+            }
+            R.id.russian -> {
+                localizationPlugin?.setMapLanguage(MapLocale.RUSSIAN)
+                return true
+            }
+            R.id.chinese -> {
+                localizationPlugin?.setMapLanguage(MapLocale.CHINESE)
+                return true
+            }
+            R.id.simplified_chinese -> {
+                localizationPlugin?.setMapLanguage(MapLocale.SIMPLIFIED_CHINESE)
+                return true
+            }
+            R.id.portuguese -> {
+                localizationPlugin?.setMapLanguage(MapLocale.PORTUGUESE)
+                return true
+            }
+            R.id.arabic -> {
+                localizationPlugin?.setMapLanguage(MapLocale.ARABIC)
+                return true
+            }
+            R.id.japanese -> {
+                localizationPlugin?.setMapLanguage(MapLocale.JAPANESE)
+                return true
+            }
+            R.id.korean -> {
+                localizationPlugin?.setMapLanguage(MapLocale.KOREAN)
+                return true
+            }
+            R.id.local -> {
+                localizationPlugin?.setMapLanguage(MapLocale.LOCAL_NAME)
+                return true
+            }
+            android.R.id.home -> {
+                finish()
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+
+        private val LOCALES = arrayOf(MapLocale.CANADA, MapLocale.GERMANY, MapLocale.CHINA, MapLocale.US, MapLocale.CANADA_FRENCH, MapLocale.JAPAN, MapLocale.KOREA, MapLocale.FRANCE, MapLocale.SPAIN)
+
+        private var index: Int = 0
+
+        val nextMapLocale: MapLocale
+            get() {
+                index++
+                if (index == LOCALES.size) {
+                    index = 0
+                }
+                return LOCALES[index]
+            }
+    }
+}

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
@@ -150,10 +150,10 @@ class OfflineDownloadActivity : AppCompatActivity() {
     }
 
     private fun validCoordinates(
-        latitudeNorth: Double,
-        longitudeEast: Double,
-        latitudeSouth: Double,
-        longitudeWest: Double
+      latitudeNorth: Double,
+      longitudeEast: Double,
+      latitudeSouth: Double,
+      longitudeWest: Double
     ): Boolean {
 
         if (latitudeNorth < -90 || latitudeNorth > 90) {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
@@ -5,21 +5,18 @@ import android.support.v7.app.AppCompatActivity
 import android.widget.ArrayAdapter
 import android.widget.SeekBar
 import android.widget.Toast
-
 import com.mapbox.mapboxsdk.constants.MapboxConstants
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition
-import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions
+import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin
 import com.mapbox.mapboxsdk.plugins.offline.utils.OfflineUtils
 import com.mapbox.mapboxsdk.plugins.testapp.R
-
-import java.util.ArrayList
-
 import kotlinx.android.synthetic.main.activity_offline_download.*
+import java.util.*
 
 /**
  * Activity showing a form to configure the download of an offline region.
@@ -85,11 +82,11 @@ class OfflineDownloadActivity : AppCompatActivity() {
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) {
-
+                // Empty on purpose
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
-
+                // Empty on purpose
             }
         })
 
@@ -99,11 +96,11 @@ class OfflineDownloadActivity : AppCompatActivity() {
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) {
-
+                // Empty on purpose
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
-
+                // Empty on purpose
             }
         })
     }
@@ -152,8 +149,13 @@ class OfflineDownloadActivity : AppCompatActivity() {
         )
     }
 
-    private fun validCoordinates(latitudeNorth: Double, longitudeEast: Double, latitudeSouth: Double,
-                                 longitudeWest: Double): Boolean {
+    private fun validCoordinates(
+        latitudeNorth: Double,
+        longitudeEast: Double,
+        latitudeSouth: Double,
+        longitudeWest: Double
+    ): Boolean {
+
         if (latitudeNorth < -90 || latitudeNorth > 90) {
             return false
         } else if (longitudeEast < -180 || longitudeEast > 180) {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
-
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.plugins.offline.OfflineRegionSelector
@@ -13,17 +12,17 @@ import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions
 import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin
 import com.mapbox.mapboxsdk.plugins.testapp.R
-
-import java.util.Locale
-
 import kotlinx.android.synthetic.main.activity_offline_ui_components.*
+import java.util.*
 
 class OfflineUiComponentsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_offline_ui_components)
-        fabRegionSelector.setOnClickListener{onOfflineRegionSelectorButtonClicked()}
+        fabRegionSelector.setOnClickListener {
+            onOfflineRegionSelectorButtonClicked()
+        }
     }
 
     fun onOfflineRegionSelectorButtonClicked() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.widget.Switch
 import android.widget.Toast
 
 import com.mapbox.mapboxsdk.Mapbox

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -44,7 +44,6 @@ class ScalebarActivity : AppCompatActivity() {
         }
     }
 
-
     override fun onStart() {
         super.onStart()
         mapView.onStart()

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,13 @@ buildscript {
     google()
     jcenter()
     maven {   url "https://maven.google.com"   }
+    maven {url "https://plugins.gradle.org/m2/"}
   }
 
   dependencies {
     classpath pluginDependencies.gradle
     classpath pluginDependencies.kotlin
+    classpath pluginDependencies.kotlinLint
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,8 @@
       checkstyle: '8.10.1',
       gradle    : '3.4.0',
       kotlin    : '1.3.20',
-      dokka     : '0.9.17'
+      dokka     : '0.9.17',
+      kotlinLint: '1.26.0'
   ]
 
   dependenciesList = [
@@ -92,6 +93,7 @@
       gradle    : "com.android.tools.build:gradle:${pluginVersion.gradle}",
       checkstyle: "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
       kotlin    : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
-      dokka     : "org.jetbrains.dokka:dokka-android-gradle-plugin:${pluginVersion.dokka}"
+      dokka     : "org.jetbrains.dokka:dokka-android-gradle-plugin:${pluginVersion.dokka}",
+      kotlinLint: "org.jmailen.gradle:kotlinter-gradle:${pluginVersion.kotlinLint}"
   ]
 }


### PR DESCRIPTION
Inspired by @tobrun's addition of Kotlin lint checks in https://github.com/mapbox/mapbox-gl-native/pull/15052, this pr adds https://github.com/jeremymailen/kotlinter-gradle to create Kotlin lint checks of this repo's test app. Other than the Annotation Plugin activities, the rest of the test app's activities are written in Kotlin. This pr adds the plugin and also makes adjustments to various files so that the lint check passes 💯 . There's now a separate `make kotlin-lint` command _and_ the Kotlin lint check is added to the already existing `make checkstyle` command. 