### PR TITLE
Adding Kotlin lint check plugin and cleanup tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+indent_size=2

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ MBGL_ANDROID_PLUGINS += places;plugin-places
 MBGL_ANDROID_PLUGINS += localization;plugin-localization
 
 checkstyle:
-	./gradlew checkstyle
+	./gradlew checkstyle && ./gradlew ktlintCheck
+
+kotlin-lint:
+	./gradlew ktlintCheck
 
 test:
 	./gradlew test --info

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/Utils.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/Utils.kt
@@ -12,7 +12,6 @@ import java.io.Reader
 import java.nio.charset.Charset
 import java.util.*
 
-
 /**
  * Useful utilities used throughout the testapp.
  */

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/building/BuildingActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/building/BuildingActivity.kt
@@ -43,7 +43,7 @@ class BuildingActivity : AppCompatActivity(), OnMapReadyCallback {
 
     override fun onMapReady(mapboxMap: MapboxMap) {
         this.mapboxMap = mapboxMap
-        mapboxMap.setStyle(Style.MAPBOX_STREETS){
+        mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             buildingPlugin = BuildingPlugin(mapView, mapboxMap, it)
             buildingPlugin?.setMinZoomLevel(15f)
             fabBuilding.visibility = View.VISIBLE

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
@@ -26,7 +26,7 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnM
         this.mapboxMap = mapboxMap
         mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             mapboxMap.addOnMapClickListener(this)
-            Toast.makeText(this,"Click on the map", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "Click on the map", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
@@ -173,4 +173,3 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
       }
   }
 }
-

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
@@ -85,11 +85,11 @@ class OfflineDownloadActivity : AppCompatActivity() {
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) {
-
+              // Empty on purpose
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
-
+              // Empty on purpose
             }
         })
 
@@ -99,11 +99,11 @@ class OfflineDownloadActivity : AppCompatActivity() {
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) {
-
+              // Empty on purpose
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
-
+              // Empty on purpose
             }
         })
     }
@@ -152,8 +152,12 @@ class OfflineDownloadActivity : AppCompatActivity() {
         )
     }
 
-    private fun validCoordinates(latitudeNorth: Double, longitudeEast: Double, latitudeSouth: Double,
-                                 longitudeWest: Double): Boolean {
+    private fun validCoordinates(
+      latitudeNorth: Double,
+      longitudeEast: Double,
+      latitudeSouth: Double,
+      longitudeWest: Double
+    ): Boolean {
         if (latitudeNorth < -90 || latitudeNorth > 90) {
             return false
         } else if (longitudeEast < -180 || longitudeEast > 180) {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
@@ -23,7 +23,9 @@ class OfflineUiComponentsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_offline_ui_components)
-        fabRegionSelector.setOnClickListener{onOfflineRegionSelectorButtonClicked()}
+        fabRegionSelector.setOnClickListener {
+          onOfflineRegionSelectorButtonClicked()
+        }
     }
 
     fun onOfflineRegionSelectorButtonClicked() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
@@ -4,16 +4,13 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.widget.Switch
 import android.widget.Toast
-
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.plugins.places.picker.PlacePicker
 import com.mapbox.mapboxsdk.plugins.places.picker.model.PlacePickerOptions
 import com.mapbox.mapboxsdk.plugins.testapp.R
-
 import kotlinx.android.synthetic.main.activity_picker_launcher.*
 
 class PickerLauncherActivity : AppCompatActivity() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -44,7 +44,6 @@ class ScalebarActivity : AppCompatActivity() {
         }
     }
 
-
     override fun onStart() {
         super.onStart()
         mapView.onStart()

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,13 @@ buildscript {
     google()
     jcenter()
     maven {   url "https://maven.google.com"   }
+    maven { url "https://plugins.gradle.org/m2/" }
   }
 
   dependencies {
     classpath pluginDependencies.gradle
     classpath pluginDependencies.kotlin
+    classpath pluginDependencies.kotlinLint
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,8 @@
       checkstyle: '8.10.1',
       gradle    : '3.4.0',
       kotlin    : '1.3.20',
-      dokka     : '0.9.17'
+      dokka     : '0.9.17',
+      kotlinLint: '8.1.0'
   ]
 
   dependenciesList = [
@@ -92,6 +93,7 @@
       gradle    : "com.android.tools.build:gradle:${pluginVersion.gradle}",
       checkstyle: "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
       kotlin    : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
-      dokka     : "org.jetbrains.dokka:dokka-android-gradle-plugin:${pluginVersion.dokka}"
+      dokka     : "org.jetbrains.dokka:dokka-android-gradle-plugin:${pluginVersion.dokka}",
+      kotlinLint: "org.jlleitschuh.gradle:ktlint-gradle:${pluginVersion.kotlinLint}"
   ]
 }


### PR DESCRIPTION
Inspired by @tobrun's addition of Kotlin lint checks in https://github.com/mapbox/mapbox-gl-native/pull/15052, this pr adds https://github.com/JLLeitschuh/ktlint-gradle to create Kotlin lint checks of this repo's test app. This pr is a follow up to initial work done in https://github.com/mapbox/mapbox-plugins-android/pull/1006. #1006 spun a bit out of control with trying various plugins and config, so this pr is a fresh restart. 

`.editorconfig` seems to be working because I'm not getting prompted to fix indentation like I was in https://github.com/mapbox/mapbox-plugins-android/pull/1006#discussion_r301440874.

Other than the Annotation Plugin activities, the rest of the test app's activities are written in Kotlin. This pr adds the plugin and also makes adjustments to various files so that the lint check passes 💯 . 

There's now a separate `make kotlin-lint` command _and_ the Kotlin lint check is added to the already existing `make checkstyle` command. 