### PR TITLE
[annotation-plugin] add support for clustering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -160,6 +160,17 @@
               android:value=".activity.FeatureOverviewActivity" />
     </activity>
     <activity
+        android:name=".activity.annotation.ClusterSymbolActivity"
+        android:description="@string/description_symbol_cluster"
+        android:label="@string/title_symbol_cluster">
+      <meta-data
+          android:name="@string/category"
+          android:value="@string/category_annotation" />
+      <meta-data
+          android:name="android.support.PARENT_ACTIVITY"
+          android:value=".activity.FeatureOverviewActivity" />
+    </activity>
+    <activity
             android:name=".activity.annotation.DynamicSymbolChangeActivity"
             android:description="@string/description_symbol_change"
             android:label="@string/title_symbol_change">

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
@@ -1,0 +1,232 @@
+package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.os.AsyncTask;
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.util.Pair;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.plugins.annotation.ClusterOptions;
+import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
+import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
+import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
+import com.mapbox.mapboxsdk.plugins.testapp.R;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.ref.WeakReference;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import timber.log.Timber;
+
+/**
+ * Test activity showcasing adding a large amount of Symbols with a cluster configuration.
+ */
+public class ClusterSymbolActivity extends AppCompatActivity {
+
+  private SymbolManager symbolManager;
+  private List<Symbol> symbols = new ArrayList<>();
+
+  private MapboxMap mapboxMap;
+  private MapView mapView;
+  private FeatureCollection locations;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_cluster);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this::initMap);
+  }
+
+  private void initMap(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    mapboxMap.moveCamera(
+      CameraUpdateFactory.newLatLngZoom(
+        new LatLng(38.87031, -77.00897), 10
+      )
+    );
+
+    ClusterOptions clusterOptions = new ClusterOptions()
+      .withColorLevels(new Pair[] {
+        new Pair(100, Color.RED),
+        new Pair(50, Color.BLUE),
+        new Pair(0, Color.GREEN)
+      });
+
+    mapboxMap.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS), style -> {
+      symbolManager = new SymbolManager(mapView, mapboxMap, style, null, clusterOptions);
+      symbolManager.setIconAllowOverlap(true);
+      loadData();
+    });
+  }
+
+  private void loadData() {
+    int amount = 10000;
+    if (locations == null) {
+      new LoadLocationTask(this, amount).execute();
+    } else {
+      showMarkers(amount);
+    }
+  }
+
+  private void onLatLngListLoaded(FeatureCollection featureCollection, int amount) {
+    locations = featureCollection;
+    showMarkers(amount);
+  }
+
+  private void showMarkers(int amount) {
+    if (mapboxMap == null || locations == null || locations.features() == null || mapView.isDestroyed()) {
+      return;
+    }
+    // delete old symbols
+    symbolManager.delete(symbols);
+    if (locations.features().size() < amount) {
+      amount = locations.features().size();
+    }
+
+    showSymbols(amount);
+  }
+
+  private void showSymbols(int amount) {
+    List<SymbolOptions> options = new ArrayList<>();
+    Random random = new Random();
+    int randomIndex;
+
+    List<Feature> features = locations.features();
+    if (features == null) {
+      return;
+    }
+
+    for (int i = 0; i < amount; i++) {
+      randomIndex = random.nextInt(features.size());
+      Feature feature = features.get(randomIndex);
+      options.add(new SymbolOptions()
+        .withGeometry((Point) feature.geometry())
+        .withIconImage("fire-station-11")
+      );
+    }
+    symbols = symbolManager.create(options);
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+
+    if (symbolManager != null) {
+      symbolManager.onDestroy();
+    }
+
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  private static class LoadLocationTask extends AsyncTask<Void, Integer, FeatureCollection> {
+
+    private final WeakReference<ClusterSymbolActivity> activity;
+    private final int amount;
+
+    private LoadLocationTask(ClusterSymbolActivity activity, int amount) {
+      this.amount = amount;
+      this.activity = new WeakReference<>(activity);
+    }
+
+    @Override
+    protected FeatureCollection doInBackground(Void... params) {
+      ClusterSymbolActivity activity = this.activity.get();
+      if (activity != null) {
+        String json = null;
+        try {
+          json = GeoParseUtil.loadStringFromAssets(activity.getApplicationContext());
+        } catch (IOException exception) {
+          Timber.e(exception, "Could not add markers");
+        }
+
+        if (json != null) {
+          return FeatureCollection.fromJson(json);
+        }
+      }
+      return null;
+    }
+
+    @Override
+    protected void onPostExecute(FeatureCollection locations) {
+      super.onPostExecute(locations);
+      ClusterSymbolActivity activity = this.activity.get();
+      if (activity != null) {
+        activity.onLatLngListLoaded(locations, amount);
+      }
+    }
+  }
+
+  public static class GeoParseUtil {
+
+    static String loadStringFromAssets(final Context context) throws IOException {
+      InputStream is = context.getAssets().open("points.geojson");
+      BufferedReader rd = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+      return readAll(rd);
+    }
+
+    private static String readAll(Reader rd) throws IOException {
+      StringBuilder sb = new StringBuilder();
+      int cp;
+      while ((cp = rd.read()) != -1) {
+        sb.append((char) cp);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/app/src/main/res/layout/activity_cluster.xml
+++ b/app/src/main/res/layout/activity_cluster.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/coordinator_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
   <string name="title_symbol">Symbol</string>
   <string name="title_symbol_press">Press for Symbol</string>
   <string name="title_symbol_bulk">Bulk amount of Symbols</string>
+  <string name="title_symbol_cluster">Cluster Symbols</string>
   <string name="title_symbol_change">Change Symbol</string>
   <string name="title_fill">Fill</string>
   <string name="title_fill_change">Change Fill</string>
@@ -51,6 +52,7 @@
   <string name="description_symbol_press">Show a symbol by pressing the map</string>
   <string name="description_symbol_change">Dynamically change a symbol on the map</string>
   <string name="description_symbol_bulk">Show fire hydrants in Washington DC area</string>
+  <string name="description_symbol_cluster">Show fire hydrants in Washington DC area in a cluster.</string>
   <string name="description_line">Show lines on a map</string>
   <string name="description_line_change">Show changing lines on a map</string>
   <string name="description_fill">Show fills on a map</string>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '9.5.0',
+      mapboxMapSdk       : '9.6.0',
       mapboxJava         : '5.5.0',
       mapboxTurf         : '5.5.0',
       playLocation       : '16.0.0',

--- a/plugin-annotation/scripts/annotation_element_provider.java.ejs
+++ b/plugin-annotation/scripts/annotation_element_provider.java.ejs
@@ -38,6 +38,11 @@ class <%- camelize(type) %>ElementProvider implements CoreElementProvider<<%- ca
   }
 
   @Override
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  @Override
   public <%- camelize(type) %>Layer getLayer() {
     return new <%- camelize(type) %>Layer(layerId, sourceId);
   }

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -49,7 +49,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   @UiThread
   public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-    this(mapView, mapboxMap, style, null, null);
+    this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
   }
 
   /**
@@ -61,7 +61,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
    */
   @UiThread
   public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapView, mapboxMap, style, belowLayerId, null);
+    this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
   }
 
   /**
@@ -76,6 +76,22 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
   public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
     this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
   }
+<% if (type === "symbol") { -%>
+
+  /**
+   * Create a <%- type %> manager, used to manage <%- type %>s.
+   *
+   * @param mapboxMap the map object to add <%- type %>s to
+   * @param style a valid a fully loaded style object
+   * @param belowLayerId the id of the layer above the circle layer
+   * @param clusterOptions options for the clustering configuration
+   */
+  @UiThread
+  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @NonNull ClusterOptions clusterOptions) {
+    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    clusterOptions.apply(style, coreElementProvider.getSourceId());
+  }
+<% } -%>
 
   @VisibleForTesting
   <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -57,11 +57,11 @@ public abstract class AnnotationManager<
   private long currentId;
 
   protected L layer;
-  private GeoJsonSource geoJsonSource;
+  protected GeoJsonSource geoJsonSource;
   private final MapClickResolver mapClickResolver;
   private Style style;
   private String belowLayerId;
-  private CoreElementProvider<L> coreElementProvider;
+  protected CoreElementProvider<L> coreElementProvider;
   private DraggableAnnotationController draggableAnnotationController;
 
   @UiThread

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
@@ -33,6 +33,11 @@ class CircleElementProvider implements CoreElementProvider<CircleLayer>{
   }
 
   @Override
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  @Override
   public CircleLayer getLayer() {
     return new CircleLayer(layerId, sourceId);
   }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -43,7 +43,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    */
   @UiThread
   public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-    this(mapView, mapboxMap, style, null, null);
+    this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
   }
 
   /**
@@ -55,7 +55,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
    */
   @UiThread
   public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapView, mapboxMap, style, belowLayerId, null);
+    this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ClusterOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ClusterOptions.java
@@ -1,0 +1,248 @@
+package com.mapbox.mapboxsdk.plugins.annotation;
+
+import android.graphics.Color;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.gt;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.gte;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.has;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.lt;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
+
+/**
+ * Options to show and configure symbol clustering with using SymbolManager.
+ * <p>
+ * It exposes a minimal of configuration options, a more advanced setup can be created manually with
+ * using CircleLayer and SymbolLayers directly.
+ * </p>
+ */
+public class ClusterOptions {
+
+  private int clusterRadius;
+  private int clusterMaxZoom;
+  private Pair<Integer, Integer>[] colorLevels;
+
+  @Nullable
+  private Expression circleRadius;
+  @Nullable
+  private Expression textColor;
+  @Nullable
+  private Expression textSize;
+  @Nullable
+  private Expression textField;
+
+  /**
+   * Creates a default ClusterOptions object
+   */
+  public ClusterOptions() {
+    clusterRadius = 50;
+    clusterMaxZoom = 14;
+    colorLevels = new Pair[] {new Pair(0, Color.BLUE)};
+  }
+
+  /**
+   * Get the cluster radius, 50 by default.
+   *
+   * @return the radius at which the cluster dissolves
+   */
+  public int getClusterRadius() {
+    return clusterRadius;
+  }
+
+  /**
+   * Set the cluster radius, 50 by default.
+   *
+   * @param clusterRadius the radius at which the cluster dissolves
+   * @return this
+   */
+  public ClusterOptions withClusterRadius(int clusterRadius) {
+    this.clusterRadius = clusterRadius;
+    return this;
+  }
+
+  /**
+   * Set the cluster maximum, 14 by default.
+   *
+   * @return the cluster maximum zoom, at this zoom level clusters dissolve automatically
+   */
+  public int getClusterMaxZoom() {
+    return clusterMaxZoom;
+  }
+
+  /**
+   * Set the cluster maximum zoom, 14 by default.
+   *
+   * @param clusterMaxZoom the cluster maximum zoom, at this zoom level clusters dissolve automatically
+   * @return this
+   */
+  public ClusterOptions withClusterMaxZoom(int clusterMaxZoom) {
+    this.clusterMaxZoom = clusterMaxZoom;
+    return this;
+  }
+
+  /**
+   * Get the cluster color levels, which a pair constructed with amount of point and a int color value.
+   *
+   * @return the cluster color levels array
+   */
+  @NonNull
+  public Pair<Integer, Integer>[] getColorLevels() {
+    return colorLevels;
+  }
+
+  /**
+   * Set the cluster color levels, which a pair constructed with amount of point and a int color value.
+   *
+   * @param colorLevels the cluster color levels array
+   * @return this
+   */
+  public ClusterOptions withColorLevels(@NonNull Pair<Integer, Integer>[] colorLevels) {
+    this.colorLevels = colorLevels;
+    return this;
+  }
+
+  /**
+   * Get the circle radius of the cluster items, 18 by default
+   *
+   * @return the cluster item circle radius
+   */
+  @Nullable
+  public Expression getCircleRadius() {
+    return circleRadius;
+  }
+
+  /**
+   * Set the circle radius of cluster items. 18 by default
+   *
+   * @param circleRadius the cluster item circle radius
+   * @return this
+   */
+  public ClusterOptions withCircleRadius(@Nullable Expression circleRadius) {
+    this.circleRadius = circleRadius;
+    return this;
+  }
+
+  /**
+   * Get the text color of cluster item. White by default
+   *
+   * @return the cluster item text color
+   */
+  @Nullable
+  public Expression getTextColor() {
+    return textColor;
+  }
+
+  /**
+   * Set the text color of cluster item. White by default.
+   *
+   * @param textColor the cluster item text color
+   * @return this
+   */
+  public ClusterOptions withTextColor(@Nullable Expression textColor) {
+    this.textColor = textColor;
+    return this;
+  }
+
+  /**
+   * Get the text size of cluster item. 12 by default.
+   *
+   * @return the cluster item text size
+   */
+  @Nullable
+  public Expression getTextSize() {
+    return textSize;
+  }
+
+  /**
+   * Set the text size of cluster item. 12 by default.
+   *
+   * @param textSize the cluster item text size
+   * @return this
+   */
+  public ClusterOptions withTextSize(@Nullable Expression textSize) {
+    this.textSize = textSize;
+    return this;
+  }
+
+  /**
+   * Set the text field of a cluster item. toNumber(get("point_count")) by default.
+   *
+   * @return the cluster item text field
+   */
+  @Nullable
+  public Expression getTextField() {
+    return textField;
+  }
+
+  /**
+   * Set the text field of a cluster item. toNumber(get("point_count")) by default.
+   *
+   * @param textField the cluster item text field
+   * @return this
+   */
+  public ClusterOptions withTextField(@Nullable Expression textField) {
+    this.textField = textField;
+    return this;
+  }
+
+  /**
+   * Apply cluster options to a style and source id.
+   *
+   * @param style    style to apply this to
+   * @param sourceId source id to apply this to
+   */
+  public void apply(@NonNull Style style, @NonNull String sourceId) {
+    for (int i = 0; i < colorLevels.length; i++) {
+      style.addLayer(createClusterLevelLayer(i, colorLevels, sourceId));
+    }
+    style.addLayer(createClusterTextLayer(sourceId));
+  }
+
+  private CircleLayer createClusterLevelLayer(int level, Pair<Integer, Integer>[] levels, String sourceId) {
+    CircleLayer circles = new CircleLayer("mapbox-android-cluster-circle" + level, sourceId);
+    circles.setProperties(
+      circleColor(levels[level].second),
+      circleRadius(circleRadius != null ? circleRadius : literal(18.0f))
+    );
+
+    Expression pointCount = Expression.toNumber(get("point_count"));
+    circles.setFilter(
+      level == 0
+        ? all(has("point_count"),
+        gte(pointCount, literal(levels[level].first))
+      ) : all(has("point_count"),
+        gt(pointCount, literal(levels[level].first)),
+        lt(pointCount, literal(levels[level - 1].first))
+      )
+    );
+    return circles;
+  }
+
+  private SymbolLayer createClusterTextLayer(String sourceId) {
+    return new SymbolLayer("mapbox-android-cluster-text", sourceId)
+      .withProperties(
+        textField(textField != null ? textField : get("point_count")),
+        textSize(textSize != null ? textSize : literal(12f)),
+        textColor(textColor != null ? textColor : Expression.color(Color.WHITE)),
+        textIgnorePlacement(true),
+        textAllowOverlap(true)
+      );
+  }
+}

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
@@ -10,6 +10,8 @@ interface CoreElementProvider<L extends Layer> {
 
   String getLayerId();
 
+  String getSourceId();
+
   L getLayer();
 
   GeoJsonSource getSource(@Nullable GeoJsonOptions geoJsonOptions);

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
@@ -33,6 +33,11 @@ class FillElementProvider implements CoreElementProvider<FillLayer>{
   }
 
   @Override
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  @Override
   public FillLayer getLayer() {
     return new FillLayer(layerId, sourceId);
   }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -42,7 +42,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    */
   @UiThread
   public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-    this(mapView, mapboxMap, style, null, null);
+    this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
   }
 
   /**
@@ -54,7 +54,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
    */
   @UiThread
   public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapView, mapboxMap, style, belowLayerId, null);
+    this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
@@ -33,6 +33,11 @@ class LineElementProvider implements CoreElementProvider<LineLayer>{
   }
 
   @Override
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  @Override
   public LineLayer getLayer() {
     return new LineLayer(layerId, sourceId);
   }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -45,7 +45,7 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   @UiThread
   public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-    this(mapView, mapboxMap, style, null, null);
+    this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
   }
 
   /**
@@ -57,7 +57,7 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
    */
   @UiThread
   public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapView, mapboxMap, style, belowLayerId, null);
+    this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
@@ -33,6 +33,11 @@ class SymbolElementProvider implements CoreElementProvider<SymbolLayer>{
   }
 
   @Override
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  @Override
   public SymbolLayer getLayer() {
     return new SymbolLayer(layerId, sourceId);
   }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -65,7 +65,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   @UiThread
   public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-    this(mapView, mapboxMap, style, null, null);
+    this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
   }
 
   /**
@@ -77,7 +77,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
    */
   @UiThread
   public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapView, mapboxMap, style, belowLayerId, null);
+    this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
   }
 
   /**
@@ -91,6 +91,20 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
   @UiThread
   public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
     this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+  }
+
+  /**
+   * Create a symbol manager, used to manage symbols.
+   *
+   * @param mapboxMap the map object to add symbols to
+   * @param style a valid a fully loaded style object
+   * @param belowLayerId the id of the layer above the circle layer
+   * @param clusterOptions options for the clustering configuration
+   */
+  @UiThread
+  public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @NonNull ClusterOptions clusterOptions) {
+    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    clusterOptions.apply(style, coreElementProvider.getSourceId());
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This PR adds a default implementation for clustering support with the symbol of annotation plugin. If exposed functionality is too limited, users can roll their own version using the circle/symbol layer.

Current API is limited to changing:

```
  clusterRadius;
  clusterMaxZoom;
  colorLevels;
  circleRadius;
  textColor;
  textSize;
  textField;
```


![ezgif com-video-to-gif(18)](https://user-images.githubusercontent.com/2151639/102785097-b32e1400-439d-11eb-86a4-8a45bbe81238.gif)


closes https://github.com/mapbox/mapbox-plugins-android/issues/648