### PR TITLE
Expand the max distance of scale bar.

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
@@ -41,6 +41,10 @@ class ScaleBarConstants {
       add(new Pair<>(500000, 2));
       add(new Pair<>(600000, 3));
       add(new Pair<>(800000, 2));
+      add(new Pair<>(1000000, 2));
+      add(new Pair<>(2000000, 2));
+      add(new Pair<>(3000000, 3));
+      add(new Pair<>(4000000, 2));
     }
   };
 
@@ -77,6 +81,11 @@ class ScaleBarConstants {
       add(new Pair<>(200 * FEET_PER_MILE, 2));
       add(new Pair<>(300 * FEET_PER_MILE, 3));
       add(new Pair<>(400 * FEET_PER_MILE, 2));
+      add(new Pair<>(600 * FEET_PER_MILE, 3));
+      add(new Pair<>(1000 * FEET_PER_MILE, 2));
+      add(new Pair<>(1500 * FEET_PER_MILE, 3));
+      add(new Pair<>(2000 * FEET_PER_MILE, 2));
+      add(new Pair<>(3000 * FEET_PER_MILE, 2));
     }
   };
 }

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
@@ -48,6 +48,9 @@ class ScaleBarConstants {
       add(new Pair<>(5000000, 2));
       add(new Pair<>(6000000, 3));
       add(new Pair<>(8000000, 2));
+      add(new Pair<>(10000000, 2));
+      add(new Pair<>(12000000, 2));
+      add(new Pair<>(15000000, 2));
     }
   };
 
@@ -93,6 +96,7 @@ class ScaleBarConstants {
       add(new Pair<>(5000 * FEET_PER_MILE, 2));
       add(new Pair<>(6000 * FEET_PER_MILE, 3));
       add(new Pair<>(8000 * FEET_PER_MILE, 2));
+      add(new Pair<>(10000 * FEET_PER_MILE, 2));
     }
   };
 }

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
@@ -45,6 +45,9 @@ class ScaleBarConstants {
       add(new Pair<>(2000000, 2));
       add(new Pair<>(3000000, 3));
       add(new Pair<>(4000000, 2));
+      add(new Pair<>(5000000, 2));
+      add(new Pair<>(6000000, 3));
+      add(new Pair<>(8000000, 2));
     }
   };
 
@@ -86,6 +89,10 @@ class ScaleBarConstants {
       add(new Pair<>(1500 * FEET_PER_MILE, 3));
       add(new Pair<>(2000 * FEET_PER_MILE, 2));
       add(new Pair<>(3000 * FEET_PER_MILE, 2));
+      add(new Pair<>(4000 * FEET_PER_MILE, 2));
+      add(new Pair<>(5000 * FEET_PER_MILE, 2));
+      add(new Pair<>(6000 * FEET_PER_MILE, 3));
+      add(new Pair<>(8000 * FEET_PER_MILE, 2));
     }
   };
 }


### PR DESCRIPTION
The max distance for scale bar is not large enough, so the distance text will overlap at zoom level 0. Expand the max distance to make scale bar display normally at zoom level 0.
![device-2019-08-06-152824](https://user-images.githubusercontent.com/8577318/62520833-f64b1e00-b860-11e9-8cd3-0cac9d07d823.png)
![device-2019-08-06-152807](https://user-images.githubusercontent.com/8577318/62520834-f6e3b480-b860-11e9-936e-553c5d277574.png)
CC: @chloekraw 

 