### PR TITLE
Switching all plugins to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
     minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     applicationId "com.mapbox.mapboxsdk.plugins.testapp"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true
   }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
@@ -4,27 +4,30 @@ import android.app.Activity;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.espresso.IdlingResourceTimeoutException;
-import android.support.test.espresso.ViewInteraction;
-import android.support.test.rule.ActivityTestRule;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
 
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction;
 import com.mapbox.mapboxsdk.plugins.annotation.WaitAction;
 import com.mapbox.mapboxsdk.plugins.utils.OnMapReadyIdlingResource;
+
 import junit.framework.Assert;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResourceTimeoutException;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.rule.ActivityTestRule;
 import timber.log.Timber;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 public abstract class BaseActivityTest {
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/activity.junit.ejs
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/activity.junit.ejs
@@ -5,7 +5,7 @@
 // This file is generated
 package com.mapbox.mapboxsdk.plugins.gen.<%- subPackage %>;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.<%- subPackage %>.<%- activity %>;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
@@ -3,7 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
@@ -3,7 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
@@ -3,7 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/MapboxMapAction.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/MapboxMapAction.java
@@ -1,14 +1,17 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
 import android.view.View;
+
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+
 import org.hamcrest.Matcher;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 public class MapboxMapAction implements ViewAction {
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
@@ -3,7 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/WaitAction.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/WaitAction.java
@@ -1,11 +1,14 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
 import android.view.View;
+
 import org.hamcrest.Matcher;
 
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+
 
 public final class WaitAction implements ViewAction {
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/building/BuildingPluginAction.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/building/BuildingPluginAction.java
@@ -1,15 +1,17 @@
 package com.mapbox.mapboxsdk.plugins.building;
 
 import android.content.Context;
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
 import org.hamcrest.Matcher;
 
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+
 
 class BuildingPluginAction implements ViewAction {
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/building/BuildingPluginTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/building/BuildingPluginTest.java
@@ -1,9 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.building;
 
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.espresso.IdlingResourceTimeoutException;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
@@ -17,13 +13,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResourceTimeoutException;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
 import timber.log.Timber;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePluginTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/offline/OfflinePluginTest.java
@@ -1,8 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.offline;
 
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
@@ -16,9 +13,12 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/LiveDataTestUtil.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/LiveDataTestUtil.java
@@ -1,11 +1,11 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.Observer;
-import android.support.annotation.Nullable;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.Nullable;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
 
 public class LiveDataTestUtil {
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/SearchHistoryDaoTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/SearchHistoryDaoTest.java
@@ -1,9 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.data;
 
-import android.arch.core.executor.testing.InstantTaskExecutorRule;
-import android.arch.persistence.room.Room;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.LiveDataTestUtil;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.dao.SearchHistoryDao;
@@ -17,6 +13,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.room.Room;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.mapbox.mapboxsdk.plugins.places.autocomplete.data.TestData.SEARCH_HISTORY_ENTITY;
 import static com.mapbox.mapboxsdk.plugins.places.autocomplete.data.TestData.SEARCH_HISTORY_ENTITY_TWO;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragmentTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragmentTest.java
@@ -3,9 +3,6 @@ package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 import android.content.Context;
 import android.graphics.Color;
 import android.net.wifi.WifiManager;
-import android.support.test.espresso.action.ViewActions;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.TestData;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.model.PlaceOptions;
@@ -18,17 +15,20 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasBackground;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withHint;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasBackground;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxsdk.plugins.scalebar;
 
 
 import android.app.Activity;
-import android.support.test.runner.AndroidJUnit4;
-import android.support.v4.content.ContextCompat;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -17,6 +15,8 @@ import com.mapbox.pluginscalebar.ScaleBarWidget;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.core.content.ContextCompat;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginAction.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginAction.java
@@ -1,14 +1,15 @@
 package com.mapbox.mapboxsdk.plugins.traffic;
 
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
 import org.hamcrest.Matcher;
 
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 class TrafficPluginAction implements ViewAction {
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPluginTest.java
@@ -1,10 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.traffic;
 
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.IdlingResourceTimeoutException;
-import android.support.test.espresso.UiController;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
@@ -20,12 +15,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingResourceTimeoutException;
+import androidx.test.espresso.UiController;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
 import timber.log.Timber;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.Local;
 import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.MotorWay;
 import static com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin.Primary;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/OnMapReadyIdlingResource.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/OnMapReadyIdlingResource.java
@@ -3,14 +3,15 @@ package com.mapbox.mapboxsdk.plugins.utils;
 import android.app.Activity;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.test.espresso.IdlingResource;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
+
+import androidx.annotation.NonNull;
+import androidx.test.espresso.IdlingResource;
 
 public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallback {
 

--- a/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/SingleFragmentActivity.java
+++ b/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/SingleFragmentActivity.java
@@ -1,13 +1,14 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatActivity;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.mapbox.mapboxsdk.plugins.testapp.R;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
 
 /**
  * Used for testing fragments inside a fake activity.

--- a/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
+++ b/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
@@ -1,7 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.plugins.testapp.R
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/FeatureOverviewActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/FeatureOverviewActivity.java
@@ -12,13 +12,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.IdRes;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.SparseArray;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,6 +21,14 @@ import android.widget.Toast;
 import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import timber.log.Timber;
 
 import java.lang.ref.WeakReference;

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
@@ -4,8 +4,9 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.app.AppCompatActivity;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.MenuItemCompat;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -26,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Activity showcasing adding circles using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
@@ -5,10 +5,8 @@ import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.support.annotation.DrawableRes;
-import android.support.design.widget.FloatingActionButton;
-import android.support.v7.app.AppCompatActivity;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -19,6 +17,9 @@ import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
+
+import androidx.annotation.DrawableRes;
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Test activity showcasing updating a Marker position, title, icon and snippet.

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
@@ -2,14 +2,11 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -19,7 +16,6 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Fill;
 import com.mapbox.mapboxsdk.plugins.annotation.FillManager;
 import com.mapbox.mapboxsdk.plugins.annotation.FillOptions;
-import com.mapbox.mapboxsdk.plugins.annotation.OnFillClickListener;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
@@ -28,6 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Activity showcasing adding fills using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -23,6 +21,9 @@ import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 
 import static com.mapbox.mapboxsdk.plugins.testapp.activity.annotation.FillChangeActivity.Config.BLUE_COLOR;
 import static com.mapbox.mapboxsdk.plugins.testapp.activity.annotation.FillChangeActivity.Config.BROKEN_SHAPE_POINTS;

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -22,6 +21,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Activity showcasing adding lines using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -23,6 +22,8 @@ import com.mapbox.mapboxsdk.utils.ColorUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Test activity showcasing the Polyline annotations API.

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
@@ -5,11 +5,6 @@ import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.app.AppCompatDelegate;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -19,6 +14,12 @@ import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 
 /**
  * Test activity showcasing to add a Symbol on click.

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -4,7 +4,6 @@ import android.animation.ValueAnimator;
 import android.graphics.Color;
 import android.graphics.PointF;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/building/BuildingActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/building/BuildingActivity.kt
@@ -2,11 +2,11 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.building
 
 import android.graphics.Color
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.SeekBar
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
@@ -1,8 +1,8 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.ktx.maps
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
@@ -1,10 +1,10 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.localization
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.markerview
 
 import android.animation.ValueAnimator
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
@@ -18,6 +17,7 @@ import com.mapbox.mapboxsdk.plugins.testapp.R
 import java.util.Random
 
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.plugins.testapp.Utils
 import kotlinx.android.synthetic.main.activity_annotation.*

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
@@ -1,10 +1,10 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.offline
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.widget.ArrayAdapter
 import android.widget.SeekBar
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 
 import com.mapbox.mapboxsdk.constants.MapboxConstants
 import com.mapbox.mapboxsdk.geometry.LatLng

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.kt
@@ -1,9 +1,9 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.offline
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.offline.OfflineManager
 import com.mapbox.mapboxsdk.offline.OfflineRegion
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionListActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionListActivity.kt
@@ -2,11 +2,11 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.offline
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.offline.OfflineManager
 import com.mapbox.mapboxsdk.offline.OfflineRegion
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
@@ -3,8 +3,8 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.offline
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteFragmentActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteFragmentActivity.kt
@@ -2,9 +2,9 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.places
 
 import android.graphics.Color
 import android.os.Bundle
-import android.support.v4.content.ContextCompat
-import android.support.v7.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature
 import com.mapbox.mapboxsdk.Mapbox

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/AutocompleteLauncherActivity.kt
@@ -4,8 +4,8 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.google.gson.JsonObject
 import com.mapbox.api.geocoding.v5.models.CarmenFeature
 import com.mapbox.geojson.Point

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/places/PickerLauncherActivity.kt
@@ -3,8 +3,8 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.places
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -1,7 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.scalebar
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.turf.TurfMeasurement
 import com.mapbox.mapboxsdk.maps.Style
@@ -17,8 +17,6 @@ import com.mapbox.mapboxsdk.style.layers.LineLayer
 
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import com.mapbox.turf.TurfConstants
-
-import java.util.*
 
 /**
  * Activity showing a scalebar used on a MapView.

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/traffic/TrafficActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/traffic/TrafficActivity.kt
@@ -1,7 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.traffic
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback

--- a/app/src/main/res/layout/activity_annotation.xml
+++ b/app/src/main/res/layout/activity_annotation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/coordinator_layout"
@@ -17,7 +17,7 @@
             android:layout_height="wrap_content"
             android:visibility="gone"/>
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fabStyles"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -30,4 +30,4 @@
             app:layout_constraintRight_toRightOf="parent"
             app:srcCompat="@drawable/ic_layers"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_building.xml
+++ b/app/src/main/res/layout/activity_building.xml
@@ -18,7 +18,7 @@
     app:mapbox_cameraZoom="16"
     app:mapbox_uiAttribution="false"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabBuilding"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -26,7 +26,7 @@
     android:layout_alignParentRight="true"
     android:layout_gravity="end|bottom"
     android:layout_margin="16dp"
-    android:src="@drawable/ic_business"
+    app:srcCompat="@drawable/ic_business"
     android:tint="@android:color/white"
     app:backgroundTint="@color/colorPrimary"/>
 

--- a/app/src/main/res/layout/activity_feature_overview.xml
+++ b/app/src/main/res/layout/activity_feature_overview.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_localization.xml
+++ b/app/src/main/res/layout/activity_localization.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
@@ -18,7 +18,7 @@
 
   </com.mapbox.mapboxsdk.maps.MapView>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
       android:id="@+id/fabStyles"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
@@ -33,7 +33,7 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintRight_toRightOf="parent"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
       android:id="@+id/fabCamera"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintRight_toRightOf="parent"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabLocalize"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -61,4 +61,4 @@
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_maps_ktx.xml
+++ b/app/src/main/res/layout/activity_maps_ktx.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/coordinator_layout"
@@ -15,4 +15,4 @@
             app:mapbox_cameraTilt="45"
             app:mapbox_cameraZoom="15"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_offline_download.xml
+++ b/app/src/main/res/layout/activity_offline_download.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
 xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:app="http://schemas.android.com/apk/res-auto"
 android:id="@+id/coordinator_layout"
@@ -7,7 +7,7 @@ android:layout_width="match_parent"
 android:layout_height="match_parent"
 android:orientation="vertical">
 
-<android.support.v4.widget.NestedScrollView
+<androidx.core.widget.NestedScrollView
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -175,9 +175,9 @@ android:orientation="vertical">
 
   </LinearLayout>
 
-</android.support.v4.widget.NestedScrollView>
+</androidx.core.widget.NestedScrollView>
 
-<android.support.design.widget.FloatingActionButton
+<com.google.android.material.floatingactionbutton.FloatingActionButton
   android:id="@+id/fabStartDownload"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
@@ -187,4 +187,4 @@ android:orientation="vertical">
   android:tint="@android:color/white"
   app:backgroundTint="@color/colorPrimary"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_offline_region_detail.xml
+++ b/app/src/main/res/layout/activity_offline_region_detail.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -19,7 +19,7 @@
             app:mapbox_uiCompass="false"
             app:mapbox_uiLogo="false"/>
 
-        <android.support.v4.widget.NestedScrollView
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/bottomSheet"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -79,7 +79,7 @@
             </LinearLayout>
 
 
-        </android.support.v4.widget.NestedScrollView>
+        </androidx.core.widget.NestedScrollView>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -144,7 +144,7 @@
         </LinearLayout>
     </LinearLayout>
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fabDelete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -153,4 +153,4 @@
             app:layout_anchor="@+id/barView"
             app:layout_anchorGravity="bottom|end"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_offline_ui_components.xml
+++ b/app/src/main/res/layout/activity_offline_ui_components.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabRegionSelector"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -18,6 +18,6 @@
     app:srcCompat="@drawable/ic_save"
     android:layout_marginRight="16dp"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/activity_picker_launcher.xml
+++ b/app/src/main/res/layout/activity_picker_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -51,7 +51,7 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
       android:id="@+id/fabLocationPicker"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
@@ -66,4 +66,4 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:srcCompat="@drawable/mapbox_ic_place"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_places_fragment.xml
+++ b/app/src/main/res/layout/activity_places_fragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
@@ -14,4 +14,4 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_places_launcher.xml
+++ b/app/src/main/res/layout/activity_places_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -16,7 +16,7 @@
     app:mapbox_cameraZoom="11"
     app:mapbox_uiAttribution="false"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabCard"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -29,7 +29,7 @@
     app:layout_anchorGravity="top"
     app:srcCompat="@drawable/ic_layers"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabFullScreen"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -39,4 +39,4 @@
     app:backgroundTint="@color/colorPrimary"
     app:srcCompat="@android:drawable/ic_search_category_default"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_scalebar.xml
+++ b/app/src/main/res/layout/activity_scalebar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -14,7 +14,7 @@
         app:mapbox_cameraTargetLng="-122.447244"
         app:mapbox_cameraZoom="15.5" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabScaleWidget"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -23,4 +23,4 @@
         android:tint="@android:color/white"
         app:backgroundTint="@color/colorPrimary"
         app:srcCompat="@drawable/ic_scale" />
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_traffic.xml
+++ b/app/src/main/res/layout/activity_traffic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/coordinator_layout"
@@ -15,7 +15,7 @@
     app:mapbox_cameraZoom="9"
     app:mapbox_uiAttribution="false"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabStyles"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -28,7 +28,7 @@
     app:backgroundTint="@color/colorAccent"
     app:layout_anchorGravity="top"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/fabTraffic"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -38,4 +38,4 @@
     android:tint="@android:color/white"
     app:backgroundTint="@color/colorPrimary"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/marker_view.xml
+++ b/app/src/main/res/layout/marker_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<androidx.cardview.widget.CardView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="wrap_content"
@@ -23,4 +23,4 @@
             android:layout_toRightOf="@id/imageview"
             android:layout_height="32dp"/>
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,8 @@ POM_DEVELOPER_NAME=Mapbox
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2560M
+android.useAndroidX=true
+android.enableJetifier=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,58 +39,58 @@
   ]
 
   dependenciesList = [
-      // mapbox
-      mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
-      mapboxGeoJson          : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxJava}",
-      mapboxGeocoding        : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxJava}",
-      mapboxTurf             : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxTurf}",
+          // mapbox
+          mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
+          mapboxGeoJson          : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxJava}",
+          mapboxGeocoding        : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxJava}",
+          mapboxTurf             : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxTurf}",
 
-      // Google Play Location
-      playLocation           : "com.google.android.gms:play-services-location:${version.playLocation}",
+          // Google Play Location
+          playLocation           : "com.google.android.gms:play-services-location:${version.playLocation}",
 
-      // AutoValue
-      autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
-      autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
-      autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
+          // AutoValue
+          autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
+          autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
+          autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
 
-      // support
-      supportAnnotation      : "com.android.support:support-annotations:${version.supportLib}",
-      supportAppcompatV7     : "com.android.support:appcompat-v7:${version.supportLib}",
-      supportV4              : "com.android.support:support-v4:${version.supportLib}",
-      supportDesign          : "com.android.support:design:${version.supportLib}",
-      supportRecyclerView    : "com.android.support:recyclerview-v7:${version.supportLib}",
-      supportCardView        : "com.android.support:cardview-v7:${version.supportLib}",
-      supportConstraintLayout: "com.android.support.constraint:constraint-layout:${version.constraintLayout}",
+          // support
+          supportAnnotation      : 'androidx.annotation:annotation:1.0.0',
+          supportAppcompatV7     : 'androidx.appcompat:appcompat:1.0.0',
+          supportV4              : 'androidx.legacy:legacy-support-v4:1.0.0',
+          supportDesign          : 'com.google.android.material:material:1.0.0',
+          supportRecyclerView    : 'androidx.recyclerview:recyclerview:1.0.0',
+          supportCardView        : 'androidx.cardview:cardview:1.0.0',
+          supportConstraintLayout: 'androidx.constraintlayout:constraintlayout:1.1.3',
 
-      // architecture
-      lifecycleExtensions    : "android.arch.lifecycle:extensions:${version.lifecycleExtensions}",
-      lifecycleCompiler      : "android.arch.lifecycle:compiler:${version.lifecycleCompiler}",
-      roomRuntime            : "android.arch.persistence.room:runtime:${version.room}",
-      roomCompiler           : "android.arch.persistence.room:compiler:${version.room}",
+          // architecture
+          lifecycleExtensions    : 'androidx.lifecycle:lifecycle-extensions:2.0.0',
+          lifecycleCompiler      : "android.arch.lifecycle:compiler:${version.lifecycleCompiler}",
+          roomRuntime            : 'androidx.room:room-runtime:2.0.0',
+          roomCompiler           : 'androidx.room:room-compiler:2.0.0',
 
-      // square crew
-      timber                 : "com.jakewharton.timber:timber:${version.timber}",
-      leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanary}",
-      leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanary}",
-      leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanary}",
+          // square crew
+          timber                 : "com.jakewharton.timber:timber:${version.timber}",
+          leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanary}",
+          leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanary}",
+          leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanary}",
 
-      // instrumentation test
-      testRunner             : "com.android.support.test:runner:${version.testRunner}",
-      testRules              : "com.android.support.test:rules:${version.testRunner}",
-      testEspressoCore       : "com.android.support.test.espresso:espresso-core:${version.espresso}",
-      testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${version.espresso}",
-      testRoom               : "android.arch.persistence.room:testing:${version.room}",
-      testArchCore           : "android.arch.core:core-testing:${version.androidArchCore}",
-      mockitoCore            : "org.mockito:mockito-core:${version.mockito}",
-      mockitoAndroid         : "org.mockito:mockito-android:${version.mockito}",
-      mockk                  : "io.mockk:mockk:${version.mockk}",
+          // instrumentation test
+          testRunner             : 'androidx.test.ext:junit:1.1.1',
+          testRules              : 'androidx.test:rules:1.1.1',
+          testEspressoCore       : 'androidx.test.espresso:espresso-core:3.1.0',
+          testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${version.espresso}",
+          testRoom               : 'androidx.room:room-testing:2.0.0',
+          testArchCore           : 'androidx.arch.core:core-testing:2.0.0',
+          mockitoCore            : "org.mockito:mockito-core:${version.mockito}",
+          mockitoAndroid         : "org.mockito:mockito-android:${version.mockito}",
+          mockk                  : "io.mockk:mockk:${version.mockk}",
 
-      // unit test
-      junit                  : "junit:junit:${version.junit}",
-      mockito                : "org.mockito:mockito-inline:${version.mockito}",
-      androidArchCore        : "android.arch.core:core-testing:${version.androidArchCore}",
-      robolectric            : "org.robolectric:robolectric:${version.robolectric}",
-      kotlin                 : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${pluginVersion.kotlin}",
+          // unit test
+          junit                  : "junit:junit:${version.junit}",
+          mockito                : "org.mockito:mockito-inline:${version.mockito}",
+          androidArchCore        : 'androidx.arch.core:core-testing:2.0.0',
+          robolectric            : "org.robolectric:robolectric:${version.robolectric}",
+          kotlin                 : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${pluginVersion.kotlin}",
   ]
 
   pluginDependencies = [

--- a/ktx-mapbox-maps/build.gradle
+++ b/ktx-mapbox-maps/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     configurations {

--- a/plugin-annotation/build.gradle
+++ b/plugin-annotation/build.gradle
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     configurations {

--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -7,9 +7,11 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.ColorInt;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.graphics.PointF;
-import android.support.annotation.UiThread;
+import androidx.annotation.UiThread;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -18,8 +20,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.mapboxsdk.maps.Projection;
 

--- a/plugin-annotation/scripts/annotation_element_provider.java.ejs
+++ b/plugin-annotation/scripts/annotation_element_provider.java.ejs
@@ -7,7 +7,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -7,7 +7,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -7,10 +7,10 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -6,7 +6,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -7,8 +7,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.*;
 import com.mapbox.geojson.Geometry;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Annotation.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Annotation.java
@@ -1,13 +1,13 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.mapboxsdk.maps.Projection;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public abstract class Annotation<T extends Geometry> {
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -1,11 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
-import android.support.v4.util.LongSparseArray;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
@@ -21,12 +16,15 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
+import androidx.collection.LongSparseArray;
 
 /**
  * Generic AnnotationManager, can be used to create annotation specific managers.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
@@ -2,9 +2,11 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.ColorInt;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.graphics.PointF;
-import android.support.annotation.UiThread;
+import androidx.annotation.UiThread;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -13,8 +15,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.mapboxsdk.maps.Projection;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -2,10 +2,10 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
@@ -2,8 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.*;
 import com.mapbox.geojson.Geometry;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ConvertUtils.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ConvertUtils.java
@@ -1,8 +1,8 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
-
 import com.google.gson.JsonArray;
+
+import androidx.annotation.Nullable;
 
 class ConvertUtils {
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
@@ -1,9 +1,10 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import androidx.annotation.Nullable;
 
 interface CoreElementProvider<L extends Layer> {
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -2,9 +2,6 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.annotation.SuppressLint;
 import android.graphics.PointF;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -15,6 +12,10 @@ import com.mapbox.geojson.Geometry;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 final class DraggableAnnotationController<T extends Annotation, D extends OnAnnotationDragListener<T>> {
   private final MapboxMap mapboxMap;
   private AnnotationManager<?, T, ?, D, ?, ?> annotationManager;
@@ -24,7 +25,8 @@ final class DraggableAnnotationController<T extends Annotation, D extends OnAnno
   private final int touchAreaMaxX;
   private final int touchAreaMaxY;
 
-  @Nullable private T draggedAnnotation;
+  @Nullable
+  private T draggedAnnotation;
 
   @SuppressLint("ClickableViewAccessibility")
   DraggableAnnotationController(MapView mapView, MapboxMap mapboxMap) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
@@ -2,9 +2,11 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.ColorInt;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.graphics.PointF;
-import android.support.annotation.UiThread;
+import androidx.annotation.UiThread;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -13,8 +15,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.mapboxsdk.maps.Projection;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -2,10 +2,10 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
@@ -2,8 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.*;
 import com.mapbox.geojson.Geometry;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
@@ -2,9 +2,11 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.ColorInt;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.graphics.PointF;
-import android.support.annotation.UiThread;
+import androidx.annotation.UiThread;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -13,8 +15,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.mapboxsdk.maps.Projection;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -2,10 +2,10 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
@@ -2,8 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.*;
 import com.mapbox.geojson.Geometry;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -2,9 +2,11 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.ColorInt;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.graphics.PointF;
-import android.support.annotation.UiThread;
+import androidx.annotation.UiThread;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -13,8 +15,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.mapboxsdk.maps.Projection;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
@@ -2,7 +2,7 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -2,10 +2,10 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -2,8 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.*;
 import com.mapbox.geojson.Geometry;

--- a/plugin-building/build.gradle
+++ b/plugin-building/build.gradle
@@ -6,7 +6,7 @@ android {
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   configurations {

--- a/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
+++ b/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
@@ -1,16 +1,17 @@
 package com.mapbox.mapboxsdk.plugins.building;
 
 import android.graphics.Color;
-import android.support.annotation.ColorInt;
-import android.support.annotation.FloatRange;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
 import com.mapbox.mapboxsdk.style.light.Light;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.FloatRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.mapbox.mapboxsdk.constants.MapboxConstants.MAXIMUM_ZOOM;
 import static com.mapbox.mapboxsdk.constants.MapboxConstants.MINIMUM_ZOOM;

--- a/plugin-localization/build.gradle
+++ b/plugin-localization/build.gradle
@@ -6,7 +6,7 @@ android {
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   configurations {

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.localization;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
 
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -20,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.raw;

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -1,8 +1,5 @@
 package com.mapbox.mapboxsdk.plugins.localization;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -11,6 +8,10 @@ import java.lang.annotation.Retention;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringDef;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 

--- a/plugin-markerview/build.gradle
+++ b/plugin-markerview/build.gradle
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     configurations {

--- a/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerView.java
+++ b/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerView.java
@@ -1,10 +1,11 @@
 package com.mapbox.mapboxsdk.plugins.markerview;
 
 import android.graphics.PointF;
-import android.support.annotation.NonNull;
 import android.view.View;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.Projection;
+
+import androidx.annotation.NonNull;
 
 /**
  * MarkerView class wraps a latitude-longitude pair with a Android SDK View.

--- a/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
+++ b/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
@@ -1,13 +1,14 @@
 package com.mapbox.mapboxsdk.plugins.markerview;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
 
 /**
  * Class responsible for synchronising views at a LatLng on top of a Map.

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineRegionSelector.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineRegionSelector.java
@@ -3,13 +3,14 @@ package com.mapbox.mapboxsdk.plugins.offline;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
 
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
 import com.mapbox.mapboxsdk.plugins.offline.ui.OfflineActivity;
+
+import androidx.annotation.NonNull;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_DEFINITION;
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_REGION_NAME;

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/NotificationOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/NotificationOptions.java
@@ -2,10 +2,11 @@ package com.mapbox.mapboxsdk.plugins.offline.model;
 
 import android.content.Context;
 import android.os.Parcelable;
-import android.support.annotation.DrawableRes;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.mapboxsdk.plugins.offline.R;
+
+import androidx.annotation.DrawableRes;
 
 @AutoValue
 public abstract class NotificationOptions implements Parcelable {

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/OfflineDownloadOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/OfflineDownloadOptions.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.offline.model;
 
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.mapboxsdk.offline.OfflineRegion;
@@ -11,6 +9,9 @@ import com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadService;
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin;
 
 import java.util.UUID;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * This model class wraps the offline region definition with notifications options and the offline

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/RegionSelectionOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/RegionSelectionOptions.java
@@ -1,13 +1,14 @@
 package com.mapbox.mapboxsdk.plugins.offline.model;
 
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.plugins.offline.ui.OfflineActivity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Options specific to the Region Selection UI component.

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
@@ -6,10 +6,11 @@ import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.IBinder;
-import android.support.annotation.Nullable;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
-import android.support.v4.util.LongSparseArray;
+
+import androidx.annotation.Nullable;
+import androidx.collection.LongSparseArray;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 import com.mapbox.mapboxsdk.offline.OfflineManager;
 import com.mapbox.mapboxsdk.offline.OfflineRegion;

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflinePlugin.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflinePlugin.java
@@ -4,14 +4,15 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.offline.OfflineRegion;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.KEY_BUNDLE;
 

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/OfflineActivity.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/OfflineActivity.java
@@ -2,9 +2,6 @@ package com.mapbox.mapboxsdk.plugins.offline.ui;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.constraint.ConstraintLayout;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Window;
 
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
@@ -12,6 +9,10 @@ import com.mapbox.mapboxsdk.plugins.offline.OfflinePluginConstants;
 import com.mapbox.mapboxsdk.plugins.offline.R;
 import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
 import com.mapbox.mapboxsdk.plugins.offline.utils.ColorUtils;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.constraintlayout.widget.ConstraintLayout;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_DEFINITION;
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_REGION_NAME;

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/RegionSelectionFragment.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/RegionSelectionFragment.java
@@ -3,15 +3,12 @@ package com.mapbox.mapboxsdk.plugins.offline.ui;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.design.widget.FloatingActionButton;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapbox.geojson.Feature;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -29,6 +26,9 @@ import com.mapbox.mapboxsdk.style.sources.VectorSource;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import timber.log.Timber;
 
 public class RegionSelectionFragment extends Fragment implements OnMapReadyCallback,

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/ColorUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/ColorUtils.java
@@ -2,10 +2,11 @@ package com.mapbox.mapboxsdk.plugins.offline.utils;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.support.annotation.AttrRes;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
 import android.util.TypedValue;
+
+import androidx.annotation.AttrRes;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
 
 public final class ColorUtils {
 

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
@@ -8,8 +8,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationCompat;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
 
 import com.mapbox.mapboxsdk.plugins.offline.R;
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions;

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/OfflineUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/OfflineUtils.java
@@ -1,12 +1,13 @@
 package com.mapbox.mapboxsdk.plugins.offline.utils;
 
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 
 import org.json.JSONObject;
+
+import androidx.annotation.NonNull;
 
 public class OfflineUtils {
 

--- a/plugin-offline/src/main/res/layout/mapbox_offline_activity.xml
+++ b/plugin-offline/src/main/res/layout/mapbox_offline_activity.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <android.support.design.widget.AppBarLayout
+  <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/mapbox_offline_app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <include layout="@layout/mapbox_offline_toolbar"/>
 
-  </android.support.design.widget.AppBarLayout>
+  </com.google.android.material.appbar.AppBarLayout>
 
   <FrameLayout
     android:id="@+id/fragment_container"
@@ -23,4 +23,4 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@id/mapbox_offline_app_bar_layout"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-offline/src/main/res/layout/mapbox_offline_region_selection_fragment.xml
+++ b/plugin-offline/src/main/res/layout/mapbox_offline_region_selection_fragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -29,7 +29,7 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"/>
 
-  <android.support.design.widget.FloatingActionButton
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/mapbox_offline_select_region_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -59,4 +59,4 @@
     app:layout_constraintTop_toBottomOf="@+id/mapbox_offline_scrim_view"
     tools:text="Washington D.C."/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-offline/src/main/res/layout/mapbox_offline_toolbar.xml
+++ b/plugin-offline/src/main/res/layout/mapbox_offline_toolbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -50,4 +50,4 @@
     app:layout_constraintTop_toTopOf="parent"
     app:srcCompat="@drawable/mapbox_ic_arrow_back"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/DataRepository.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/DataRepository.java
@@ -1,14 +1,15 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MediatorLiveData;
-import android.arch.lifecycle.Observer;
-import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.SearchHistoryDatabase;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.entity.SearchHistoryEntity;
 
 import java.util.List;
+
+import androidx.annotation.Nullable;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
+import androidx.lifecycle.Observer;
 
 
 /**

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/PlaceAutocomplete.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/PlaceAutocomplete.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.plugins.places.autocomplete;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.SearchHistoryDatabase;
@@ -12,6 +11,8 @@ import com.mapbox.mapboxsdk.plugins.places.autocomplete.ui.PlaceAutocompleteActi
 import com.mapbox.mapboxsdk.plugins.places.common.PlaceConstants;
 
 import java.util.ArrayList;
+
+import androidx.annotation.NonNull;
 
 /**
  * PlaceAutocomplete provides an activity that allows a user to start typing a place name or an

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/SearchHistoryDatabase.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/SearchHistoryDatabase.java
@@ -1,19 +1,20 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.data;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.arch.persistence.db.SupportSQLiteDatabase;
-import android.arch.persistence.room.Database;
-import android.arch.persistence.room.Room;
-import android.arch.persistence.room.RoomDatabase;
-import android.arch.persistence.room.TypeConverters;
 import android.content.Context;
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
 
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.converter.CarmenFeatureConverter;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.dao.SearchHistoryDao;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.entity.SearchHistoryEntity;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
 @Database(entities = {SearchHistoryEntity.class}, version = 1)
 @TypeConverters(CarmenFeatureConverter.class)

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/converter/CarmenFeatureConverter.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/converter/CarmenFeatureConverter.java
@@ -1,9 +1,10 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.data.converter;
 
-import android.arch.persistence.room.TypeConverter;
-import android.support.annotation.NonNull;
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
+
+import androidx.annotation.NonNull;
+import androidx.room.TypeConverter;
 
 public final class CarmenFeatureConverter {
 

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/dao/SearchHistoryDao.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/dao/SearchHistoryDao.java
@@ -1,14 +1,15 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.data.dao;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
 
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.data.entity.SearchHistoryEntity;
 
 import java.util.List;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 
 /**
  * The Data Access Objects specifically for the search history database

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/entity/SearchHistoryEntity.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/data/entity/SearchHistoryEntity.java
@@ -1,12 +1,13 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.data.entity;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
-import android.support.annotation.NonNull;
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.model.SearchHistory;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 @Entity(tableName = "searchhistory")
 public class SearchHistoryEntity implements SearchHistory {

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/model/PlaceOptions.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/model/PlaceOptions.java
@@ -2,11 +2,6 @@ package com.mapbox.mapboxsdk.plugins.places.autocomplete.model;
 
 import android.graphics.Color;
 import android.os.Parcelable;
-import android.support.annotation.ColorInt;
-import android.support.annotation.FloatRange;
-import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.geocoding.v5.GeocodingCriteria.GeocodingTypeCriteria;
@@ -19,6 +14,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.FloatRange;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Create a PlaceOptions object which can be used to customize the autocomplete geocoder results and

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteActivity.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteActivity.java
@@ -2,13 +2,14 @@ package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
 import com.mapbox.mapboxsdk.places.R;
 import com.mapbox.mapboxsdk.plugins.places.autocomplete.model.PlaceOptions;
 import com.mapbox.mapboxsdk.plugins.places.common.PlaceConstants;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 public class PlaceAutocompleteActivity extends AppCompatActivity implements PlaceSelectionListener {
 

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragment.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/PlaceAutocompleteFragment.java
@@ -1,13 +1,8 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
 import android.app.Activity;
-import android.arch.lifecycle.Observer;
-import android.arch.lifecycle.ViewModelProviders;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,6 +22,11 @@ import com.mapbox.mapboxsdk.plugins.places.common.utils.KeyboardUtils;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProviders;
 import timber.log.Timber;
 
 public class PlaceAutocompleteFragment extends Fragment implements ResultClickCallback,

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/ResultCardView.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/ResultCardView.java
@@ -1,11 +1,12 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 
 import com.mapbox.mapboxsdk.places.R;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class ResultCardView extends ResultView {
 

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/ResultItemDecoration.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/ResultItemDecoration.java
@@ -3,8 +3,9 @@ package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.widget.RecyclerView;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.View;
 
 import com.mapbox.mapboxsdk.places.R;

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/ResultView.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/ResultView.java
@@ -1,10 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 
@@ -13,6 +9,11 @@ import com.mapbox.mapboxsdk.places.R;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class ResultView extends LinearLayout {
 

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/SearchResultAdapter.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/SearchResultAdapter.java
@@ -1,9 +1,11 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.widget.RecyclerView;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/SearchView.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/ui/SearchView.java
@@ -1,12 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.ui;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
@@ -17,6 +11,13 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import com.mapbox.mapboxsdk.places.R;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.OnLifecycleEvent;
 
 public class SearchView extends LinearLayout implements ImageButton.OnClickListener, TextWatcher,
   LifecycleObserver {

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/viewmodel/PlaceAutocompleteViewModel.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/autocomplete/viewmodel/PlaceAutocompleteViewModel.java
@@ -1,12 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.places.autocomplete.viewmodel;
 
 import android.app.Application;
-import android.arch.lifecycle.AndroidViewModel;
-import android.arch.lifecycle.MutableLiveData;
-import android.arch.lifecycle.ViewModel;
-import android.arch.lifecycle.ViewModelProvider;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.mapbox.api.geocoding.v5.MapboxGeocoding;
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
@@ -21,6 +15,12 @@ import com.mapbox.mapboxsdk.plugins.places.common.PlaceConstants;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/common/utils/ColorUtils.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/common/utils/ColorUtils.java
@@ -2,10 +2,11 @@ package com.mapbox.mapboxsdk.plugins.places.common.utils;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.support.annotation.AttrRes;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
 import android.util.TypedValue;
+
+import androidx.annotation.AttrRes;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
 
 public final class ColorUtils {
 

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/PlacePicker.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/PlacePicker.java
@@ -2,14 +2,15 @@ package com.mapbox.mapboxsdk.plugins.places.picker;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.plugins.places.common.PlaceConstants;
 import com.mapbox.mapboxsdk.plugins.places.picker.model.PlacePickerOptions;
 import com.mapbox.mapboxsdk.plugins.places.picker.ui.PlacePickerActivity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 
 public final class PlacePicker {

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/model/PlacePickerOptions.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/model/PlacePickerOptions.java
@@ -1,9 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.places.picker.model;
 
 import android.os.Parcelable;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.geocoding.v5.GeocodingCriteria.GeocodingTypeCriteria;
@@ -11,6 +8,10 @@ import com.mapbox.core.utils.TextUtils;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.plugins.places.common.model.BasePlaceOptions;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 @AutoValue
 public abstract class PlacePickerOptions implements BasePlaceOptions, Parcelable {

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/CurrentPlaceSelectionBottomSheet.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/CurrentPlaceSelectionBottomSheet.java
@@ -1,18 +1,19 @@
 package com.mapbox.mapboxsdk.plugins.places.picker.ui;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import android.support.design.widget.BottomSheetBehavior;
-import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
 import com.mapbox.mapboxsdk.places.R;
 
-import static android.support.design.widget.BottomSheetBehavior.STATE_COLLAPSED;
-import static android.support.design.widget.BottomSheetBehavior.STATE_HIDDEN;
+import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN;
 import static com.mapbox.mapboxsdk.plugins.places.common.utils.GeocodingUtils.removeNameFromAddress;
 
 public class CurrentPlaceSelectionBottomSheet extends CoordinatorLayout {

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/PlacePickerActivity.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/PlacePickerActivity.java
@@ -1,23 +1,18 @@
 package com.mapbox.mapboxsdk.plugins.places.picker.ui;
 
-import android.arch.lifecycle.Observer;
-import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.constraint.ConstraintLayout;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
+
+import androidx.annotation.NonNull;
 import android.view.View;
 import android.view.Window;
 import android.view.animation.OvershootInterpolator;
 import android.widget.ImageView;
 import android.widget.Toast;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
 import com.google.gson.JsonObject;
 import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
@@ -45,9 +40,15 @@ import com.mapbox.mapboxsdk.plugins.places.picker.viewmodel.PlacePickerViewModel
 import java.util.List;
 import java.util.Locale;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProviders;
 import timber.log.Timber;
 
-import static android.support.design.widget.Snackbar.LENGTH_LONG;
+import static com.google.android.material.snackbar.Snackbar.LENGTH_LONG;
 
 /**
  * Do not use this class directly, instead create an intent using the {@link IntentBuilder} inside

--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/viewmodel/PlacePickerViewModel.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/viewmodel/PlacePickerViewModel.java
@@ -1,9 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.places.picker.viewmodel;
 
 import android.app.Application;
-import android.arch.lifecycle.AndroidViewModel;
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
 
 import com.mapbox.api.geocoding.v5.MapboxGeocoding;
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
@@ -11,6 +8,9 @@ import com.mapbox.api.geocoding.v5.models.GeocodingResponse;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.plugins.places.picker.model.PlacePickerOptions;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.MutableLiveData;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;

--- a/plugin-places/src/main/res/layout/mapbox_activity_autocomplete.xml
+++ b/plugin-places/src/main/res/layout/mapbox_activity_autocomplete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/root_layout"
   android:layout_width="match_parent"
@@ -11,4 +11,4 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_activity_place_picker.xml
+++ b/plugin-places/src/main/res/layout/mapbox_activity_place_picker.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   tools:context="com.mapbox.mapboxsdk.plugins.places.picker.ui.PlacePickerActivity">
 
-  <android.support.design.widget.AppBarLayout
+  <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/place_picker_app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <include layout="@layout/mapbox_toolbar_place_picker"/>
 
-  </android.support.design.widget.AppBarLayout>
+  </com.google.android.material.appbar.AppBarLayout>
 
   <include layout="@layout/mapbox_content_place_picker"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/plugin-places/src/main/res/layout/mapbox_content_place_picker.xml
+++ b/plugin-places/src/main/res/layout/mapbox_content_place_picker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
@@ -51,4 +51,4 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_fragment_autocomplete_card.xml
+++ b/plugin-places/src/main/res/layout/mapbox_fragment_autocomplete_card.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/root_layout"
@@ -8,7 +8,7 @@
   android:background="@android:color/transparent"
   android:paddingTop="6dp">
 
-  <android.support.v7.widget.CardView
+  <androidx.cardview.widget.CardView
     android:id="@+id/cardView"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
@@ -31,7 +31,7 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"/>
-  </android.support.v7.widget.CardView>
+  </androidx.cardview.widget.CardView>
 
   <View
     android:id="@+id/scroll_drop_shadow"
@@ -71,7 +71,7 @@
         android:layout_height="wrap_content"
         android:visibility="gone"/>
 
-      <android.support.v7.widget.CardView
+      <androidx.cardview.widget.CardView
         android:id="@+id/offlineResultView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -88,7 +88,7 @@
 
         <include layout="@layout/mapbox_item_offline_message"/>
 
-      </android.support.v7.widget.CardView>
+      </androidx.cardview.widget.CardView>
 
 
       <com.mapbox.mapboxsdk.plugins.places.autocomplete.ui.ResultCardView
@@ -104,4 +104,4 @@
     </LinearLayout>
   </ScrollView>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_fragment_autocomplete_full.xml
+++ b/plugin-places/src/main/res/layout/mapbox_fragment_autocomplete_full.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:local="http://schemas.android.com/tools"
@@ -7,7 +7,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <android.support.constraint.ConstraintLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/toolbar"
     android:layout_width="0dp"
     android:layout_height="56dp"
@@ -31,9 +31,9 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"/>
 
-  </android.support.constraint.ConstraintLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 
-  <android.support.constraint.ConstraintLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="0dp"
     android:layout_height="0dp"
     app:layout_constraintBottom_toBottomOf="parent"
@@ -93,5 +93,5 @@
       </LinearLayout>
     </ScrollView>
 
-  </android.support.constraint.ConstraintLayout>
-</android.support.constraint.ConstraintLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_item_offline_message.xml
+++ b/plugin-places/src/main/res/layout/mapbox_item_offline_message.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
@@ -41,6 +41,6 @@
     android:text="@string/mapbox_plugins_offline_message"
     android:layout_marginLeft="64dp"
     android:layout_marginRight="16dp"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/plugin-places/src/main/res/layout/mapbox_item_search_result.xml
+++ b/plugin-places/src/main/res/layout/mapbox_item_search_result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -58,6 +58,6 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
     tools:text="The White House"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/plugin-places/src/main/res/layout/mapbox_toolbar_place_picker.xml
+++ b/plugin-places/src/main/res/layout/mapbox_toolbar_place_picker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -50,4 +50,4 @@
     app:layout_constraintTop_toTopOf="parent"
     app:srcCompat="@drawable/mapbox_ic_arrow_back"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_view_bottom_sheet_container.xml
+++ b/plugin-places/src/main/res/layout/mapbox_view_bottom_sheet_container.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="bottom">
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/user_location_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -21,7 +21,7 @@
         app:srcCompat="@drawable/mapbox_plugins_ic_user_location"
         app:useCompatPadding="true" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/place_chosen_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <View
             android:id="@+id/shadow"
@@ -64,4 +64,4 @@
 
     </LinearLayout>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/plugin-places/src/main/res/layout/mapbox_view_card_results.xml
+++ b/plugin-places/src/main/res/layout/mapbox_view_card_results.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -8,7 +8,7 @@
   android:layout_height="wrap_content"
   android:orientation="vertical">
 
-  <android.support.v7.widget.CardView
+  <androidx.cardview.widget.CardView
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_marginBottom="4dp"
@@ -36,5 +36,5 @@
       tools:layout_editor_absoluteX="5dp"
       tools:layout_editor_absoluteY="6dp"/>
 
-  </android.support.v7.widget.CardView>
-</android.support.constraint.ConstraintLayout>
+  </androidx.cardview.widget.CardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_view_details_bottom_header.xml
+++ b/plugin-places/src/main/res/layout/mapbox_view_details_bottom_header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -59,4 +59,4 @@
     app:layout_constraintLeft_toLeftOf="parent"
     app:layout_constraintRight_toRightOf="parent"
     app:layout_constraintTop_toTopOf="parent"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_view_results.xml
+++ b/plugin-places/src/main/res/layout/mapbox_view_results.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content">
 
-  <android.support.v7.widget.RecyclerView
+  <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/rv_search_results"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -21,5 +21,5 @@
     app:layout_constraintStart_toStartOf="parent"
     tools:listitem="@layout/mapbox_item_search_result">
 
-  </android.support.v7.widget.RecyclerView>
-</android.support.constraint.ConstraintLayout>
+  </androidx.recyclerview.widget.RecyclerView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-places/src/main/res/layout/mapbox_view_search.xml
+++ b/plugin-places/src/main/res/layout/mapbox_view_search.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
@@ -68,4 +68,4 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
     app:srcCompat="@drawable/mapbox_ic_arrow_back"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugin-scalebar/build.gradle
+++ b/plugin-scalebar/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     configurations {

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
@@ -1,11 +1,12 @@
 package com.mapbox.pluginscalebar;
 
 import android.content.Context;
-import android.support.annotation.ColorRes;
-import android.support.annotation.DimenRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
-import android.support.v4.content.ContextCompat;
+
+import androidx.annotation.ColorRes;
+import androidx.annotation.DimenRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import androidx.core.content.ContextCompat;
 
 import java.util.Locale;
 

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
@@ -1,8 +1,5 @@
 package com.mapbox.pluginscalebar;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -10,6 +7,10 @@ import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Projection;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 
 /**
  * Plugin class that shows a scale bar on MapView and changes the scale corresponding to the MapView's scale.

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarWidget.java
@@ -5,14 +5,15 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.os.Handler;
 import android.os.Message;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
 import android.util.Pair;
 import android.view.View;
 
 import java.lang.ref.WeakReference;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
 
 import static com.mapbox.pluginscalebar.ScaleBarConstants.FEET_PER_MILE;
 import static com.mapbox.pluginscalebar.ScaleBarConstants.KILOMETER;

--- a/plugin-traffic/build.gradle
+++ b/plugin-traffic/build.gradle
@@ -6,7 +6,7 @@ android {
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   configurations {

--- a/plugin-traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
+++ b/plugin-traffic/src/main/java/com/mapbox/mapboxsdk/plugins/traffic/TrafficPlugin.java
@@ -1,11 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.traffic;
 
 import android.graphics.Color;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.annotation.VisibleForTesting;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -22,6 +17,11 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;


### PR DESCRIPTION
This pr switches this repo's plugins and related files to AndroidX. 

These changes follow the `9.0.0` Maps SDK release, which introduced AndroidX in https://github.com/mapbox/mapbox-gl-native-android/pull/129/files and went out in https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.0.0-alpha.1

The Java SDK switch to AndroidX happened at https://github.com/mapbox/mapbox-java/pull/1095 and went out in the `5.0.0` release: https://github.com/mapbox/mapbox-java/releases/tag/v5.0.0