### PR TITLE
Switch Timber log level to debug for setMapLanguage

### DIFF
--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -252,7 +252,7 @@ public final class LocalizationPlugin {
         if (url == null) {
           url = "not found";
         }
-        Timber.w("The %s (%s) source is not based on Mapbox Vector Tiles. Supported sources:\n %s",
+        Timber.d("The %s (%s) source is not based on Mapbox Vector Tiles. Supported sources:\n %s",
           source.getId(), url, SUPPORTED_SOURCES);
       }
     }


### PR DESCRIPTION
This creates a huge amount of log spam otherwise in applications using various sources.