### PR TITLE
Add option to config max width of scalebar.

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -255,14 +255,14 @@ public class ScaleBarTest extends BaseActivityTest {
     assertEquals(0.5f,scaleBarWidget.getRatio(), 0f);
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       ScaleBarOptions option = new ScaleBarOptions(activity);
-      option.setRatio(0.1f);
+      option.setMaxWidthRatio(0.1f);
       scaleBarWidget = scaleBarPlugin.create(option);
       assertNotNull(scaleBarWidget);
       assertEquals(0.1f, scaleBarWidget.getRatio(), 0f);
     });
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       ScaleBarOptions option = new ScaleBarOptions(activity);
-      option.setRatio(1.0f);
+      option.setMaxWidthRatio(1.0f);
       scaleBarWidget = scaleBarPlugin.create(option);
       assertNotNull(scaleBarWidget);
       assertEquals(1.0f, scaleBarWidget.getRatio(), 0f);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -20,6 +20,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
+import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.HALF;
+import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.QUARTER;
+import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.THIRD;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -245,6 +248,27 @@ public class ScaleBarTest extends BaseActivityTest {
       scaleBarWidget = scaleBarPlugin.create(option);
       assertNotNull(scaleBarWidget);
       assertFalse(scaleBarWidget.isMetricUnit());
+    });
+  }
+
+  @Test
+  public void testRatio() {
+    validateTestSetup();
+    setupScaleBar();
+    assertEquals(HALF,scaleBarWidget.getRatio());
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      ScaleBarOptions option = new ScaleBarOptions(activity);
+      option.setRatio(THIRD);
+      scaleBarWidget = scaleBarPlugin.create(option);
+      assertNotNull(scaleBarWidget);
+      assertEquals(THIRD, scaleBarWidget.getRatio());
+    });
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      ScaleBarOptions option = new ScaleBarOptions(activity);
+      option.setRatio(QUARTER);
+      scaleBarWidget = scaleBarPlugin.create(option);
+      assertNotNull(scaleBarWidget);
+      assertEquals(QUARTER, scaleBarWidget.getRatio());
     });
   }
 }

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -20,9 +20,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
-import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.HALF;
-import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.QUARTER;
-import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.THIRD;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -255,20 +252,20 @@ public class ScaleBarTest extends BaseActivityTest {
   public void testRatio() {
     validateTestSetup();
     setupScaleBar();
-    assertEquals(HALF,scaleBarWidget.getRatio());
+    assertEquals(0.5f,scaleBarWidget.getRatio(), 0f);
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       ScaleBarOptions option = new ScaleBarOptions(activity);
-      option.setRatio(THIRD);
+      option.setRatio(0.1f);
       scaleBarWidget = scaleBarPlugin.create(option);
       assertNotNull(scaleBarWidget);
-      assertEquals(THIRD, scaleBarWidget.getRatio());
+      assertEquals(0.1f, scaleBarWidget.getRatio(), 0f);
     });
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       ScaleBarOptions option = new ScaleBarOptions(activity);
-      option.setRatio(QUARTER);
+      option.setRatio(1.0f);
       scaleBarWidget = scaleBarPlugin.create(option);
       assertNotNull(scaleBarWidget);
-      assertEquals(QUARTER, scaleBarWidget.getRatio());
+      assertEquals(1.0f, scaleBarWidget.getRatio(), 0f);
     });
   }
 }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -46,6 +46,7 @@ class ScalebarActivity : AppCompatActivity() {
                 .setMarginTop(15f)
                 .setMarginLeft(16f)
                 .setTextBarMargin(15f)
+                .setRatio(ScaleBarOptions.ScaleBarRatio.QUARTER)
 
         scaleBarPlugin.create(scaleBarOptions)
         fabScaleWidget.setOnClickListener {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -46,7 +46,7 @@ class ScalebarActivity : AppCompatActivity() {
                 .setMarginTop(15f)
                 .setMarginLeft(16f)
                 .setTextBarMargin(15f)
-                .setRatio(ScaleBarOptions.ScaleBarRatio.QUARTER)
+                .setRatio(0.5f)
 
         scaleBarPlugin.create(scaleBarOptions)
         fabScaleWidget.setOnClickListener {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -46,7 +46,7 @@ class ScalebarActivity : AppCompatActivity() {
                 .setMarginTop(15f)
                 .setMarginLeft(16f)
                 .setTextBarMargin(15f)
-                .setRatio(0.5f)
+                .setMaxWidthRatio(0.5f)
 
         scaleBarPlugin.create(scaleBarOptions)
         fabScaleWidget.setOnClickListener {

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
@@ -16,6 +16,15 @@ import java.util.Locale;
 public class ScaleBarOptions {
   public static final int REFRESH_INTERVAL_DEFAULT = 15;
 
+  /**
+   * Enum for scale bar max width ratio compared with MapView width.
+   */
+  public enum ScaleBarRatio {
+    HALF,
+    THIRD,
+    QUARTER
+  }
+
   private final Context context;
   private int refreshInterval;
   private int textColor;
@@ -28,6 +37,7 @@ public class ScaleBarOptions {
   private float borderWidth;
   private float textSize;
   private boolean isMetricUnit;
+  private ScaleBarRatio ratio;
 
   public ScaleBarOptions(@NonNull Context context) {
     this.context = context;
@@ -42,6 +52,7 @@ public class ScaleBarOptions {
     setTextColor(android.R.color.black);
     setPrimaryColor(android.R.color.black);
     setSecondaryColor(android.R.color.white);
+    setRatio(ScaleBarRatio.HALF);
   }
 
   /**
@@ -62,6 +73,7 @@ public class ScaleBarOptions {
     scaleBarWidget.setSecondaryColor(secondaryColor);
     scaleBarWidget.setTextColor(textColor);
     scaleBarWidget.setTextSize(textSize);
+    scaleBarWidget.setRatio(ratio);
     return scaleBarWidget;
   }
 
@@ -253,6 +265,16 @@ public class ScaleBarOptions {
    */
   public ScaleBarOptions setTextBarMargin(@DimenRes int textBarMargin) {
     this.textBarMargin = context.getResources().getDimension(textBarMargin);
+    return this;
+  }
+
+  /**
+   * Set the ratio of scale bar max width compared with MapView width.
+   *
+   * @param ratio the ratio scale bar will use.
+   */
+  public ScaleBarOptions setRatio(ScaleBarRatio ratio) {
+    this.ratio = ratio;
     return this;
   }
 

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import androidx.annotation.ColorRes;
 import androidx.annotation.DimenRes;
+import androidx.annotation.FloatRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
@@ -43,7 +44,7 @@ public class ScaleBarOptions {
     setTextColor(android.R.color.black);
     setPrimaryColor(android.R.color.black);
     setSecondaryColor(android.R.color.white);
-    setRatio(0.5f);
+    setMaxWidthRatio(0.5f);
   }
 
   /**
@@ -264,7 +265,7 @@ public class ScaleBarOptions {
    *
    * @param ratio the ratio scale bar will use, must be in the range from 0.1f to 1.0f.
    */
-  public ScaleBarOptions setRatio(@FloatRange(from = 0.1f, to = 1.0f) float ratio) {
+  public ScaleBarOptions setMaxWidthRatio(@FloatRange(from = 0.1f, to = 1.0f) float ratio) {
     this.ratio = ratio;
     return this;
   }

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
@@ -16,15 +16,6 @@ import java.util.Locale;
 public class ScaleBarOptions {
   public static final int REFRESH_INTERVAL_DEFAULT = 15;
 
-  /**
-   * Enum for scale bar max width ratio compared with MapView width.
-   */
-  public enum ScaleBarRatio {
-    HALF,
-    THIRD,
-    QUARTER
-  }
-
   private final Context context;
   private int refreshInterval;
   private int textColor;
@@ -37,7 +28,7 @@ public class ScaleBarOptions {
   private float borderWidth;
   private float textSize;
   private boolean isMetricUnit;
-  private ScaleBarRatio ratio;
+  private float ratio;
 
   public ScaleBarOptions(@NonNull Context context) {
     this.context = context;
@@ -52,7 +43,7 @@ public class ScaleBarOptions {
     setTextColor(android.R.color.black);
     setPrimaryColor(android.R.color.black);
     setSecondaryColor(android.R.color.white);
-    setRatio(ScaleBarRatio.HALF);
+    setRatio(0.5f);
   }
 
   /**
@@ -271,9 +262,9 @@ public class ScaleBarOptions {
   /**
    * Set the ratio of scale bar max width compared with MapView width.
    *
-   * @param ratio the ratio scale bar will use.
+   * @param ratio the ratio scale bar will use, must be in the range from 0.1f to 1.0f.
    */
-  public ScaleBarOptions setRatio(ScaleBarRatio ratio) {
+  public ScaleBarOptions setRatio(@FloatRange(from = 0.1f, to = 1.0f) float ratio) {
     this.ratio = ratio;
     return this;
   }

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
@@ -19,6 +19,9 @@ import static com.mapbox.pluginscalebar.ScaleBarConstants.FEET_PER_MILE;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.KILOMETER;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.KILOMETER_UNIT;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.MILE_UNIT;
+import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.HALF;
+import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.QUARTER;
+import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.THIRD;
 
 /**
  * The scale widget is a visual representation of the scale bar plugin.
@@ -41,6 +44,7 @@ public class ScaleBarWidget extends View {
   private float textSize;
   private double distancePerPixel;
   private boolean isMetricUnit;
+  private float ratio;
   private ArrayList<Pair<Integer, Integer>> scaleTable;
   private String unit;
   private final RefreshHandler refreshHandler;
@@ -59,7 +63,7 @@ public class ScaleBarWidget extends View {
     if (distancePerPixel <= 0) {
       return;
     }
-    double maxDistance = mapViewWidth * distancePerPixel / 2;
+    double maxDistance = mapViewWidth * distancePerPixel * ratio;
     Pair<Integer, Integer> pair = scaleTable.get(0);
     for (int i = 1; i < scaleTable.size(); i++) {
       pair = scaleTable.get(i);
@@ -71,7 +75,7 @@ public class ScaleBarWidget extends View {
     }
 
     int unitDistance = pair.first / pair.second;
-    float unitBarWidth = maxBarWidth / 2f;
+    float unitBarWidth = maxBarWidth / pair.second;
     if (unitDistance == 0) {
       unitDistance = 1;
     } else {
@@ -179,7 +183,7 @@ public class ScaleBarWidget extends View {
    */
   public void setMarginLeft(float marginLeft) {
     this.marginLeft = marginLeft;
-    maxBarWidth = mapViewWidth / 2f - marginLeft;
+    maxBarWidth = mapViewWidth * ratio - marginLeft;
   }
 
   /**
@@ -346,7 +350,7 @@ public class ScaleBarWidget extends View {
    */
   void setMapViewWidth(int mapViewWidth) {
     this.mapViewWidth = mapViewWidth;
-    maxBarWidth = mapViewWidth / 2f - marginLeft;
+    maxBarWidth = mapViewWidth * ratio - marginLeft;
   }
 
   /**
@@ -362,6 +366,31 @@ public class ScaleBarWidget extends View {
       return distance < FEET_PER_MILE ? distance + unit
         : decimalFormat.format(distance * 1.0 / FEET_PER_MILE) + MILE_UNIT;
     }
+  }
+
+  /**
+   * Set the ratio of scale bar max width compared with MapView width.
+   * @param ratio the ratio scale bar will use.
+   */
+  public void setRatio(ScaleBarOptions.ScaleBarRatio ratio) {
+    switch (ratio) {
+      case HALF:
+        this.ratio = 0.5f;
+        break;
+      case THIRD:
+        this.ratio = 0.33f;
+        break;
+      default:
+        this.ratio = 0.25f;
+    }
+  }
+
+  /**
+   * Get the current ratio of scale bar.
+   * @return current ratio.
+   */
+  public ScaleBarOptions.ScaleBarRatio getRatio() {
+    return this.ratio == 0.5f ? HALF : this.ratio == 0.33f ? THIRD : QUARTER;
   }
 
   /**

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
@@ -19,9 +19,6 @@ import static com.mapbox.pluginscalebar.ScaleBarConstants.FEET_PER_MILE;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.KILOMETER;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.KILOMETER_UNIT;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.MILE_UNIT;
-import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.HALF;
-import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.QUARTER;
-import static com.mapbox.pluginscalebar.ScaleBarOptions.ScaleBarRatio.THIRD;
 
 /**
  * The scale widget is a visual representation of the scale bar plugin.
@@ -372,25 +369,16 @@ public class ScaleBarWidget extends View {
    * Set the ratio of scale bar max width compared with MapView width.
    * @param ratio the ratio scale bar will use.
    */
-  public void setRatio(ScaleBarOptions.ScaleBarRatio ratio) {
-    switch (ratio) {
-      case HALF:
-        this.ratio = 0.5f;
-        break;
-      case THIRD:
-        this.ratio = 0.33f;
-        break;
-      default:
-        this.ratio = 0.25f;
-    }
+  public void setRatio(float ratio) {
+    this.ratio = ratio;
   }
 
   /**
    * Get the current ratio of scale bar.
    * @return current ratio.
    */
-  public ScaleBarOptions.ScaleBarRatio getRatio() {
-    return this.ratio == 0.5f ? HALF : this.ratio == 0.33f ? THIRD : QUARTER;
+  public float getRatio() {
+    return this.ratio;
   }
 
   /**


### PR DESCRIPTION
Resolves #1046 
ratio is calculated according scalebar with / mapview width.
Currently we add support for HALF, THIRD and QUATER, may add more if needed in future. 