### PR TITLE
Bumped Maps SDK to 9.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '8.6.2',
+      mapboxMapSdk       : '9.0.0',
       mapboxJava         : '5.0.0',
       mapboxTurf         : '5.0.0',
       playLocation       : '16.0.0',


### PR DESCRIPTION
Part of the 9.0.0 Maps SDK release.

Related to this pr is https://github.com/mapbox/mapbox-plugins-android/pull/1086, which bumps this repo's Java SDK dependencies to 5.0.0