### PR TITLE
Fix download notification doesn't dismiss issue.

### DIFF
--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
@@ -149,8 +149,11 @@ public class OfflineDownloadService extends Service {
         getApplicationContext(), offlineDownload), offlineDownload.notificationOptions(),
       OfflineDownloadStateReceiver.createCancelIntent(getApplicationContext(), offlineDownload)
     );
-    startForeground(offlineDownload.uuid().intValue(), notificationBuilder.build());
-
+    if (regionLongSparseArray.isEmpty()) {
+      startForeground(offlineDownload.uuid().intValue(), notificationBuilder.build());
+    } else {
+      notificationManager.notify(offlineDownload.uuid().intValue(), notificationBuilder.build());
+    }
     if (offlineDownload.notificationOptions().requestMapSnapshot()) {
       // create map bitmap to show as notification icon
       createMapSnapshot(offlineDownload.definition(), new MapSnapshotter.SnapshotReadyCallback() {


### PR DESCRIPTION
In Android 11, if we invoke `startForeground` multi times, the last notification will not be able to dismissed. 
This pr add the check for it and only invoke `startForeground` for the first notification.