### PR TITLE
Transifex project has been deleted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,20 +17,10 @@ We welcome contributions to this plugin repository. If you're interested in buil
 
 ## Adding or updating a localization
 
-The Mapbox Plugins SDK for Android features several translations contributed through [Transifex](https://www.transifex.com/mapbox/mapbox-plugins-android/). If your language already has a translation, feel free to complete or proofread it. Otherwise, please [request your language](https://www.transifex.com/mapbox/mapbox-plugins-android/) so you can start translating. Note that we’re primarily interested in languages that Android supports as system languages.
+The Mapbox Plugins SDK for Android features several translations that were previously through Transifex. This project no longer uses Transifex to manage its translations, but please consider translating the following related projects instead:
 
-While you’re there, please consider also translating the following related projects:
-
-* [OSRM Text Instructions](https://www.transifex.com/project-osrm/osrm-text-instructions/), which the Mapbox Directions API uses to generate textual and verbal turn instructions ([instructions](https://github.com/Project-OSRM/osrm-text-instructions/blob/master/CONTRIBUTING.md#adding-or-updating-a-localization)).
-* [Mapbox Navigation SDK for iOS](https://www.transifex.com/mapbox/mapbox-navigation-ios/), the analogous library for iOS applications ([instructions](https://github.com/mapbox/mapbox-navigation-ios/blob/main/CONTRIBUTING.md#adding-or-updating-a-localization)).
 * [Mapbox Maps SDK for Android](https://www.transifex.com/mapbox/mapbox-gl-native/), which is responsible for the map view and minor UI elements such as the Mapbox Telemetry permissions dialog
-
-Once you’ve finished translating the Android Plugins SDK into a new language in Transifex, open an issue in this repository asking to pull in your translations. You can also pull in the translations yourself:
-
-1. Create a new branch that will contain the new translations.
-1. _(First time only.)_ Download the [`tx` command line tool](https://docs.transifex.com/client/installing-the-client) and [configure your .transifexrc](https://docs.transifex.com/client/client-configuration).
-1. Run `tx pull -a` to fetch translations from Transifex. You can restrict the operation to just the new language using `tx pull -l xyz`, where _xyz_ is the language code.
-1. Commit any new files that were added and open a pull request with your changes.
+* [Mapbox Navigation SDK for Android](https://www.transifex.com/mapbox/mapbox-navigation-sdk-for-android/), which is responsible for turn-by-turn navigation logic and UI ([instructions](https://github.com/mapbox/mapbox-navigation-android/blob/main/CONTRIBUTING.md#adding-or-updating-a-localization)).
 
 # Code of conduct
 Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](http://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](http://contributor-covenant.org/version/1/2/0/).


### PR DESCRIPTION
Updated language in the contributing guide about translations, now that this repository’s Transifex project has been deleted for inactivity. Since Transifex integration was deleted from this repository in #463, the translations have been unused but have continued to mislead translators into putting effort into translations.

/cc @tobrun @Guardiola31337