### PR TITLE
Implement cancel draggable during onAnnotationDrag

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -103,12 +103,13 @@ public class CircleActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onAnnotationDrag(Circle annotation) {
+        public boolean onAnnotationDrag(Circle annotation) {
           draggableInfoTv.setText(String.format(
             Locale.US,
             "ID: %s\nLatLng:%f, %f",
             annotation.getId(),
             annotation.getLatLng().getLatitude(), annotation.getLatLng().getLongitude()));
+          return true;
         }
 
         @Override

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -142,12 +142,13 @@ public class SymbolActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onAnnotationDrag(Symbol annotation) {
+        public boolean onAnnotationDrag(Symbol annotation) {
           draggableInfoTv.setText(String.format(
             Locale.US,
             "ID: %s\nLatLng:%f, %f",
             annotation.getId(),
             annotation.getLatLng().getLatitude(), annotation.getLatLng().getLongitude()));
+          return true;
         }
 
         @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -101,13 +101,18 @@ final class DraggableAnnotationController<T extends Annotation, D extends OnAnno
       );
 
       if (shiftedGeometry != null) {
+        Geometry oldGeometry = draggedAnnotation.geometry;
         draggedAnnotation.setGeometry(
           shiftedGeometry
         );
         annotationManager.internalUpdateSource();
         if (!annotationManager.getDragListeners().isEmpty()) {
           for (D d : annotationManager.getDragListeners()) {
-            d.onAnnotationDrag(draggedAnnotation);
+            if (!d.onAnnotationDrag(draggedAnnotation)) {
+              draggedAnnotation.setGeometry(oldGeometry);
+              stopDragging(draggedAnnotation);
+              return true;
+            }
           }
         }
         return true;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/OnAnnotationDragListener.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/OnAnnotationDragListener.java
@@ -18,8 +18,9 @@ public interface OnAnnotationDragListener<T extends Annotation> {
    * Called when an annotation dragging is in progress.
    *
    * @param annotation the annotation
+   * @return False if this drag should be canceled, true otherwise.
    */
-  void onAnnotationDrag(T annotation);
+  boolean onAnnotationDrag(T annotation);
 
   /**
    * Called when an annotation dragging has finished.


### PR DESCRIPTION
While using this plugin, I needed to cancel a drag event when my point was further apart from another location. The way I solved this was by deleting the point and repainting it so that cancel the drag event. The problem is that it's not efficient at all.

Here is a proposal to allow a drag event to be canceled directly in the `dragEventListener`. I would be pleased to have your feedback @langsmith and @LukasPaczos.

Thanks in advance