### PR TITLE
Refactor plugins state management in case of widget recreation

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,6 +16,7 @@
       supportLib         : '28.0.0',
       constraintLayout   : '1.1.2',
       mockito            : '2.23.4',
+      mockk              : '1.9.3',
       leakCanary         : '1.6.3',
       timber             : '4.7.1',
       testRunner         : '1.0.2',
@@ -80,6 +81,7 @@
       testArchCore           : "android.arch.core:core-testing:${version.androidArchCore}",
       mockitoCore            : "org.mockito:mockito-core:${version.mockito}",
       mockitoAndroid         : "org.mockito:mockito-android:${version.mockito}",
+      mockk                  : "io.mockk:mockk:${version.mockk}",
 
       // unit test
       junit                  : "junit:junit:${version.junit}",

--- a/plugin-scalebar/build.gradle
+++ b/plugin-scalebar/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
@@ -25,8 +26,9 @@ android {
 dependencies {
     implementation dependenciesList.mapboxMapSdk
     javadocDeps dependenciesList.mapboxMapSdk
+    testImplementation dependenciesList.kotlin
+    testImplementation dependenciesList.mockk
     testImplementation dependenciesList.junit
-    testImplementation dependenciesList.mockito
 }
 
 apply from: "${rootDir}/gradle/javadoc.gradle"

--- a/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
@@ -1,0 +1,105 @@
+package com.mapbox.pluginscalebar
+
+import android.view.View
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Projection
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class ScaleBarPluginTest {
+  @MockK
+  lateinit var mapView: MapView
+
+  @MockK
+  lateinit var projection: Projection
+
+  @MockK
+  lateinit var mapboxMap: MapboxMap
+
+  @MockK
+  lateinit var scaleBarOptions: ScaleBarOptions
+
+  @MockK
+  lateinit var scaleBarWidget: ScaleBarWidget
+
+  @Before
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    every { mapView.width } returns 1000
+    every { projection.getMetersPerPixelAtLatitude(CameraPosition.DEFAULT.target.latitude) } returns 100_000.0
+    every { mapboxMap.projection } returns projection
+    every { mapboxMap.cameraPosition } returns CameraPosition.DEFAULT
+    every { scaleBarOptions.build() } returns scaleBarWidget
+  }
+
+  @Test
+  fun sanity() {
+    assertNotNull(mapView)
+    assertNotNull(mapboxMap)
+    assertNotNull(scaleBarOptions)
+    assertNotNull(scaleBarWidget)
+  }
+
+  @Test
+  fun create_isEnabled() {
+    val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    scaleBarPlugin.create(scaleBarOptions)
+
+    assertTrue(scaleBarPlugin.isEnabled)
+    verify { scaleBarWidget.visibility = View.VISIBLE }
+    verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+  }
+
+  @Test
+  fun disable() {
+    val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    scaleBarPlugin.create(scaleBarOptions)
+    scaleBarPlugin.isEnabled = false
+
+    assertFalse(scaleBarPlugin.isEnabled)
+    verify { scaleBarWidget.visibility = View.GONE }
+    verify { mapboxMap.removeOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+  }
+
+  @Test
+  fun enable() {
+    val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    scaleBarPlugin.create(scaleBarOptions)
+    verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+    verify(exactly = 1) { scaleBarWidget.visibility = View.VISIBLE }
+    scaleBarPlugin.isEnabled = false
+    scaleBarPlugin.isEnabled = true
+
+    assertTrue(scaleBarPlugin.isEnabled)
+    verify(exactly = 2) { scaleBarWidget.visibility = View.VISIBLE }
+    verify(exactly = 2) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+  }
+
+  @Test
+  fun disable_enable_widgetIsNull() {
+    val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    scaleBarPlugin.isEnabled = false
+    scaleBarPlugin.isEnabled = true
+
+    verify(exactly = 0) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+  }
+
+  @Test
+  fun disableBeforeCreate_ignoreResults() {
+    val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    scaleBarPlugin.isEnabled = false
+    scaleBarPlugin.create(scaleBarOptions)
+
+    assertTrue(scaleBarPlugin.isEnabled)
+    verify { scaleBarWidget.visibility = View.VISIBLE }
+    verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+  }
+}


### PR DESCRIPTION
This PR refactors the state handling, hardens `setEnabled` calls to avoid null pointer exceptions and introduces scale bar unit tests.