### PR TITLE
Bump Maps SDK to v8.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '8.4.0',
+      mapboxMapSdk       : '8.5.0-beta.1',
       mapboxJava         : '4.9.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '8.5.0-beta.1',
+      mapboxMapSdk       : '8.5.0',
       mapboxJava         : '4.9.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',


### PR DESCRIPTION
No issues found during 8.5.0-beta.1 QA