### PR TITLE
Update `SymbolActivity.java` to match screenshot in docs 

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -69,7 +69,7 @@ public class SymbolActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-    mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+    mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.LIGHT, style -> {
       findViewById(R.id.fabStyles).setOnClickListener(v -> {
         mapboxMap.setStyle(Utils.INSTANCE.getNextStyle());
         mapboxMap.getStyle(this::addAirplaneImageToStyle);


### PR DESCRIPTION
This PR makes a small change to an example so it matches the screenshot I've added to android-docs: https://github.com/mapbox/android-docs/pull/1679

- Changes the symbol example map style from `MAPBOX_STREETS` TO `LIGHT` so the symbols are more visible.