### PR TITLE
[places] Setting reverse geocoding BottomSheetBehavior hideable to true

### DIFF
--- a/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/CurrentPlaceSelectionBottomSheet.java
+++ b/plugin-places/src/main/java/com/mapbox/mapboxsdk/plugins/places/picker/ui/CurrentPlaceSelectionBottomSheet.java
@@ -77,7 +77,8 @@ public class CurrentPlaceSelectionBottomSheet extends CoordinatorLayout {
 
   private void toggleBottomSheet() {
     bottomSheetBehavior.setPeekHeight(rootView.findViewById(R.id.bottom_sheet_header).getHeight());
-    bottomSheetBehavior.setHideable(isShowing());
-    bottomSheetBehavior.setState(isShowing() ? STATE_HIDDEN : STATE_COLLAPSED);
+    boolean isShowing = isShowing();
+    bottomSheetBehavior.setHideable(isShowing);
+    bottomSheetBehavior.setState(isShowing ? STATE_HIDDEN : STATE_COLLAPSED);
   }
 }


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-plugins-android/issues/908 by adjusting the Places Plugin's BottomSheetBehavior.

cc @orlikraf, who had a helpful comment at https://github.com/mapbox/mapbox-plugins-android/issues/908#issuecomment-596203513