### PR TITLE
Refactored `fromUrl` usage to `fromUri`

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
@@ -66,7 +66,7 @@ public class BulkSymbolActivity extends AppCompatActivity implements AdapterView
       )
     );
 
-    mapboxMap.setStyle(new Style.Builder().fromUrl(Style.MAPBOX_STREETS), style -> {
+    mapboxMap.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS), style -> {
       findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
       symbolManager = new SymbolManager(mapView, mapboxMap, style);
       symbolManager.setIconAllowOverlap(true);

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
@@ -59,7 +59,7 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
       ));
 
       mapboxMap.setStyle(new Style.Builder()
-          .fromUrl(Style.MAPBOX_STREETS)
+          .fromUri(Style.MAPBOX_STREETS)
           .withImage(ID_ICON_1, generateBitmap(R.drawable.mapbox_ic_place), true)
           .withImage(ID_ICON_2, generateBitmap(R.drawable.mapbox_ic_offline), true)
         , style -> {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
@@ -77,7 +77,7 @@ public class FillChangeActivity extends AppCompatActivity implements OnMapReadyC
 
   @Override
   public void onMapReady(@NonNull MapboxMap map) {
-    map.setStyle(new Style.Builder().fromUrl(Style.MAPBOX_STREETS), style -> {
+    map.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS), style -> {
       fillManager = new FillManager(mapView, map, style, "aerialway");
       fillManager.addClickListener(fill -> Toast.makeText(
         FillChangeActivity.this,

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
@@ -67,7 +67,7 @@ public class LineChangeActivity extends AppCompatActivity {
           4)
       );
 
-      mapboxMap.setStyle(new Style.Builder().fromUrl(Style.MAPBOX_STREETS), style -> {
+      mapboxMap.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS), style -> {
         findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
         lineManager = new LineManager(mapView, mapboxMap, style);

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
@@ -75,7 +75,7 @@ public class PressForSymbolActivity extends AppCompatActivity {
   }
 
   private Style.Builder getStyleBuilder(@NonNull String styleUrl) {
-    return new Style.Builder().fromUrl(styleUrl)
+    return new Style.Builder().fromUri(styleUrl)
       .withImage(ID_ICON, generateBitmap(R.drawable.mapbox_ic_place));
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
@@ -47,7 +47,7 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     fabStyles.setOnClickListener {
-      mapboxMap?.setStyle(Style.Builder().fromUrl(Utils.nextStyle))
+      mapboxMap?.setStyle(Style.Builder().fromUri(Utils.nextStyle))
     }
   }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/traffic/TrafficActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/traffic/TrafficActivity.kt
@@ -35,7 +35,7 @@ class TrafficActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         fabStyles.setOnClickListener {
-            mapboxMap?.setStyle(Style.Builder().fromUrl(Utils.nextStyle))
+            mapboxMap?.setStyle(Style.Builder().fromUri(Utils.nextStyle))
         }
     }
 


### PR DESCRIPTION
`fromUrl()` was recently deprecated, so this pr refactors usage of `Style.Builder().fromUrl()` to `Style.Builder().fromUri()`

https://github.com/mapbox/mapbox-android-demo/pull/1120 is related