### PR TITLE
Invalidate the widget when plugin is toggled

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
@@ -99,6 +99,7 @@ public class ScaleBarPlugin {
     scaleBarWidget.setVisibility(enabled ? View.VISIBLE : View.GONE);
     if (enabled) {
       addCameraListeners();
+      invalidateScaleBar();
     } else {
       removeCameraListeners();
     }

--- a/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
@@ -107,4 +107,17 @@ class ScaleBarPluginTest {
     verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
     verify(exactly = 1) { mapboxMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
   }
+
+  @Test
+  fun toggled_invalidateWidget() {
+    val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    scaleBarPlugin.create(scaleBarOptions)
+    verify(exactly = 1) { mapboxMap.cameraPosition }
+    verify(exactly = 1) { scaleBarWidget.setDistancePerPixel(100_000.0) }
+    scaleBarPlugin.isEnabled = false
+    scaleBarPlugin.isEnabled = true
+
+    verify(exactly = 2) { mapboxMap.cameraPosition }
+    verify(exactly = 2) { scaleBarWidget.setDistancePerPixel(100_000.0) }
+  }
 }


### PR DESCRIPTION
CPs https://github.com/mapbox/mapbox-plugins-android/pull/1034 and targets `master` because of a misclick.

Closes https://github.com/mapbox/mapbox-plugins-android/issues/1031.