### PR TITLE
Prevent annotation changes from invalidating unrelated drag actions

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -131,7 +131,7 @@ public abstract class AnnotationManager<
     T t = options.build(currentId, this);
     annotations.put(t.getId(), t);
     currentId++;
-    updateSource();
+    internalUpdateSource();
     return t;
   }
 
@@ -150,7 +150,7 @@ public abstract class AnnotationManager<
       annotations.put(annotation.getId(), annotation);
       currentId++;
     }
-    updateSource();
+    internalUpdateSource();
     return annotationList;
   }
 
@@ -162,7 +162,8 @@ public abstract class AnnotationManager<
   @UiThread
   public void delete(T annotation) {
     annotations.remove(annotation.getId());
-    updateSource();
+    draggableAnnotationController.onAnnotationUpdated(annotation);
+    internalUpdateSource();
   }
 
   /**
@@ -174,8 +175,9 @@ public abstract class AnnotationManager<
   public void delete(List<T> annotationList) {
     for (T annotation : annotationList) {
       annotations.remove(annotation.getId());
+      draggableAnnotationController.onAnnotationUpdated(annotation);
     }
-    updateSource();
+    internalUpdateSource();
   }
 
   /**
@@ -196,7 +198,8 @@ public abstract class AnnotationManager<
   public void update(T annotation) {
     if (annotations.containsValue(annotation)) {
       annotations.put(annotation.getId(), annotation);
-      updateSource();
+      draggableAnnotationController.onAnnotationUpdated(annotation);
+      internalUpdateSource();
     } else {
       Logger.e(TAG, "Can't update annotation: "
         + annotation.toString()
@@ -213,12 +216,13 @@ public abstract class AnnotationManager<
   public void update(List<T> annotationList) {
     for (T annotation : annotationList) {
       annotations.put(annotation.getId(), annotation);
+      draggableAnnotationController.onAnnotationUpdated(annotation);
     }
-    updateSource();
+    internalUpdateSource();
   }
 
   /**
-   * Trigger an update to the underlying source
+   * Trigger an update to the underlying source. Invalidates active drags.
    */
   public void updateSource() {
     draggableAnnotationController.onSourceUpdated();

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -97,6 +97,12 @@ final class DraggableAnnotationController {
     }
   }
 
+  void onAnnotationUpdated(Annotation annotation) {
+    if (annotation == draggedAnnotation) {
+      stopDragging(draggedAnnotation, draggedAnnotationManager);
+    }
+  }
+
   void onSourceUpdated() {
     stopDragging(draggedAnnotation, draggedAnnotationManager);
   }


### PR DESCRIPTION
Relates to, but does not resolve, #1029 

### Motivation for change

I have a use case where markers on the map are 'linked' together via lines. As the user drags a marker, it is necessary that the line is programmatically updated as well. Due to the current logic which ensures data integrity, updates to the associated lines invalidate/stop the drag action.

This simple change adds a new method to the `DraggableAnnotationController` which allows the `AnnotationManager` to notify the controller of more fine-grain changes to the map source. If the change wasn't to the dragged annotation, the drag will continue.

### Future work

As stated above, this does not resolve #1029, which asks that changes to certain attributes of a dragged annotation don't stop the drag action. For example, a circle should be able to change size while being dragged, as this does not logically interfere with the annotation moving. 

Although not included in this PR, a solution to that could be to add a field/method to the `Annotation` class which computes a 'drag integrity hash' which hashes all fields that must remain static during a drag. When a drag starts, the `DraggableAnnotationManager` can take note of this hash. When notified of an update, the controller can check the current integrity hash of the annotation, and if it doesn't match the original stop the drag. 

If that solution is agreeable, I can update this PR to include that.