### PR TITLE
Improve MarkerView flick behavior

### DIFF
--- a/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
+++ b/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
@@ -13,7 +13,7 @@ import androidx.annotation.UiThread;
 /**
  * Class responsible for synchronising views at a LatLng on top of a Map.
  */
-public class MarkerViewManager implements MapView.OnCameraDidChangeListener {
+public class MarkerViewManager implements MapView.OnCameraDidChangeListener, MapView.OnCameraIsChangingListener {
 
   private final MapView mapView;
   private final MapboxMap mapboxMap;
@@ -41,6 +41,7 @@ public class MarkerViewManager implements MapView.OnCameraDidChangeListener {
   public void onDestroy() {
     markers.clear();
     mapView.removeOnCameraDidChangeListener(this);
+    mapView.removeOnCameraIsChangingListener(this);
     initialised = false;
   }
 
@@ -58,6 +59,7 @@ public class MarkerViewManager implements MapView.OnCameraDidChangeListener {
     if (!initialised) {
       initialised = true;
       mapView.addOnCameraDidChangeListener(this);
+      mapView.addOnCameraIsChangingListener(this);
     }
     markerView.setProjection(mapboxMap.getProjection());
     mapView.addView(markerView.getView());
@@ -88,6 +90,11 @@ public class MarkerViewManager implements MapView.OnCameraDidChangeListener {
 
   @Override
   public void onCameraDidChange(boolean animated) {
+    update();
+  }
+
+  @Override
+  public void onCameraIsChanging() {
     update();
   }
 }


### PR DESCRIPTION
## Background
MarkerView position is only updated with`onCameraDidChange`. When a user flicks the map, MarkerView keeps the position until the flick animation is finished as below. This behavior looks laggy from user point of view.
![before](https://user-images.githubusercontent.com/13183117/99398316-98dcc280-2927-11eb-9132-b8b0910cf70d.gif)

## Update
Call `update()` in `onCameraIsChanging` as well.

## Result
![after](https://user-images.githubusercontent.com/13183117/99398383-af831980-2927-11eb-8332-92e65856d286.gif)
 