### PR TITLE
 Release new versions of all plugins with v9 prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Plugins are single-purpose libraries built on top of the [Mapbox Maps SDK for An
  
 * [**Traffic:** Adds a real-time traffic layer to any Mapbox base map.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-traffic)
 
-* [**Location layer:** Add a location marker on your map indicating the user's location.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-locationlayer)
+* [**Location layer:** [Deprecated] Add a location marker on your map indicating the user's location.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-locationlayer)
 
 * [**Building:** Add extruded "3D" buildings in your map style.](https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-building)
 

--- a/plugin-annotation/CHANGELOG.md
+++ b/plugin-annotation/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-annotation-v9:0.8.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Expose underlying, generated Layer ID [#1071](https://github.com/mapbox/mapbox-plugins-android/pull/1071)
+
 ### mapbox-android-plugin-annotation-v8:0.7.0 - June 11, 2019
 #### Features
 - uppercase static fields [#939](https://github.com/mapbox/mapbox-plugins-android/pull/939)

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.7.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 }
 ```
 
@@ -48,7 +48,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.8.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-annotation/gradle.properties
+++ b/plugin-annotation/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.8.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-annotation-v8
+VERSION_NAME=0.9.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-annotation-v9
 POM_NAME=Mapbox Android Annotation Plugin
 POM_DESCRIPTION=Mapbox Android Annotation Plugin
 POM_PACKAGING=aar

--- a/plugin-building/CHANGELOG.md
+++ b/plugin-building/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-building-v9:0.7.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Make LAYER_ID of BuildingPlugin public [#997](https://github.com/mapbox/mapbox-plugins-android/pull/997)
+
 ### mapbox-android-plugin-building-v8:0.6.0 - June 11, 2019
 
 No changes since last release. Release happened to update the module to `-v8`. 

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v8:0.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v9:0.7.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v8:0.7.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v9:0.8.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-building/gradle.properties
+++ b/plugin-building/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.7.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-building-v8
+VERSION_NAME=0.8.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-building-v9
 POM_NAME=Mapbox Android Building Plugin
 POM_DESCRIPTION=Mapbox Android Building Plugin
 POM_PACKAGING=aar

--- a/plugin-localization/CHANGELOG.md
+++ b/plugin-localization/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-localization-v9:0.12.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+
+#### Bugs
+- Switch Timber log level to debug for setMapLanguage [#1085](https://github.com/mapbox/mapbox-plugins-android/pull/1085)
+
 ### mapbox-android-plugin-localization-v8:0.11.0 - August 20, 2019
 #### Features
 - adjusted Timber.e to Timber.d [#993](https://github.com/mapbox/mapbox-plugins-android/pull/993)

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.11.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.12.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.13.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-localization/gradle.properties
+++ b/plugin-localization/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.12.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-localization-v8
+VERSION_NAME=0.13.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-localization-v9
 POM_NAME=Mapbox Android Localization Plugin
 POM_DESCRIPTION=Mapbox Android Localization Plugin
 POM_PACKAGING=aar

--- a/plugin-markerview/CHANGELOG.md
+++ b/plugin-markerview/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-markerview-v9:0.4.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+
 ### mapbox-android-plugin-markerview-v8:0.3.0 - June 11, 2019
 #### Features
 - remove obsolete build tools declaration [#827](https://github.com/mapbox/mapbox-plugins-android/pull/827)

--- a/plugin-markerview/README.md
+++ b/plugin-markerview/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v8:0.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0'
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v8:0.4.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.5.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-markerview/gradle.properties
+++ b/plugin-markerview/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.4.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-markerview-v8
+VERSION_NAME=0.5.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-markerview-v9
 POM_NAME=Mapbox Android MarkerView Plugin
 POM_DESCRIPTION=Mapbox Android MarkerView Plugin
 POM_PACKAGING=aar

--- a/plugin-offline/CHANGELOG.md
+++ b/plugin-offline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-offline-v9:0.7.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+
 ### mapbox-android-plugin-offline-v8:0.6.0 - June 11, 2019
 
 No changes since last release. Release happened to update the module to `-v8`. 

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v8:0.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v9:0.7.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v8:0.7.0-SNAPSHOT'
+	implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v9:0.8.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-offline/gradle.properties
+++ b/plugin-offline/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.7.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-offline-v8
+VERSION_NAME=0.8.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-offline-v9
 POM_NAME=Mapbox Android Offline Plugin
 POM_DESCRIPTION=Mapbox Android Offline Plugin
 POM_PACKAGING=aar

--- a/plugin-places/CHANGELOG.md
+++ b/plugin-places/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-places-v9:0.10.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Added user location button to Places Plugin's PlacePickerActivity [#994](https://github.com/mapbox/mapbox-plugins-android/pull/994)
+
 ### mapbox-android-plugin-places-v8:0.9.0 - June 11, 2019
 #### Features
 - Adding visual limit option to the number of recently seached places [#922](https://github.com/mapbox/mapbox-plugins-android/pull/922)

--- a/plugin-places/README.md
+++ b/plugin-places/README.md
@@ -21,7 +21,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v8:0.9.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v9:0.10.0'
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v8:0.10.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v9:0.11.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-places/gradle.properties
+++ b/plugin-places/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.10.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-places-v8
+VERSION_NAME=0.11.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-places-v9
 POM_NAME=Mapbox Android Places Plugin
 POM_DESCRIPTION=Mapbox Android Places Plugin
 POM_PACKAGING=aar

--- a/plugin-scalebar/CHANGELOG.md
+++ b/plugin-scalebar/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-scalebar-v9:0.4.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+#### Bugs
+- Fix scale bar incorrect scale [#1088](https://github.com/mapbox/mapbox-plugins-android/pull/1088)
+
 ### mapbox-android-plugin-scalebar-v8:0.3.0 - August 20, 2019
 
 #### Features

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -18,7 +18,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v8:0.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v9:0.4.0'
 }
 ```
 
@@ -35,7 +35,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v8:0.4.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v9:0.5.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-scalebar/gradle.properties
+++ b/plugin-scalebar/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.4.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-scalebar-v8
+VERSION_NAME=0.5.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-scalebar-v9
 POM_NAME=Mapbox Android Scalebar Plugin
 POM_DESCRIPTION=Mapbox Android Scalebar Plugin
 POM_PACKAGING=aar

--- a/plugin-traffic/CHANGELOG.md
+++ b/plugin-traffic/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for the Mapbox traffic plugin
 
+### mapbox-android-plugin-traffic-v9:0.10.0 - March 5, 2020
+#### Features
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+
 ### mapbox-android-plugin-traffic-v8:0.9.0 - June 11, 2019
 
 No changes since last release. Release happened to update the module to `-v8`.

--- a/plugin-traffic/README.md
+++ b/plugin-traffic/README.md
@@ -20,7 +20,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v8:0.9.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v9:0.10.0'
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v8:0.10.0-SNAPSHOT'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic-v9:0.11.0-SNAPSHOT'
 }
 ```
 

--- a/plugin-traffic/gradle.properties
+++ b/plugin-traffic/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.10.0-SNAPSHOT
-POM_ARTIFACT_ID=mapbox-android-plugin-traffic-v8
+VERSION_NAME=0.11.0-SNAPSHOT
+POM_ARTIFACT_ID=mapbox-android-plugin-traffic-v9
 POM_NAME=Mapbox Android Traffic Plugin
 POM_DESCRIPTION=Mapbox Android Traffic Plugin
 POM_PACKAGING=aar


### PR DESCRIPTION
This pr addresses https://github.com/mapbox/mapbox-plugins-android/issues/1102 by doing a new release of all of our plugins.