### PR TITLE
Include a new label (`confirmed`) that will be exempted by stalebot.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,7 @@ limitPerRun: 1
 # SEMVER-MAJOR - @tobrun
 exemptLabels:
   - SEMVER-MAJOR
+  - confirmed
 
 pulls:
   daysUntilStale: 60

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Note that depending on the plugin you add, there might be required permissions a
 2. Open up your application's `build.gradle`
 3. Make sure that your project's `minSdkVersion` is at API 14 or higher
 4. Under dependencies, add a new build rule for the latest plugin version you are trying to use.
-
 ```gradle
 repositories {
   mavenCentral()

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Note that depending on the plugin you add, there might be required permissions a
 2. Open up your application's `build.gradle`
 3. Make sure that your project's `minSdkVersion` is at API 14 or higher
 4. Under dependencies, add a new build rule for the latest plugin version you are trying to use.
+
 ```gradle
 repositories {
   mavenCentral()


### PR DESCRIPTION
This PR proposes including a new `confirmed` label in the Stale bot configuration that will be exempted, in addition to the existing `SEMVER-MAJOR`. This label can be applied to tickets that have been confirmed, include all the necessary information to be actionable, and are expected to continue to be relevant for a period of time longer than the default `daysUntilStale` value.

As an initial example, I'm using this new label with https://github.com/mapbox/mapbox-plugins-android/issues/1044.