### PR TITLE
Annotation order vs click priority inverted

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -413,7 +413,7 @@ public abstract class AnnotationManager<
   T queryMapForFeatures(@NonNull PointF point) {
     List<Feature> features = mapboxMap.queryRenderedFeatures(point, coreElementProvider.getLayerId());
     if (!features.isEmpty()) {
-      long id = features.get(0).getProperty(getAnnotationIdKey()).getAsLong();
+      long id = features.get(features.size()-1).getProperty(getAnnotationIdKey()).getAsLong();
       return annotations.get(id);
     }
     return null;


### PR DESCRIPTION
The order of annotations is inverted relative to the click priority. 
This causes annotations on lower (potentially occluded) layers, to priority the as opposed to the one actually visible to the user.

A detailed example of the issue can be found here:

https://github.com/tobrun/flutter-mapbox-gl/issues/563

Getting the last feature instead of the first one should fix this. 

**NOTE**
I tried testing this, but struggled to get a working setup - gradle causing build issues - so it would be fantastic is someone else could test this or help me getting a working test setup.

