### PR TITLE
Bumped Java SDK dependencies to 5.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,8 @@
 
   version = [
       mapboxMapSdk       : '9.4.0',
-      mapboxJava         : '5.4.1',
-      mapboxTurf         : '5.4.1',
+      mapboxJava         : '5.5.0',
+      mapboxTurf         : '5.5.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.6',


### PR DESCRIPTION
Part of the `5.5.0` Java SDK release https://github.com/mapbox/mapbox-java/issues/1175