### PR TITLE
Remove .0 from distance text in scale bar

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
@@ -43,7 +43,7 @@ public class ScaleBarWidget extends View {
   private ArrayList<Pair<Integer, Integer>> scaleTable;
   private String unit;
   private final RefreshHandler refreshHandler;
-  private DecimalFormat decimalFormat = new DecimalFormat("0.0");
+  private DecimalFormat decimalFormat = new DecimalFormat("0.#");
 
   ScaleBarWidget(@NonNull Context context) {
     super(context);


### PR DESCRIPTION
Currently the scale bar will show distance text as follows:
1500m-> 1.5km
3000m-> 3.0km
In this PR, it will change to:
1500m-> 1.5km
3000m-> 3km