### PR TITLE
Update underlying maps sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,23 @@ Note that depending on the plugin you add, there might be required permissions a
 ```gradle
 repositories {
   mavenCentral()
+  maven {
+    url 'https://api.mapbox.com/downloads/v2/releases/maven'
+    authentication {
+      basic(BasicAuthentication)
+    }
+    credentials {
+      username "mapbox"
+      password = "SDK_REGISTRY_TOKEN"
+    }
+  }
 }
 
 dependencies {
   implementation 'com.mapbox.mapboxsdk:{PLUGIN_NAME}-v{MAJOR_MAPS_SDK_VERSION_NUMBER}:PLUGIN_VERSION_NUMBER'
 }
 ```
+5. Replace SDK_REGISTRY_TOKEN with a Mapbox access token that has the downloads scope
 
 Plugin artifacts are versioned based on the major release of the Maps SDK for Android, which means, that each artifact's name has a major version of the Maps SDK it's compatible with appended.
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,16 @@ allprojects {
   repositories {
     google()
     jcenter()
+    maven {
+      url 'https://api.mapbox.com/downloads/v2/releases/maven'
+      authentication {
+        basic(BasicAuthentication)
+      }
+      credentials {
+        username "mapbox"
+        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
+      }
+    }
 //    SNAPSHOT repository
 //    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
 //    maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '9.2.0',
+      mapboxMapSdk       : '9.4.0',
       mapboxJava         : '5.4.1',
       mapboxTurf         : '5.4.1',
       playLocation       : '16.0.0',


### PR DESCRIPTION
To validate https://github.com/mapbox/mapbox-plugins-android/issues/1130 and making this repo future proof. This PR updates our Maps SDK version to 9.4.0 and adds configuration for using the Mapbox SDK registry. This change has been reflected in the documentation as part of the readme.