### PR TITLE
Cancel download should remove currently downloaded map

### DIFF
--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
@@ -156,10 +156,10 @@ public class OfflineDownloadService extends Service {
       createMapSnapshot(offlineDownload.definition(), new MapSnapshotter.SnapshotReadyCallback() {
         @Override
         public void onSnapshotReady(MapSnapshot snapshot) {
-          final int regionId = offlineDownload.uuid().intValue();
+          final Long regionId = offlineDownload.uuid();
           if (regionLongSparseArray.get(regionId) != null) {
             notificationBuilder.setLargeIcon(snapshot.getBitmap());
-            notificationManager.notify(regionId, notificationBuilder.build());
+            notificationManager.notify(regionId.intValue(), notificationBuilder.build());
           }
         }
       });
@@ -180,7 +180,7 @@ public class OfflineDownloadService extends Service {
   }
 
   private void cancelDownload(final OfflineDownloadOptions offlineDownload) {
-    int serviceId = offlineDownload.uuid().intValue();
+    final Long serviceId = offlineDownload.uuid();
     OfflineRegion offlineRegion = regionLongSparseArray.get(serviceId);
     if (offlineRegion != null) {
       offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
@@ -198,7 +198,7 @@ public class OfflineDownloadService extends Service {
       });
     }
     OfflineDownloadStateReceiver.dispatchCancelBroadcast(getApplicationContext(), offlineDownload);
-    removeOfflineRegion(serviceId);
+    removeOfflineRegion(serviceId.intValue());
   }
 
   private synchronized void removeOfflineRegion(int regionId) {


### PR DESCRIPTION
I had a look at the code of the offline plugin and find out what might cause the cancel download not to delete the currently downloading map.

This is a PR to fix issue #189 

Note : I have not been able to actually test that this fix the issue as there is no cancel button in the demo app but in any case what I changed seems incorrect to me and might prevent the map to be deleted.

Any comment and review is most welcome @tobrun, @LukasPaczos and @langsmith 