### PR TITLE
Bumped Java SDK to stable 4.9.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@
 
   version = [
       mapboxMapSdk       : '8.3.0',
-      mapboxJava         : '4.8.0',
+      mapboxJava         : '4.9.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.6',


### PR DESCRIPTION
Part of the `4.9.0` release of the Mapbox Java SDK: https://github.com/mapbox/mapbox-java/issues/1070