### PR TITLE
Add locale for vi

### DIFF
--- a/plugin-localization/CHANGELOG.md
+++ b/plugin-localization/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### mapbox-android-plugin-localization-v9:0.14.0 - September 16, 2021
+#### Bugs
+- Add locale for Locale("vi")[#1202](https://github.com/mapbox/mapbox-plugins-android/pull/1202)
+
 ### mapbox-android-plugin-localization-v9:0.13.0 - August 24, 2021
 
 - Adding Vietnamese and Italian support to Localization Plugin[#1098](https://github.com/mapbox/mapbox-plugins-android/pull/1098)

--- a/plugin-localization/gradle.properties
+++ b/plugin-localization/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.14.0-SNAPSHOT
+VERSION_NAME=0.15.0-SNAPSHOT
 POM_ARTIFACT_ID=mapbox-android-plugin-localization-v9
 POM_NAME=Mapbox Android Localization Plugin
 POM_DESCRIPTION=Mapbox Android Localization Plugin

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -348,6 +348,7 @@ public final class MapLocale {
     LOCALE_SET.put(new Locale("pt", "PT"), PORTUGAL);
     LOCALE_SET.put(new Locale("pt", "BR"), BRAZIL);
     LOCALE_SET.put(new Locale("vi", "VN"), VIETNAM);
+    LOCALE_SET.put(new Locale("vi"), VIETNAM);
     LOCALE_SET.put(Locale.ITALY, MapLocale.ITALY);
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
In some devices `Locale("vi", "VN")` is not supported for VIETNAM, this pr add `Locale("vi")` for these devices.