### PR TITLE
Fix scalebar not show correctly when pixelRatio is set.

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
@@ -109,7 +109,7 @@ public class ScaleBarPlugin {
   private void invalidateScaleBar() {
     CameraPosition cameraPosition = mapboxMap.getCameraPosition();
     scaleBarWidget.setDistancePerPixel((projection.getMetersPerPixelAtLatitude(cameraPosition.target.getLatitude()))
-      / mapView.getContext().getResources().getDisplayMetrics().density);
+      / mapView.getPixelRatio());
   }
 
   private void addCameraListeners() {

--- a/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
@@ -50,6 +50,7 @@ class ScaleBarPluginTest {
     every { mapboxMap.cameraPosition } returns CameraPosition.DEFAULT
     every { scaleBarOptions.build() } returns scaleBarWidget
     every { mapView.context} returns context
+    every { mapView.pixelRatio } returns 2f
     every { context.resources} returns resources
     every { resources.displayMetrics} returns displayMetrics
   }


### PR DESCRIPTION
Resolves #1093 
This pr use `mapView.getPixelRatio()` to calculate the correct DistancePerPixel value for scale bar