### PR TITLE
Java SDK bump to 5.2.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,8 @@
 
   version = [
       mapboxMapSdk       : '9.1.0',
-      mapboxJava         : '5.1.0',
-      mapboxTurf         : '5.1.0',
+      mapboxJava         : '5.2.1',
+      mapboxTurf         : '5.2.1',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.6',


### PR DESCRIPTION
Part of the 5.2.1 release of the Mapbox Java SDK https://github.com/mapbox/mapbox-java/issues/1147