### PR TITLE
Update scale bar style to show text border.

### DIFF
--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -90,6 +90,37 @@ public class ScaleBarTest extends BaseActivityTest {
   }
 
   @Test
+  public void testTextBorder() {
+    validateTestSetup();
+    setupScaleBar();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_text_border_width),
+        scaleBarWidget.getTextBorderWidth(), 0);
+      assertTrue(scaleBarWidget.isShowTextBorder());
+
+      ScaleBarOptions option = new ScaleBarOptions(activity);
+      option.setTextBorderWidth(R.dimen.fab_margin);
+      scaleBarWidget = scaleBarPlugin.create(option);
+      assertNotNull(scaleBarWidget);
+
+      assertEquals(activity.getResources().getDimension(R.dimen.fab_margin),
+        scaleBarWidget.getTextBorderWidth(), 0);
+
+      option = new ScaleBarOptions(activity);
+      option.setTextBorderWidth(100f);
+      scaleBarWidget = scaleBarPlugin.create(option);
+      assertNotNull(scaleBarWidget);
+      assertEquals(100f, scaleBarWidget.getTextBorderWidth(), 0);
+
+      option = new ScaleBarOptions(activity);
+      option.setShowTextBorder(false);
+      scaleBarWidget = scaleBarPlugin.create(option);
+      assertNotNull(scaleBarWidget);
+      assertFalse(scaleBarWidget.isShowTextBorder());
+    });
+  }
+
+  @Test
   public void testScaleBarWidth() {
     validateTestSetup();
     setupScaleBar();
@@ -252,7 +283,7 @@ public class ScaleBarTest extends BaseActivityTest {
   public void testRatio() {
     validateTestSetup();
     setupScaleBar();
-    assertEquals(0.5f,scaleBarWidget.getRatio(), 0f);
+    assertEquals(0.5f, scaleBarWidget.getRatio(), 0f);
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       ScaleBarOptions option = new ScaleBarOptions(activity);
       option.setMaxWidthRatio(0.1f);

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -38,15 +38,17 @@ class ScalebarActivity : AppCompatActivity() {
         val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
         val scaleBarOptions = ScaleBarOptions(this)
         scaleBarOptions
-                .setTextColor(R.color.mapboxRed)
-                .setTextSize(20f)
-                .setBarHeight(15f)
-                .setBorderWidth(5f)
+                .setTextColor(android.R.color.black)
+                .setTextSize(40f)
+                .setBarHeight(5f)
+                .setBorderWidth(2f)
                 .setRefreshInterval(15)
                 .setMarginTop(15f)
                 .setMarginLeft(16f)
                 .setTextBarMargin(15f)
                 .setMaxWidthRatio(0.5f)
+                .setShowTextBorder(true)
+                .setTextBorderWidth(5f)
 
         scaleBarPlugin.create(scaleBarOptions)
         fabScaleWidget.setOnClickListener {

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarConstants.java
@@ -11,7 +11,7 @@ class ScaleBarConstants {
   static String METER_UNIT = " m";
   static String FEET_UNIT = " ft";
   static String KILOMETER_UNIT = " km";
-  static String MILE_UNIT = " mile";
+  static String MILE_UNIT = " mi";
   static ArrayList<Pair<Integer, Integer>> metricTable = new ArrayList<Pair<Integer, Integer>>() {
     {
       add(new Pair<>(1, 2));

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
@@ -30,6 +30,8 @@ public class ScaleBarOptions {
   private float textSize;
   private boolean isMetricUnit;
   private float ratio;
+  private boolean showTextBorder;
+  private float textBorderWidth;
 
   public ScaleBarOptions(@NonNull Context context) {
     this.context = context;
@@ -40,6 +42,8 @@ public class ScaleBarOptions {
     setMarginTop(R.dimen.mapbox_scale_bar_margin_top);
     setMarginLeft(R.dimen.mapbox_scale_bar_margin_left);
     setTextBarMargin(R.dimen.mapbox_scale_bar_text_margin);
+    setTextBorderWidth(R.dimen.mapbox_scale_bar_border_width);
+    setShowTextBorder(true);
     isMetricUnit = LocaleUnitResolver.isMetricSystem();
     setTextColor(android.R.color.black);
     setPrimaryColor(android.R.color.black);
@@ -66,6 +70,8 @@ public class ScaleBarOptions {
     scaleBarWidget.setTextColor(textColor);
     scaleBarWidget.setTextSize(textSize);
     scaleBarWidget.setRatio(ratio);
+    scaleBarWidget.setShowTextBorder(showTextBorder);
+    scaleBarWidget.setTextBorderWidth(textBorderWidth);
     return scaleBarWidget;
   }
 
@@ -180,6 +186,40 @@ public class ScaleBarOptions {
    */
   public ScaleBarOptions setBorderWidth(@DimenRes int borderWidth) {
     this.borderWidth = context.getResources().getDimension(borderWidth);
+    return this;
+  }
+
+  /**
+   * Set the border width for texts in scale bar.
+   *
+   * @param textBorderWidth the border width for texts in scale bar, in dp.
+   * @return this.
+   */
+  public ScaleBarOptions setTextBorderWidth(@DimenRes int textBorderWidth) {
+    this.textBorderWidth = context.getResources().getDimension(textBorderWidth);
+    return this;
+  }
+
+
+  /**
+   * Set the border width for texts in scale bar.
+   *
+   * @param textBorderWidth the border width for texts in scale bar, in pixel.
+   * @return this.
+   */
+  public ScaleBarOptions setTextBorderWidth(float textBorderWidth) {
+    this.textBorderWidth = textBorderWidth;
+    return this;
+  }
+
+  /**
+   * Set whether to show the text border.
+   *
+   * @param showTextBorder whether to show the text border or not.
+   * @return this.
+   */
+  public ScaleBarOptions setShowTextBorder(boolean showTextBorder) {
+    this.showTextBorder = showTextBorder;
     return this;
   }
 

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarOptions.java
@@ -42,7 +42,7 @@ public class ScaleBarOptions {
     setMarginTop(R.dimen.mapbox_scale_bar_margin_top);
     setMarginLeft(R.dimen.mapbox_scale_bar_margin_left);
     setTextBarMargin(R.dimen.mapbox_scale_bar_text_margin);
-    setTextBorderWidth(R.dimen.mapbox_scale_bar_border_width);
+    setTextBorderWidth(R.dimen.mapbox_scale_bar_text_border_width);
     setShowTextBorder(true);
     isMetricUnit = LocaleUnitResolver.isMetricSystem();
     setTextColor(android.R.color.black);

--- a/plugin-scalebar/src/main/res/values/dimens.xml
+++ b/plugin-scalebar/src/main/res/values/dimens.xml
@@ -5,5 +5,6 @@
     <dimen name="mapbox_scale_bar_text_margin">2dp</dimen>
     <dimen name="mapbox_scale_bar_text_size">8dp</dimen>
     <dimen name="mapbox_scale_bar_border_width">1dp</dimen>
-    <dimen name="mapbox_scale_bar_height">4dp</dimen>
+    <dimen name="mapbox_scale_bar_height">2dp</dimen>
+    <dimen name="mapbox_scale_bar_text_border_width">2dp</dimen>
 </resources>


### PR DESCRIPTION
This pr changes the style for scale bar, including:
1. Reduce the default height of scale bar
2. Add text border and APIs for setting
3. Change unit "mile" to "mi".

Fixs #1058 
![image](https://user-images.githubusercontent.com/8577318/80365072-9b0eff00-88b9-11ea-9ae9-562776dc67bd.png)
