### PR TITLE
Android 12 compartibility fixes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,7 @@ android {
     applicationId "com.mapbox.mapboxsdk.plugins.testapp"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true
+    multiDexEnabled = true
   }
 
   buildTypes {
@@ -64,12 +65,15 @@ dependencies {
     exclude group: 'android.arch.lifecycle'
     exclude group: 'com.google.android.gms'
   })
-  implementation dependenciesList.mapboxGeocoding
+  implementation (dependenciesList.mapboxGeocoding, {
+    exclude group: 'com.squareup.okhttp3'
+  })
   implementation dependenciesList.mapboxTurf
 
   // Architecture
   implementation dependenciesList.lifecycleExtensions
   implementation dependenciesList.roomRuntime
+  implementation dependenciesList.androidxMultidex
   kapt dependenciesList.roomCompiler
 
   // Google Play Services

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,19 +43,6 @@ android {
   }
 }
 
-// Disable Leak Canary for UI and unit test.
-configurations.all { config ->
-  if (config.name.contains('UnitTest') || config.name.contains('AndroidTest')) {
-    config.resolutionStrategy.eachDependency { details ->
-      if (details.requested.group == 'com.squareup.leakcanary'
-          && details.requested.name == 'leakcanary-android') {
-        details.useTarget(group: details.requested.group, name: 'leakcanary-android-no-op',
-            version: details.requested.version)
-      }
-    }
-  }
-}
-
 dependencies {
   // Kotlin
   implementation dependenciesList.kotlin
@@ -107,8 +94,6 @@ dependencies {
 
   // Leak canary
   debugImplementation dependenciesList.leakCanaryDebug
-  releaseImplementation dependenciesList.leakCanaryRelease
-  testImplementation dependenciesList.leakCanaryTest
 
   // Plugin modules
   implementation project(':plugin-traffic')

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools" package="com.mapbox.mapboxsdk.plugins.testapp">
 
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
   <application
@@ -14,7 +15,8 @@
           android:supportsRtl="true"
           android:theme="@style/AppTheme"
           tools:ignore="AllowBackup,GoogleAppIndexingWarning">
-    <activity android:name=".activity.FeatureOverviewActivity">
+    <activity android:name=".activity.FeatureOverviewActivity"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
@@ -276,7 +278,8 @@
       android:name="com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadService"
       android:exported="false"/>
 
-    <receiver android:name="com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadStateReceiver">
+    <receiver android:name="com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadStateReceiver"
+        android:exported="false">
       <intent-filter>
         <action android:name="com.mapbox.mapboxsdk.plugins.offline"/>
       </intent-filter>

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/PluginApplication.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/PluginApplication.kt
@@ -1,21 +1,15 @@
 package com.mapbox.mapboxsdk.plugins.testapp
 
-import android.app.Application
+import androidx.multidex.MultiDexApplication
 
 import com.mapbox.mapboxsdk.Mapbox
-import com.squareup.leakcanary.LeakCanary
 
 import timber.log.Timber
 
-class PluginApplication : Application() {
+class PluginApplication : MultiDexApplication() {
 
     override fun onCreate() {
         super.onCreate()
-        if (LeakCanary.isInAnalyzerProcess(this)) {
-            return
-        }
-
-        LeakCanary.install(this)
         initializeLogger()
         Mapbox.getInstance(this, getString(R.string.mapbox_access_token))
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapboxMapSdk       : '9.6.0',
+      mapboxMapSdk       : '9.6.2',
       mapboxJava         : '5.5.0',
       mapboxTurf         : '5.5.0',
       playLocation       : '16.0.0',
@@ -18,7 +18,7 @@
       constraintLayout   : '1.1.2',
       mockito            : '2.23.4',
       mockk              : '1.9.3',
-      leakCanary         : '1.6.3',
+      leakCanary         : '2.7',
       timber             : '4.7.1',
       testRunner         : '1.0.2',
       espresso           : '3.0.2',
@@ -27,7 +27,9 @@
       lifecycleLiveData  : '1.1.1',
       room               : '1.1.0',
       androidArchCore    : '1.1.0',
-      robolectric        : '3.8'
+      robolectric        : '3.8',
+      androidXCore       : '1.5.0',
+      androidxMultidex   : '2.0.1'
   ]
 
   pluginVersion = [
@@ -56,6 +58,7 @@
           autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
 
           // support
+          androidCore            : "androidx.core:core:${version.androidXCore}",
           supportAnnotation      : 'androidx.annotation:annotation:1.0.0',
           supportAppcompatV7     : 'androidx.appcompat:appcompat:1.0.0',
           supportV4              : 'androidx.legacy:legacy-support-v4:1.0.0',
@@ -69,7 +72,7 @@
           lifecycleCompiler      : "android.arch.lifecycle:compiler:${version.lifecycleCompiler}",
           roomRuntime            : 'androidx.room:room-runtime:2.0.0',
           roomCompiler           : 'androidx.room:room-compiler:2.0.0',
-
+          androidxMultidex       : "androidx.multidex:multidex:${version.androidxMultidex}",
           // square crew
           timber                 : "com.jakewharton.timber:timber:${version.timber}",
           leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanary}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,8 +76,6 @@
           // square crew
           timber                 : "com.jakewharton.timber:timber:${version.timber}",
           leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanary}",
-          leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanary}",
-          leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanary}",
 
           // instrumentation test
           testRunner             : 'androidx.test.ext:junit:1.1.1',

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadStateReceiver.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadStateReceiver.java
@@ -4,6 +4,7 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 
@@ -90,6 +91,10 @@ public class OfflineDownloadStateReceiver extends BroadcastReceiver {
   }
 
   static PendingIntent createNotificationIntent(Context context, OfflineDownloadOptions offlineDownload) {
+    int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      flags |= PendingIntent.FLAG_IMMUTABLE;
+    }
     Class returnActivity = offlineDownload.notificationOptions().getReturnActivity();
     Intent notificationIntent = new Intent(context, returnActivity);
     notificationIntent.putExtra(KEY_BUNDLE, offlineDownload);
@@ -97,7 +102,7 @@ public class OfflineDownloadStateReceiver extends BroadcastReceiver {
       context,
       0,
       notificationIntent,
-      PendingIntent.FLAG_UPDATE_CURRENT
+      flags
     );
   }
 }

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
@@ -42,6 +42,10 @@ public class NotificationUtils {
                                                                  PendingIntent contentIntent,
                                                                  NotificationOptions options,
                                                                  Intent cancelIntent) {
+    int flags = PendingIntent.FLAG_CANCEL_CURRENT;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      flags |= PendingIntent.FLAG_IMMUTABLE;
+    }
     return new NotificationCompat.Builder(context, OfflineConstants.NOTIFICATION_CHANNEL)
       .setContentTitle(options.contentTitle())
       .setContentText(options.contentText())
@@ -51,7 +55,6 @@ public class NotificationUtils {
       .setContentIntent(contentIntent)
       .addAction(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? 0 : R.drawable.ic_cancel,
         options.cancelText(),
-        PendingIntent.getService(context, offlineDownload.uuid().intValue(), cancelIntent,
-          PendingIntent.FLAG_CANCEL_CURRENT));
+        PendingIntent.getService(context, offlineDownload.uuid().intValue(), cancelIntent, flags));
   }
 }

--- a/plugin-scalebar/build.gradle
+++ b/plugin-scalebar/build.gradle
@@ -25,6 +25,8 @@ android {
 
 dependencies {
     implementation dependenciesList.mapboxMapSdk
+    implementation dependenciesList.supportAnnotation
+    implementation dependenciesList.androidCore
     javadocDeps dependenciesList.mapboxMapSdk
     testImplementation dependenciesList.kotlin
     testImplementation dependenciesList.mockk


### PR DESCRIPTION
Included changes:

- [x]  LeacyCanary, update to 2.7, no need to config for release and test. No need any config in codes.
- [x]  Multidex, methods num exceed limit after bump all the dependency. 
- [x] Add `android:exported="true"` in manifest and config for PendingIntent for Android 12
- [x] Bump maps sdk to 9.6.2 which contains the telemetry fix for Android 12